### PR TITLE
UX consistency pass + Spiral effect + resume restore

### DIFF
--- a/main.py
+++ b/main.py
@@ -197,12 +197,14 @@ class Plugin:
 
     def _wants_render_loop(self) -> bool:
         # Modes driven by our per-frame render loop (software effect engine or
-        # ambilight capture) instead of firmware. Hardware effects only take a
-        # single color, so anything that must paint the custom gradient (wave, or
-        # any effect with "use gradient" on) and ambient capture run in software.
-        # Gradient mode also runs in software on devices that cannot render a
+        # ambilight capture) instead of firmware. Ambient capture always runs in
+        # software. Gradient mode runs in software on devices that cannot render a
         # spatial gradient (single-color zones, e.g. Legion rings) — there we
         # animate an elegant crossfade through the palette instead.
+        # For effects: the custom-gradient overlay must be painted per-frame, and
+        # so must wave on devices that can show more than one color at once
+        # (per-zone or per-controller). Single-color devices render wave with
+        # their native hardware effect instead of collapsing it to a flat color.
         s = self._settings
         if s["mode"] == "ambient":
             return True
@@ -210,7 +212,13 @@ class Plugin:
             return not self._controller.supports_per_zone()
         if s["mode"] == "effect":
             effect = s["effect"]
-            return effect["id"] == "wave" or effect.get("use_gradient", False)
+            if effect.get("use_gradient", False):
+                return True
+            if effect["id"] == "wave":
+                return self._controller.supports_per_zone() or bool(
+                    self._capabilities.get("perControllerColor", False)
+                )
+            return False
         return False
 
     def _apply(self) -> None:

--- a/main.py
+++ b/main.py
@@ -214,6 +214,10 @@ class Plugin:
             effect = s["effect"]
             if effect.get("use_gradient", False):
                 return True
+            if effect["id"] == "spiral":
+                # Legion Go renders spiral with its own firmware effect; only
+                # software-painting devices (e.g. the Ally) run the per-frame loop.
+                return not self._controller.supports_hardware_effects()
             if effect["id"] == "wave":
                 return self._controller.supports_per_zone() or bool(
                     self._capabilities.get("perControllerColor", False)

--- a/py_modules/device.py
+++ b/py_modules/device.py
@@ -151,6 +151,7 @@ def build_capabilities(profile, has_led, zones, max_brightness, ambilight):
         "zones": zones,
         "maxBrightness": max_brightness,
         "perZone": has_led and zones > 1,
+        "hardwareEffects": False,
         "reconnectable": False,
         "perControllerColor": bool(profile.get("per_controller", False)),
         "supportedEffects": list(profile.get("supported_effects", [])),
@@ -187,6 +188,7 @@ def _build_hid_context(profile, ambilight):
     zones = profile.get("zones") or 1
     capabilities = build_capabilities(profile, True, zones, 100, ambilight)
     capabilities["perZone"] = device.supports_per_zone()
+    capabilities["hardwareEffects"] = device.supports_hardware_effects()
     capabilities["reconnectable"] = True
     return {"device": device, "capabilities": capabilities}
 

--- a/py_modules/device_profiles.py
+++ b/py_modules/device_profiles.py
@@ -2,7 +2,7 @@ ASUS_SYSFS = {
     "driver": "sysfs",
     "color_order": "rgb",
     "zones": 4,
-    "supported_effects": ["breathing", "rainbow", "wave", "cycle"],
+    "supported_effects": ["breathing", "rainbow", "wave", "cycle", "spiral"],
     "color_correction": [1.0, 0.85, 1.0],
     "experimental": [],
 }
@@ -11,7 +11,7 @@ MSI_HID = {
     "driver": "hid_msi",
     "color_order": "bgr",
     "zones": 9,
-    "supported_effects": ["breathing", "rainbow", "wave", "cycle"],
+    "supported_effects": ["breathing", "rainbow", "wave", "cycle", "spiral"],
     "swap_sticks": True,
     "experimental": [],
 }
@@ -20,7 +20,7 @@ LEGION_TABLET_HID = {
     "driver": "hid_legion_tablet",
     "color_order": "rgb",
     "zones": 2,
-    "supported_effects": ["breathing", "rainbow", "wave"],
+    "supported_effects": ["breathing", "rainbow", "spiral"],
     "per_controller": True,
     "experimental": [],
 }
@@ -29,7 +29,7 @@ LEGION_GO_S_HID = {
     "driver": "hid_legion_go_s",
     "color_order": "rgb",
     "zones": 2,
-    "supported_effects": ["breathing", "rainbow", "wave"],
+    "supported_effects": ["breathing", "rainbow", "spiral"],
     "experimental": [],
 }
 

--- a/py_modules/effects.py
+++ b/py_modules/effects.py
@@ -97,6 +97,32 @@ def frame_cycle(zones, t, speed):
     return [hsv_to_rgb((base + (360.0 * i / zones)) % 360.0, 1.0, 1.0) for i in range(zones)]
 
 
+def frame_spiral(stops, zones, t, speed):
+    # Software spiral for devices that CAN paint multiple zones (e.g. the Ally):
+    # rotate the user's gradient around the ring as a seamless loop, interpolating
+    # between zones so the motion is smooth. On single-color firmware devices
+    # (Legion Go) the spiral is rendered natively and never reaches this loop.
+    if zones <= 0:
+        return []
+    palette = interpolate_gradient([tuple(s) for s in stops], zones)
+    shift = ((_freq(speed) * t) % 1.0) * zones
+    result = []
+    for i in range(zones):
+        src = (i + shift) % zones
+        lo = int(math.floor(src)) % zones
+        hi = (lo + 1) % zones
+        frac = src - math.floor(src)
+        a, b = palette[lo], palette[hi]
+        result.append(
+            (
+                clamp8(a[0] + (b[0] - a[0]) * frac),
+                clamp8(a[1] + (b[1] - a[1]) * frac),
+                clamp8(a[2] + (b[2] - a[2]) * frac),
+            )
+        )
+    return result
+
+
 def frame_gradient_sweep(stops, zones, t, speed):
     # Temporal crossfade through the whole palette for devices that cannot render
     # a spatial gradient (single-color zones, e.g. Legion rings). All zones share
@@ -153,6 +179,8 @@ class EffectEngine:
             return frame_rainbow(self._zones, t, speed)
         if effect_id == "wave":
             return frame_wave(params.get("stops", [(255, 0, 0), (0, 0, 255)]), self._zones, t, speed)
+        if effect_id == "spiral":
+            return frame_spiral(params.get("stops", [(255, 0, 0), (0, 0, 255)]), self._zones, t, speed)
         if effect_id == "cycle":
             return frame_cycle(self._zones, t, speed)
         if effect_id == "gradient_sweep":

--- a/py_modules/effects.py
+++ b/py_modules/effects.py
@@ -97,14 +97,15 @@ def frame_cycle(zones, t, speed):
     return [hsv_to_rgb((base + (360.0 * i / zones)) % 360.0, 1.0, 1.0) for i in range(zones)]
 
 
-def frame_spiral(stops, zones, t, speed):
+def frame_spiral(palette, t, speed):
     # Software spiral for devices that CAN paint multiple zones (e.g. the Ally):
-    # rotate the user's gradient around the ring as a seamless loop, interpolating
-    # between zones so the motion is smooth. On single-color firmware devices
-    # (Legion Go) the spiral is rendered natively and never reaches this loop.
-    if zones <= 0:
+    # rotate the per-zone palette around the ring as a seamless loop, interpolating
+    # between zones so the motion is smooth. `palette` is built once per run (it
+    # never changes), so the hot path is just the rotation. On single-color
+    # firmware devices (Legion Go) the spiral is rendered natively, not here.
+    zones = len(palette)
+    if zones == 0:
         return []
-    palette = interpolate_gradient([tuple(s) for s in stops], zones)
     shift = ((_freq(speed) * t) % 1.0) * zones
     result = []
     for i in range(zones):
@@ -114,11 +115,7 @@ def frame_spiral(stops, zones, t, speed):
         frac = src - math.floor(src)
         a, b = palette[lo], palette[hi]
         result.append(
-            (
-                clamp8(a[0] + (b[0] - a[0]) * frac),
-                clamp8(a[1] + (b[1] - a[1]) * frac),
-                clamp8(a[2] + (b[2] - a[2]) * frac),
-            )
+            (clamp8(_lerp(a[0], b[0], frac)), clamp8(_lerp(a[1], b[1], frac)), clamp8(_lerp(a[2], b[2], frac)))
         )
     return result
 
@@ -172,7 +169,7 @@ class EffectEngine:
             return interpolate_gradient(params["stops"], self._zones)
         return [params.get("color", (255, 255, 255))] * self._zones
 
-    def _compute(self, effect_id, t, speed, params):
+    def _compute(self, effect_id, t, speed, params, prepared=None):
         if effect_id == "breathing":
             return frame_breathing(self._palette(params), t, speed)
         if effect_id == "rainbow":
@@ -180,7 +177,7 @@ class EffectEngine:
         if effect_id == "wave":
             return frame_wave(params.get("stops", [(255, 0, 0), (0, 0, 255)]), self._zones, t, speed)
         if effect_id == "spiral":
-            return frame_spiral(params.get("stops", [(255, 0, 0), (0, 0, 255)]), self._zones, t, speed)
+            return frame_spiral(prepared or [], t, speed)
         if effect_id == "cycle":
             return frame_cycle(self._zones, t, speed)
         if effect_id == "gradient_sweep":
@@ -190,10 +187,17 @@ class EffectEngine:
     async def _run(self, effect_id, speed, params):
         loop = asyncio.get_event_loop()
         start = loop.time()
+        # Per-run constants computed once (the spiral palette never changes while
+        # the effect runs, so we keep it off the ~30fps hot path).
+        prepared = None
+        if effect_id == "spiral":
+            prepared = interpolate_gradient(
+                params.get("stops", [(255, 0, 0), (0, 0, 255)]), self._zones
+            )
         while True:
             try:
                 t = loop.time() - start
-                frame = self._compute(effect_id, t, speed, params)
+                frame = self._compute(effect_id, t, speed, params, prepared)
                 self._apply_zones(frame)
             except asyncio.CancelledError:
                 raise

--- a/py_modules/hid_adapters.py
+++ b/py_modules/hid_adapters.py
@@ -65,6 +65,7 @@ def _effect_mode(effect_id):
         "breathing": RGBMode.Pulse,
         "rainbow": RGBMode.Rainbow,
         "wave": RGBMode.Spiral,
+        "spiral": RGBMode.Spiral,
         "cycle": RGBMode.Rainbow,
     }
     return mapping.get(effect_id, RGBMode.Solid)

--- a/src/components/ColorEditor.tsx
+++ b/src/components/ColorEditor.tsx
@@ -46,7 +46,7 @@ export const ColorEditor: FC<ColorEditorProps> = ({ color, disabled, onChange })
     <>
       <PanelSectionRow>
         <Focusable style={{ padding: "6px 0 10px" }}>
-          <Swatches selected={color} onPick={pick} />
+          <Swatches selected={color} disabled={disabled} onPick={pick} />
         </Focusable>
       </PanelSectionRow>
       <PanelSectionRow>

--- a/src/components/EffectsGallery.tsx
+++ b/src/components/EffectsGallery.tsx
@@ -9,6 +9,7 @@ interface EffectsGalleryProps {
   selected: EffectId;
   speed: number;
   disabled?: boolean;
+  firmwareSpiral?: boolean;
   onSelect: (id: EffectId) => void;
   onSpeed: (v: number) => void;
 }
@@ -133,10 +134,15 @@ export const EffectsGallery: FC<EffectsGalleryProps> = ({
   selected,
   speed,
   disabled,
+  firmwareSpiral,
   onSelect,
   onSpeed,
 }) => {
   const { t } = useI18n();
+  const labelFor = (id: EffectId) =>
+    id === "spiral" && firmwareSpiral
+      ? t("effect.spiral.legion.label")
+      : t(`effect.${id}.label`);
   return (
   <div style={{ display: "flex", flexDirection: "column", gap: 12, opacity: disabled ? 0.4 : 1 }}>
     <Keyframes />
@@ -181,7 +187,7 @@ export const EffectsGallery: FC<EffectsGalleryProps> = ({
                 textAlign: "center",
               }}
             >
-              {t(`effect.${effect.id}.label`)}
+              {labelFor(effect.id)}
             </div>
           </Focusable>
         );

--- a/src/components/EffectsGallery.tsx
+++ b/src/components/EffectsGallery.tsx
@@ -8,6 +8,7 @@ interface EffectsGalleryProps {
   effects: EffectMeta[];
   selected: EffectId;
   speed: number;
+  disabled?: boolean;
   onSelect: (id: EffectId) => void;
   onSpeed: (v: number) => void;
 }
@@ -131,12 +132,13 @@ export const EffectsGallery: FC<EffectsGalleryProps> = ({
   effects,
   selected,
   speed,
+  disabled,
   onSelect,
   onSpeed,
 }) => {
   const { t } = useI18n();
   return (
-  <div style={{ display: "flex", flexDirection: "column", gap: 12 }}>
+  <div style={{ display: "flex", flexDirection: "column", gap: 12, opacity: disabled ? 0.4 : 1 }}>
     <Keyframes />
     <Focusable
       style={{
@@ -153,8 +155,8 @@ export const EffectsGallery: FC<EffectsGalleryProps> = ({
         return (
           <Focusable
             key={effect.id}
-            onActivate={() => onSelect(effect.id)}
-            onClick={() => onSelect(effect.id)}
+            onActivate={() => !disabled && onSelect(effect.id)}
+            onClick={() => !disabled && onSelect(effect.id)}
             style={{
               display: "flex",
               flexDirection: "column",
@@ -166,7 +168,7 @@ export const EffectsGallery: FC<EffectsGalleryProps> = ({
                 ? `1px solid ${glow}`
                 : "1px solid rgba(255,255,255,0.08)",
               boxShadow: active ? `0 0 14px ${glow}55` : "none",
-              cursor: "pointer",
+              cursor: disabled ? "default" : "pointer",
               transition: "border 140ms ease, box-shadow 140ms ease",
             }}
           >
@@ -193,6 +195,7 @@ export const EffectsGallery: FC<EffectsGalleryProps> = ({
       step={1}
       valueSuffix="%"
       showValue
+      disabled={disabled}
       onChange={onSpeed}
     />
   </div>

--- a/src/components/Swatches.tsx
+++ b/src/components/Swatches.tsx
@@ -16,18 +16,20 @@ const PRESETS: RGB[] = [
 
 interface SwatchesProps {
   selected: RGB;
+  disabled?: boolean;
   onPick: (color: RGB) => void;
 }
 
 const isSame = (a: RGB, b: RGB) => a.r === b.r && a.g === b.g && a.b === b.b;
 
-export const Swatches: FC<SwatchesProps> = ({ selected, onPick }) => (
+export const Swatches: FC<SwatchesProps> = ({ selected, disabled, onPick }) => (
   <Focusable
     style={{
       display: "grid",
       gridTemplateColumns: "repeat(8, 1fr)",
       gap: 6,
       padding: "2px 0",
+      opacity: disabled ? 0.4 : 1,
     }}
   >
     {PRESETS.map((preset, i) => {
@@ -35,8 +37,8 @@ export const Swatches: FC<SwatchesProps> = ({ selected, onPick }) => (
       return (
         <Focusable
           key={i}
-          onActivate={() => onPick(preset)}
-          onClick={() => onPick(preset)}
+          onActivate={() => !disabled && onPick(preset)}
+          onClick={() => !disabled && onPick(preset)}
           style={{
             aspectRatio: "1 / 1",
             borderRadius: 8,
@@ -44,7 +46,7 @@ export const Swatches: FC<SwatchesProps> = ({ selected, onPick }) => (
             boxShadow: active
               ? `0 0 0 2px #fff, 0 0 10px ${rgbToCss(preset)}`
               : "inset 0 0 0 1px rgba(255,255,255,0.12)",
-            cursor: "pointer",
+            cursor: disabled ? "default" : "pointer",
             transition: "box-shadow 120ms ease, transform 120ms ease",
           }}
         >

--- a/src/i18n/index.tsx
+++ b/src/i18n/index.tsx
@@ -70,6 +70,9 @@ const es: Record<string, string> = {
   "effect.rainbow.label": "Arcoíris",
   "effect.wave.label": "Onda",
   "effect.cycle.label": "Ciclo",
+  "effect.spiral.label": "Espiral",
+  "effect.spiral.legion.label": "Espiral GO",
+  "effect.spiral.firmwareNote": "Efecto giratorio propio del firmware de tu Legion Go.",
 
   "ambient.gameModeBanner": "Aún no hay pantalla que leer. Ambilight funciona en Modo Juego con un juego abierto (no en Escritorio ni Big Picture).",
   "ambient.stickHint": "Las luces siguen la pantalla cerca de cada joystick. La izquierda desde arriba a la izquierda, la derecha desde el centro a la derecha.",
@@ -160,6 +163,9 @@ const en: Record<string, string> = {
   "effect.rainbow.label": "Rainbow",
   "effect.wave.label": "Wave",
   "effect.cycle.label": "Cycle",
+  "effect.spiral.label": "Spiral",
+  "effect.spiral.legion.label": "Spiral GO",
+  "effect.spiral.firmwareNote": "Your Legion Go's built-in rotating firmware effect.",
 
   "ambient.gameModeBanner": "No screen to read yet. Ambient works in Game Mode with a game running (not in Desktop or Big Picture).",
   "ambient.stickHint": "Lights follow the screen near each stick. Left from the top-left, right from the mid-right.",

--- a/src/i18n/index.tsx
+++ b/src/i18n/index.tsx
@@ -6,6 +6,9 @@ export type Lang = "es" | "en";
 const STORAGE_KEY = "colores-lang";
 
 const es: Record<string, string> = {
+  "load.error": "No se pudo cargar el estado del plugin. Vuelve a intentarlo en un momento.",
+  "load.retry": "Reintentar",
+
   "device.noLeds": "No se detectaron LEDs controlables en este dispositivo.",
   "device.preview.rings": "Anillos del joystick",
   "device.preview.off": "Apagado",
@@ -93,6 +96,9 @@ const es: Record<string, string> = {
 };
 
 const en: Record<string, string> = {
+  "load.error": "Couldn't load the plugin state. Please try again in a moment.",
+  "load.retry": "Retry",
+
   "device.noLeds": "No controllable LEDs detected on this device.",
   "device.preview.rings": "Joystick rings",
   "device.preview.off": "Off",

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -53,6 +53,7 @@ function GradientControls({
   gradient,
   layout,
   savedGradients,
+  disabled,
   onChange,
   onSave,
   onDelete,
@@ -62,6 +63,7 @@ function GradientControls({
   gradient: RGB[];
   layout: ZoneGroup[];
   savedGradients: GradientPreset[];
+  disabled?: boolean;
   onChange: (stops: RGB[]) => void;
   onSave: (name: string, stops: RGB[]) => void;
   onDelete: (name: string) => void;
@@ -73,7 +75,8 @@ function GradientControls({
     () => [...GRADIENT_PRESETS, ...savedGradients],
     [savedGradients],
   );
-  const open = () =>
+  const open = () => {
+    if (disabled) return;
     showModal(
       <GradientModal
         initial={gradient}
@@ -84,8 +87,9 @@ function GradientControls({
         onDelete={onDelete}
       />,
     );
+  };
   return (
-    <>
+    <div style={{ opacity: disabled ? 0.4 : 1 }}>
       <PanelSectionRow>
         <Focusable
           onActivate={open}
@@ -98,7 +102,7 @@ function GradientControls({
             display: "flex",
             alignItems: "center",
             justifyContent: "center",
-            cursor: "pointer",
+            cursor: disabled ? "default" : "pointer",
           }}
         >
           <span
@@ -120,14 +124,14 @@ function GradientControls({
           {allPresets.map((preset) => (
             <Focusable
               key={preset.name}
-              onActivate={() => onChange(preset.stops)}
-              onClick={() => onChange(preset.stops)}
+              onActivate={() => !disabled && onChange(preset.stops)}
+              onClick={() => !disabled && onChange(preset.stops)}
               style={{
                 height: 30,
                 borderRadius: 8,
                 background: gradientCss(preset.stops),
                 boxShadow: "inset 0 0 0 1px rgba(255,255,255,0.12)",
-                cursor: "pointer",
+                cursor: disabled ? "default" : "pointer",
               }}
             >
               <div style={{ width: "100%", height: "100%" }} />
@@ -145,11 +149,12 @@ function GradientControls({
             step={1}
             valueSuffix="%"
             showValue
+            disabled={disabled}
             onChange={onSpeed}
           />
         </PanelSectionRow>
       )}
-    </>
+    </div>
   );
 }
 
@@ -195,6 +200,8 @@ function EffectSource({
 function Content() {
   const {
     state,
+    loadError,
+    retry,
     setBrightness,
     setPower,
     setMode,
@@ -232,11 +239,33 @@ function Content() {
   if (!state) {
     return (
       <PanelSection>
-        <PanelSectionRow>
-          <div style={{ display: "flex", justifyContent: "center", padding: 20 }}>
-            <Spinner width={32} height={32} />
-          </div>
-        </PanelSectionRow>
+        {loadError ? (
+          <>
+            <PanelSectionRow>
+              <div
+                style={{
+                  fontSize: 13,
+                  color: "rgba(255,255,255,0.7)",
+                  padding: "8px 2px",
+                  lineHeight: 1.45,
+                }}
+              >
+                {t("load.error")}
+              </div>
+            </PanelSectionRow>
+            <PanelSectionRow>
+              <ButtonItem layout="below" onClick={() => retry()}>
+                {t("load.retry")}
+              </ButtonItem>
+            </PanelSectionRow>
+          </>
+        ) : (
+          <PanelSectionRow>
+            <div style={{ display: "flex", justifyContent: "center", padding: 20 }}>
+              <Spinner width={32} height={32} />
+            </div>
+          </PanelSectionRow>
+        )}
       </PanelSection>
     );
   }
@@ -337,6 +366,7 @@ function Content() {
                   gradient={gradient}
                   layout={caps.layout}
                   savedGradients={savedGradients}
+                  disabled={!power}
                   onChange={setGradient}
                   onSave={saveGradient}
                   onDelete={deleteGradient}
@@ -352,6 +382,7 @@ function Content() {
                       effects={visibleEffects}
                       selected={effect.id}
                       speed={effect.speed}
+                      disabled={!power}
                       onSelect={setEffectId}
                       onSpeed={setEffectSpeed}
                     />

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -15,7 +15,7 @@ import { useEffect, useMemo, useState } from "react";
 import { FaPalette } from "react-icons/fa";
 
 import { useColores } from "./useColores";
-import { getAmbilightStatus } from "./api";
+import { getAmbilightStatus, reconnect as apiReconnect } from "./api";
 import { rgbToCss, gradientCss } from "./color";
 import { Mode, RGB, ZoneGroup, GradientPreset, EffectColorNeed } from "./types";
 import { DevicePreview } from "./components/DevicePreview";
@@ -603,16 +603,35 @@ function Content() {
   );
 }
 
-export default definePlugin(() => ({
-  name: "Colores",
-  titleView: <div className={staticClasses.Title}>Colores</div>,
-  content: (
-    <ErrorBoundary>
-      <I18nProvider>
-        <Content />
-      </I18nProvider>
-    </ErrorBoundary>
-  ),
-  icon: <FaPalette />,
-  onDismount() {},
-}));
+export default definePlugin(() => {
+  // SteamOS restores its own controller lighting on resume from suspend, wiping
+  // whatever the user set. Re-apply the saved settings shortly after waking so
+  // the user's choice survives a sleep/wake cycle. reconnect() reconnects the
+  // controller (which re-enumerates after resume) and re-applies the settings.
+  // The delay lets SteamOS finish writing its color first so we win the race.
+  // Registered at the plugin level so it runs even when the QAM panel is closed.
+  let resumeTimer: ReturnType<typeof setTimeout> | undefined;
+  const resumeReg = SteamClient?.System?.RegisterForOnResumeFromSuspend?.(() => {
+    clearTimeout(resumeTimer);
+    resumeTimer = setTimeout(() => {
+      apiReconnect().catch(() => {});
+    }, 2000);
+  });
+
+  return {
+    name: "Colores",
+    titleView: <div className={staticClasses.Title}>Colores</div>,
+    content: (
+      <ErrorBoundary>
+        <I18nProvider>
+          <Content />
+        </I18nProvider>
+      </ErrorBoundary>
+    ),
+    icon: <FaPalette />,
+    onDismount() {
+      clearTimeout(resumeTimer);
+      resumeReg?.unregister?.();
+    },
+  };
+});

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -626,6 +626,9 @@ export default definePlugin(() => {
       apiReconnect().catch(() => {});
     }, 2000);
   });
+  if (!resumeReg) {
+    console.warn("[Colores] SteamClient unavailable at load; resume LED restore disabled");
+  }
 
   return {
     name: "Colores",

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -17,7 +17,7 @@ import { FaPalette } from "react-icons/fa";
 import { useColores } from "./useColores";
 import { getAmbilightStatus } from "./api";
 import { rgbToCss, gradientCss } from "./color";
-import { Mode, RGB, ZoneGroup, GradientPreset } from "./types";
+import { Mode, RGB, ZoneGroup, GradientPreset, EffectColorNeed } from "./types";
 import { DevicePreview } from "./components/DevicePreview";
 import { ColorEditor } from "./components/ColorEditor";
 import { ModeTabs } from "./components/ModeTabs";
@@ -302,9 +302,17 @@ function Content() {
 
   const selectedEffect = visibleEffects.find((e) => e.id === effect.id) ?? visibleEffects[0];
 
+  // A gradient-based effect only points at the gradient editor when the device
+  // actually exposes one. On single-color devices (no gradient tab) it falls back
+  // to the shared solid color, which the firmware wave uses.
+  const effectNeed: EffectColorNeed =
+    selectedEffect?.needs === "gradient" && !canGradient
+      ? "color"
+      : (selectedEffect?.needs ?? "none");
+
   const effectPreview = (): RGB[] => {
-    if (!selectedEffect || selectedEffect.needs === "none") return selectedEffect?.colors ?? [color];
-    if (selectedEffect.needs === "gradient" || effect.useGradient) return gradient;
+    if (!selectedEffect || effectNeed === "none") return selectedEffect?.colors ?? [color];
+    if (effectNeed === "gradient" || effect.useGradient) return gradient;
     return [color];
   };
 
@@ -387,7 +395,7 @@ function Content() {
                       onSpeed={setEffectSpeed}
                     />
                   </PanelSectionRow>
-                  {selectedEffect?.needs === "color" && (
+                  {effectNeed === "color" && (
                     <>
                       {canGradient && (
                         <PanelSectionRow>
@@ -406,10 +414,10 @@ function Content() {
                       />
                     </>
                   )}
-                  {selectedEffect?.needs === "gradient" && (
+                  {effectNeed === "gradient" && (
                     <EffectSource kind="gradient" color={color} gradient={gradient} />
                   )}
-                  {selectedEffect?.needs === "none" && (
+                  {effectNeed === "none" && (
                     <PanelSectionRow>
                       <div
                         style={{

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -309,12 +309,12 @@ function Content() {
   // fixed-palette effect — labelled "Spiral GO", taking no user color. Devices
   // that paint zones in software (Ally) spin the user's gradient instead.
   const firmwareSpiral = caps.hardwareEffects;
-  const effectNeed: EffectColorNeed =
-    selectedEffect?.id === "spiral" && firmwareSpiral
-      ? "none"
-      : selectedEffect?.needs === "gradient" && !canGradient
-        ? "color"
-        : (selectedEffect?.needs ?? "none");
+  const isFirmwareSpiral = selectedEffect?.id === "spiral" && firmwareSpiral;
+  const effectNeed: EffectColorNeed = isFirmwareSpiral
+    ? "none"
+    : selectedEffect?.needs === "gradient" && !canGradient
+      ? "color"
+      : (selectedEffect?.needs ?? "none");
 
   const effectPreview = (): RGB[] => {
     if (!selectedEffect || effectNeed === "none") return selectedEffect?.colors ?? [color];
@@ -433,7 +433,7 @@ function Content() {
                           padding: "4px 2px 8px",
                         }}
                       >
-                        {selectedEffect?.id === "spiral" && firmwareSpiral
+                        {isFirmwareSpiral
                           ? t("effect.spiral.firmwareNote")
                           : t("effect.spectrumNote")}
                       </div>

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -285,7 +285,10 @@ function Content() {
   } = state;
   const hasLeds = caps.color || caps.brightness;
 
-  const canGradient = (caps.perZone || caps.perControllerColor) && caps.zones > 1;
+  // Any colour device offers a gradient: per-zone devices render it spatially,
+  // single-colour devices (Legion Go S / Go 2) crossfade through the palette over
+  // time — the same gradient experience on every Legion Go.
+  const canGradient = caps.color && caps.zones >= 1;
   // Devices that can't render a spatial gradient (single-color zones, e.g. Legion
   // rings) animate a crossfade through the palette, so they expose a speed control.
   const gradientAnimated = canGradient && !caps.perZone;

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -302,13 +302,16 @@ function Content() {
 
   const selectedEffect = visibleEffects.find((e) => e.id === effect.id) ?? visibleEffects[0];
 
-  // A gradient-based effect only points at the gradient editor when the device
-  // actually exposes one. On single-color devices (no gradient tab) it falls back
-  // to the shared solid color, which the firmware wave uses.
+  // Devices with native firmware effects (Legion Go) run spiral as their own
+  // fixed-palette effect — labelled "Spiral GO", taking no user color. Devices
+  // that paint zones in software (Ally) spin the user's gradient instead.
+  const firmwareSpiral = caps.hardwareEffects;
   const effectNeed: EffectColorNeed =
-    selectedEffect?.needs === "gradient" && !canGradient
-      ? "color"
-      : (selectedEffect?.needs ?? "none");
+    selectedEffect?.id === "spiral" && firmwareSpiral
+      ? "none"
+      : selectedEffect?.needs === "gradient" && !canGradient
+        ? "color"
+        : (selectedEffect?.needs ?? "none");
 
   const effectPreview = (): RGB[] => {
     if (!selectedEffect || effectNeed === "none") return selectedEffect?.colors ?? [color];
@@ -391,6 +394,7 @@ function Content() {
                       selected={effect.id}
                       speed={effect.speed}
                       disabled={!power}
+                      firmwareSpiral={firmwareSpiral}
                       onSelect={setEffectId}
                       onSpeed={setEffectSpeed}
                     />
@@ -426,7 +430,9 @@ function Content() {
                           padding: "4px 2px 8px",
                         }}
                       >
-                        {t("effect.spectrumNote")}
+                        {selectedEffect?.id === "spiral" && firmwareSpiral
+                          ? t("effect.spiral.firmwareNote")
+                          : t("effect.spectrumNote")}
                       </div>
                     </PanelSectionRow>
                   )}

--- a/src/palette.ts
+++ b/src/palette.ts
@@ -141,6 +141,18 @@ export const EFFECT_PRESETS: EffectMeta[] = [
       { r: 41, g: 182, b: 246 },
     ],
   },
+  {
+    id: "spiral",
+    label: "Spiral",
+    needs: "gradient",
+    description: "A gradient that spins around the ring.",
+    colors: [
+      { r: 255, g: 0, b: 128 },
+      { r: 124, g: 92, b: 255 },
+      { r: 0, g: 196, b: 255 },
+      { r: 64, g: 224, b: 120 },
+    ],
+  },
 ];
 
 const NAME_PARTS: Record<"es" | "en", { adjectives: string[]; nouns: string[] }> = {

--- a/src/types.ts
+++ b/src/types.ts
@@ -25,6 +25,7 @@ export interface Capabilities {
   maxBrightness: number;
   layout: ZoneGroup[];
   perZone: boolean;
+  hardwareEffects: boolean;
   reconnectable: boolean;
   perControllerColor: boolean;
   supportedEffects: string[];
@@ -41,7 +42,7 @@ export interface AmbilightState {
   fps: number;
 }
 
-export type EffectId = "breathing" | "rainbow" | "wave" | "cycle";
+export type EffectId = "breathing" | "rainbow" | "wave" | "cycle" | "spiral";
 
 export interface EffectState {
   id: EffectId;

--- a/src/useColores.ts
+++ b/src/useColores.ts
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useRef, useState } from "react";
-import { ColoresState, EffectId, Mode, RGB } from "./types";
+import { ColoresState, EffectId, EffectState, Mode, RGB } from "./types";
 import * as api from "./api";
 
 function useThrottle<A extends unknown[]>(fn: (...args: A) => void, ms: number) {
@@ -32,16 +32,30 @@ function useThrottle<A extends unknown[]>(fn: (...args: A) => void, ms: number) 
 
 export function useColores() {
   const [state, setState] = useState<ColoresState | null>(null);
+  const [loadError, setLoadError] = useState(false);
 
   const refreshState = useCallback(() => {
     api.getState()
-      .then(setState)
-      .catch((e) => console.error("Colores: getState failed", e));
+      .then((s) => {
+        setState(s);
+        setLoadError(false);
+      })
+      .catch((e) => {
+        console.error("Colores: getState failed", e);
+        setLoadError(true);
+      });
   }, []);
 
   useEffect(() => {
     refreshState();
   }, [refreshState]);
+
+  // Mirror the live effect so successive setters in the same tick chain off the
+  // latest value instead of a stale render-time snapshot.
+  const effectRef = useRef<EffectState | null>(null);
+  useEffect(() => {
+    if (state) effectRef.current = state.effect;
+  }, [state]);
 
   const pushSolid = useThrottle((c: RGB) => api.setSolid(c.r, c.g, c.b), 60);
   const pushBrightness = useThrottle((v: number) => api.setBrightness(v), 60);
@@ -85,20 +99,17 @@ export function useColores() {
     pushGradientSpeed(gradientSpeed);
   };
 
-  const setEffectId = (id: EffectId) => {
-    setState((s) => (s ? { ...s, effect: { ...s.effect, id } } : s));
-    if (state) pushEffect(id, state.effect.speed, state.effect.useGradient);
+  const updateEffect = (patch: Partial<EffectState>) => {
+    const base = effectRef.current ?? { id: "breathing", speed: 50, useGradient: false };
+    const next: EffectState = { ...base, ...patch };
+    effectRef.current = next;
+    setState((s) => (s ? { ...s, effect: next } : s));
+    pushEffect(next.id, next.speed, next.useGradient);
   };
 
-  const setEffectSpeed = (speed: number) => {
-    setState((s) => (s ? { ...s, effect: { ...s.effect, speed } } : s));
-    if (state) pushEffect(state.effect.id, speed, state.effect.useGradient);
-  };
-
-  const setEffectGradient = (useGradient: boolean) => {
-    setState((s) => (s ? { ...s, effect: { ...s.effect, useGradient } } : s));
-    if (state) pushEffect(state.effect.id, state.effect.speed, useGradient);
-  };
+  const setEffectId = (id: EffectId) => updateEffect({ id });
+  const setEffectSpeed = (speed: number) => updateEffect({ speed });
+  const setEffectGradient = (useGradient: boolean) => updateEffect({ useGradient });
 
   const setAmbilight = (saturation: number, smoothing: number, fps: number) => {
     setState((s) => (s ? { ...s, ambilight: { saturation, smoothing, fps } } : s));
@@ -137,6 +148,8 @@ export function useColores() {
 
   return {
     state,
+    loadError,
+    retry: refreshState,
     setBrightness,
     setPower,
     setMode,

--- a/tests/test_effects.py
+++ b/tests/test_effects.py
@@ -95,16 +95,16 @@ def test_frame_cycle_valid():
 
 
 def test_frame_spiral_at_t0_matches_palette():
-    stops = [(255, 0, 0), (0, 0, 255)]
-    assert frame_spiral(stops, 4, 0.0, 50) == interpolate_gradient(stops, 4)
+    palette = interpolate_gradient([(255, 0, 0), (0, 0, 255)], 4)
+    assert frame_spiral(palette, 0.0, 50) == palette
 
 
 def test_frame_spiral_rotates_and_stays_valid():
-    stops = [(255, 0, 0), (0, 255, 0), (0, 0, 255)]
-    start = frame_spiral(stops, 4, 0.0, 60)
+    palette = interpolate_gradient([(255, 0, 0), (0, 255, 0), (0, 0, 255)], 4)
+    start = frame_spiral(palette, 0.0, 60)
     moved = False
     for t in range(1, 30):
-        frame = frame_spiral(stops, 4, t / 10.0, 60)
+        frame = frame_spiral(palette, t / 10.0, 60)
         assert len(frame) == 4
         assert all(_valid(c) for c in frame)
         if frame != start:

--- a/tests/test_effects.py
+++ b/tests/test_effects.py
@@ -3,6 +3,7 @@ from py_modules.effects import (
     frame_cycle,
     frame_gradient_sweep,
     frame_rainbow,
+    frame_spiral,
     hsv_to_rgb,
     interpolate_gradient,
 )
@@ -91,3 +92,21 @@ def test_frame_cycle_valid():
         frame = frame_cycle(4, t / 5.0, 50)
         assert len(frame) == 4
         assert all(_valid(c) for c in frame)
+
+
+def test_frame_spiral_at_t0_matches_palette():
+    stops = [(255, 0, 0), (0, 0, 255)]
+    assert frame_spiral(stops, 4, 0.0, 50) == interpolate_gradient(stops, 4)
+
+
+def test_frame_spiral_rotates_and_stays_valid():
+    stops = [(255, 0, 0), (0, 255, 0), (0, 0, 255)]
+    start = frame_spiral(stops, 4, 0.0, 60)
+    moved = False
+    for t in range(1, 30):
+        frame = frame_spiral(stops, 4, t / 10.0, 60)
+        assert len(frame) == 4
+        assert all(_valid(c) for c in frame)
+        if frame != start:
+            moved = True
+    assert moved

--- a/tests/test_main_routing.py
+++ b/tests/test_main_routing.py
@@ -84,13 +84,26 @@ class FakeAmbilight:
         self.events.append(("start", cfg))
 
 
-def _plugin(main_module, mode, effect=None, hw=True, power=True, per_zone=False):
+def _plugin(
+    main_module,
+    mode,
+    effect=None,
+    hw=True,
+    power=True,
+    per_zone=False,
+    per_controller=False,
+):
     p = main_module.Plugin()
     p._ready = True
     p._controller = FakeController(hw, per_zone)
     p._engine = FakeEngine()
     p._ambilight = FakeAmbilight()
     p._zones = 2
+    p._capabilities = {
+        "zones": 2,
+        "perControllerColor": per_controller,
+        "perZone": per_zone,
+    }
     p._settings = {
         "power": power,
         "brightness": 80,
@@ -104,14 +117,53 @@ def _plugin(main_module, mode, effect=None, hw=True, power=True, per_zone=False)
     return p
 
 
-def test_wave_effect_runs_in_software_on_hardware_device(main_module):
-    p = _plugin(main_module, "effect", {"id": "wave", "speed": 50, "use_gradient": False})
+def test_wave_on_single_color_device_uses_hardware_effect(main_module):
+    # Legion Go S-like: hardware effects, single-color zones, no per-controller.
+    # Wave must use the native firmware effect (a single solid color), not the
+    # software loop that would collapse to a flat color — and the UI has no
+    # gradient tab to point at.
+    p = _plugin(
+        main_module,
+        "effect",
+        {"id": "wave", "speed": 50, "use_gradient": False},
+        hw=True,
+        per_zone=False,
+        per_controller=False,
+    )
     p._apply()
-    kinds = [e[0] for e in p._engine.events]
-    assert "effect" in kinds
+    assert any(c[0] == "hw_effect" and c[1] == "wave" for c in p._controller.calls)
+    assert not any(e[0] == "effect" for e in p._engine.events)
+
+
+def test_wave_on_per_zone_device_runs_in_software(main_module):
+    # Ally/MSI-like: per-zone capable -> software paints the spatial gradient wave.
+    p = _plugin(
+        main_module,
+        "effect",
+        {"id": "wave", "speed": 50, "use_gradient": False},
+        hw=False,
+        per_zone=True,
+    )
+    p._apply()
     effect_event = next(e for e in p._engine.events if e[0] == "effect")
     assert effect_event[1] == "wave"
     assert effect_event[2]["stops"] == [(0, 196, 255), (136, 86, 255)]
+    assert not any(c[0] == "hw_effect" for c in p._controller.calls)
+
+
+def test_wave_on_per_controller_device_runs_in_software(main_module):
+    # Legion Go/Go 2-like: per-controller color -> software paints a two-color
+    # wave across the left/right controllers using the gradient stops.
+    p = _plugin(
+        main_module,
+        "effect",
+        {"id": "wave", "speed": 50, "use_gradient": False},
+        hw=True,
+        per_zone=False,
+        per_controller=True,
+    )
+    p._apply()
+    assert any(e[0] == "effect" and e[1] == "wave" for e in p._engine.events)
     assert not any(c[0] == "hw_effect" for c in p._controller.calls)
 
 

--- a/tests/test_main_routing.py
+++ b/tests/test_main_routing.py
@@ -167,6 +167,35 @@ def test_wave_on_per_controller_device_runs_in_software(main_module):
     assert not any(c[0] == "hw_effect" for c in p._controller.calls)
 
 
+def test_spiral_on_legion_uses_firmware_effect(main_module):
+    # Legion Go (hardware effects): spiral is the device's native firmware effect.
+    p = _plugin(
+        main_module,
+        "effect",
+        {"id": "spiral", "speed": 50, "use_gradient": False},
+        hw=True,
+        per_zone=False,
+        per_controller=True,
+    )
+    p._apply()
+    assert any(c[0] == "hw_effect" and c[1] == "spiral" for c in p._controller.calls)
+    assert not any(e[0] == "effect" for e in p._engine.events)
+
+
+def test_spiral_on_ally_runs_in_software(main_module):
+    # Ally (no hardware effects): spiral spins the user's gradient in software.
+    p = _plugin(
+        main_module,
+        "effect",
+        {"id": "spiral", "speed": 50, "use_gradient": False},
+        hw=False,
+        per_zone=True,
+    )
+    p._apply()
+    assert any(e[0] == "effect" and e[1] == "spiral" for e in p._engine.events)
+    assert not any(c[0] == "hw_effect" for c in p._controller.calls)
+
+
 def test_breathing_with_use_gradient_runs_in_software(main_module):
     p = _plugin(main_module, "effect", {"id": "breathing", "speed": 50, "use_gradient": True})
     p._apply()


### PR DESCRIPTION
Coherence/UX pass plus new functionality, verified on a real Legion Go S (gradient section, Spiral GO) and with 105 passing backend tests + clean typecheck/build.

## Changes
- **UX consistency**: `disabled={!power}` applied uniformly across gradient controls, effects gallery and the solid swatch row; infinite-spinner on a failed `get_state` replaced with an error + Retry; effect setters refactored to a shared `updateEffect` (fixes a stale-closure desync).
- **Spiral effect**: new `spiral` — on devices with firmware effects (Legion Go) it's the native rotating gradient ("Spiral GO", no user color); on per-zone devices (Ally/MSI) it's a software spiral of the user's gradient. Palette precomputed once per run (off the ~30fps hot path).
- **Wave/Onda**: removed from single-color Legion profiles (would duplicate the gradient); kept on per-zone devices.
- **Gradient section on single-color devices**: `canGradient` now keys off `caps.color`, so the Legion Go S shows the Degradado section (temporal crossfade via `gradient_sweep`), matching the Go 2.
- **Resume restore**: re-applies the user's lighting after suspend on SteamOS via `RegisterForOnResumeFromSuspend` → `reconnect()`.
- New `hardwareEffects` capability so the frontend picks firmware vs software behaviour in lockstep with the backend.

## Tests
105 pytest pass (new coverage for `frame_spiral` and spiral routing on Legion/Ally); `tsc --noEmit` and `pnpm build` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)