### PR TITLE
feat: experimental power-button LED toggle for Legion Go

### DIFF
--- a/main.py
+++ b/main.py
@@ -22,6 +22,7 @@ DEFAULTS = {
     "ambilight": {"saturation": 140, "smoothing": 75, "fps": 10},
     "saved_gradients": [],
     "enabled_experiments": [],
+    "power_led_off": False,
 }
 
 
@@ -51,6 +52,7 @@ class Plugin:
         self._capabilities = ctx["capabilities"]
         self._zones = self._capabilities.get("zones", 1) or 1
         self._controller = ctx["device"]
+        self._power_led = ctx.get("power_led")
         self._store = SettingsStore(
             os.path.join(decky.DECKY_PLUGIN_SETTINGS_DIR, "state.json")
         )
@@ -67,7 +69,18 @@ class Plugin:
             gid,
             layout=self._capabilities.get("layout"),
         )
+        self._apply_power_led()
         self._ready = True
+
+    def _apply_power_led(self) -> None:
+        # Reassert ONLY the "off" state on load. When the feature is off we leave the
+        # EC untouched and never load ec_sys, so a Legion that never enables the toggle
+        # is never tainted (matches PowerLedController's lazy-load contract). Turning
+        # the LED back on is handled by the explicit set_power_led path.
+        if not (self._power_led and self._capabilities.get("powerLed")):
+            return
+        if self._settings.get("power_led_off", False) and not self._power_led.set(True):
+            decky.logger.warning("Colores: power LED apply on load failed")
 
     async def get_version(self) -> str:
         return read_version()
@@ -108,6 +121,7 @@ class Plugin:
             },
             "ambilight": s["ambilight"],
             "savedGradients": self._serialized_saved(),
+            "powerLedOff": s.get("power_led_off", False),
         }
 
     async def set_power(self, on: bool) -> None:
@@ -175,6 +189,14 @@ class Plugin:
         self._init()
         self._settings["ambilight"] = {"saturation": saturation, "smoothing": smoothing, "fps": fps}
         self._save_and_apply()
+
+    async def set_power_led(self, off: bool) -> None:
+        self._init()
+        self._settings["power_led_off"] = off
+        self._store.save(self._settings)
+        if self._power_led and self._capabilities.get("powerLed"):
+            if not self._power_led.set(off):
+                decky.logger.warning("Colores: power LED write failed (off=%s)", off)
 
     async def set_experiment(self, feature: str, on: bool) -> None:
         self._init()

--- a/py_modules/device.py
+++ b/py_modules/device.py
@@ -3,6 +3,7 @@ import os
 from device_profiles import resolve_profile
 from led_device import SysfsRgbDevice, NullDevice
 from hid_adapters import HID_AVAILABLE, HID_DRIVERS, build_hid_device
+from power_led import PowerLedController
 
 DEVICE_REGISTRY = [
     ("board", "Jupiter", "Steam Deck"),
@@ -134,7 +135,7 @@ def _feature_state(profile, feature, present):
     return "supported" if present else "unsupported"
 
 
-def build_capabilities(profile, has_led, zones, max_brightness, ambilight):
+def build_capabilities(profile, has_led, zones, max_brightness, ambilight, power_led=None):
     present = {
         "color": has_led,
         "brightness": has_led,
@@ -158,6 +159,7 @@ def build_capabilities(profile, has_led, zones, max_brightness, ambilight):
         "supportedEffects": list(profile.get("supported_effects", [])),
         "states": states,
         "experimental": list(profile.get("experimental", [])),
+        "powerLed": bool(power_led and power_led.available()),
         "layout": build_layout(zones, profile.get("swap_sticks", False)),
     }
 
@@ -182,12 +184,12 @@ def _find_rgb_led(leds_dir):
 _IMPLEMENTED_DRIVERS = {"sysfs", "hid_msi", "hid_legion_tablet", "hid_legion_go_s"}
 
 
-def _build_hid_context(profile, ambilight):
+def _build_hid_context(profile, ambilight, power_led=None):
     device = build_hid_device(profile["driver"])
     if device is None or not device.available:
         return None
     zones = profile.get("zones") or 1
-    capabilities = build_capabilities(profile, True, zones, 100, ambilight)
+    capabilities = build_capabilities(profile, True, zones, 100, ambilight, power_led)
     capabilities["perZone"] = device.supports_per_zone()
     capabilities["hardwareEffects"] = device.supports_hardware_effects()
     capabilities["reconnectable"] = True
@@ -198,15 +200,17 @@ def build_device(sysfs_root="/", ambilight=False):
     info = detect_device(sysfs_root)
     profile = resolve_profile(info["board"], info["product"])
     info["name"] = profile["name"]
+    power_led = PowerLedController(profile.get("power_led"))
 
     if profile["driver"] in HID_DRIVERS:
         if HID_AVAILABLE:
-            hid_ctx = _build_hid_context(profile, ambilight)
+            hid_ctx = _build_hid_context(profile, ambilight, power_led)
             if hid_ctx is not None:
                 return {
                     "info": info,
                     "capabilities": hid_ctx["capabilities"],
                     "device": hid_ctx["device"],
+                    "power_led": power_led,
                 }
         profile["experimental"] = _all_experimental(profile)
 
@@ -229,9 +233,10 @@ def build_device(sysfs_root="/", ambilight=False):
     if profile["driver"] not in _IMPLEMENTED_DRIVERS:
         profile["experimental"] = _all_experimental(profile)
 
-    capabilities = build_capabilities(profile, has_led, zones, max_brightness, ambilight)
+    capabilities = build_capabilities(profile, has_led, zones, max_brightness, ambilight, power_led)
     return {
         "info": info,
         "capabilities": capabilities,
         "device": device,
+        "power_led": power_led,
     }

--- a/py_modules/device_profiles.py
+++ b/py_modules/device_profiles.py
@@ -16,6 +16,17 @@ MSI_HID = {
     "experimental": [],
 }
 
+# Power-button ring LED control via the Embedded Controller (see power_led.py).
+# Each entry is an EC byte/bit to SET to turn the LED off (cleared = on); polarity is
+# uniform across Legion devices. Offsets reverse-engineered from each device's DSDT
+# (GZFD.WMAF -> SLT2) and verified on hardware. A list because the original Legion Go
+# uses two separate fields (awake + suspend) while Go S / Go 2 use a single shared bit.
+POWER_LED_LPBL = [{"offset": 0x10, "mask": 0x40}]  # Go S, Go 2 (LPBL, awake+suspend)
+POWER_LED_LEDPM = [  # original Legion Go (LEDP awake + LEDM suspend)
+    {"offset": 0x52, "mask": 0x20},
+    {"offset": 0x58, "mask": 0x01},
+]
+
 LEGION_TABLET_HID = {
     "driver": "hid_legion_tablet",
     "color_order": "rgb",
@@ -44,15 +55,23 @@ GENERIC = {
 }
 
 
+def _copy_bits(bits):
+    return [dict(bit) for bit in bits]
+
+
 def _copy_profile(base):
     merged = dict(base)
     merged["experimental"] = list(base.get("experimental", []))
+    if base.get("power_led"):
+        merged["power_led"] = _copy_bits(base["power_led"])
     return merged
 
 
-def _profile(base, name):
+def _profile(base, name, power_led=None):
     merged = _copy_profile(base)
     merged["name"] = name
+    if power_led is not None:
+        merged["power_led"] = _copy_bits(power_led)
     return merged
 
 
@@ -61,13 +80,13 @@ PROFILES = [
     ("board", "RC72LA", _profile(ASUS_SYSFS, "ROG Ally X")),
     ("board", "RC73YA", _profile(ASUS_SYSFS, "ROG Xbox Ally")),
     ("board", "RC73XA", _profile(ASUS_SYSFS, "ROG Xbox Ally X")),
-    ("product", "83E1", _profile(LEGION_TABLET_HID, "Legion Go")),
-    ("product", "83N0", _profile(LEGION_TABLET_HID, "Legion Go 2")),
-    ("product", "83N1", _profile(LEGION_TABLET_HID, "Legion Go 2")),
-    ("product", "83L3", _profile(LEGION_GO_S_HID, "Legion Go S")),
-    ("product", "83Q2", _profile(LEGION_GO_S_HID, "Legion Go S")),
-    ("product", "83N6", _profile(LEGION_GO_S_HID, "Legion Go S")),
-    ("product", "83Q3", _profile(LEGION_GO_S_HID, "Legion Go S")),
+    ("product", "83E1", _profile(LEGION_TABLET_HID, "Legion Go", POWER_LED_LEDPM)),
+    ("product", "83N0", _profile(LEGION_TABLET_HID, "Legion Go 2", POWER_LED_LPBL)),
+    ("product", "83N1", _profile(LEGION_TABLET_HID, "Legion Go 2", POWER_LED_LPBL)),
+    ("product", "83L3", _profile(LEGION_GO_S_HID, "Legion Go S", POWER_LED_LPBL)),
+    ("product", "83Q2", _profile(LEGION_GO_S_HID, "Legion Go S", POWER_LED_LPBL)),
+    ("product", "83N6", _profile(LEGION_GO_S_HID, "Legion Go S", POWER_LED_LPBL)),
+    ("product", "83Q3", _profile(LEGION_GO_S_HID, "Legion Go S", POWER_LED_LPBL)),
     ("product_contains", "Claw 8 AI+", _profile(MSI_HID, "MSI Claw 8 AI+")),
     ("product_contains", "Claw A1M", _profile(MSI_HID, "MSI Claw")),
 ]

--- a/py_modules/power_led.py
+++ b/py_modules/power_led.py
@@ -1,0 +1,98 @@
+"""Power-button ring LED control for Lenovo Legion handhelds.
+
+The power-button LED is not an RGB LED on the HID/sysfs path Colores uses for the
+joystick rings. It is a single Embedded Controller (EC) bit. The firmware method
+`\\_SB.GZFD.WMAF` (reverse-engineered from each device's DSDT) only writes that bit, and
+on Bazzite's current kernel `acpi_call` is unavailable, so we write the EC directly via
+the in-tree `ec_sys` debug module.
+
+Config is a list of EC byte/bit entries to SET to turn the LED off (cleared = on):
+  Go S / Go 2  -> [{"offset": 0x10, "mask": 0x40}]            (LPBL, awake + suspend)
+  Legion Go    -> [{"offset": 0x52, "mask": 0x20},            (LEDP, awake)
+                   {"offset": 0x58, "mask": 0x01}]            (LEDM, suspend)
+
+Everything degrades gracefully: with no config or no reachable EC the controller is
+simply unavailable and the UI hides the toggle.
+"""
+import os
+import subprocess
+
+EC_IO = "/sys/kernel/debug/ec/ec0/io"
+
+
+class PowerLedController:
+    def __init__(self, config, ec_io=EC_IO):
+        self._config = list(config or [])
+        self._ec_io = ec_io
+
+    def available(self) -> bool:
+        """Has a known config AND the EC is reachable (or the module can be loaded).
+
+        Does NOT load ec_sys here, so merely detecting the capability never taints the
+        kernel; the module is loaded lazily on the first write.
+        """
+        if not self._config:
+            return False
+        return self._writable() or self._module_present()
+
+    def get(self):
+        """True if the LED is off (all configured bits set), False if on, None if unknown."""
+        if not self._config:
+            return None
+        if not (os.path.exists(self._ec_io) and os.access(self._ec_io, os.R_OK)):
+            return None
+        try:
+            return all(bool(self._read_byte(b["offset"]) & b["mask"]) for b in self._config)
+        except (OSError, IndexError, ValueError):
+            return None
+
+    def set(self, off: bool) -> bool:
+        """Turn the LED off (off=True) or on (off=False). Returns success."""
+        if not self._config or not self._ensure_loaded():
+            return False
+        try:
+            for bit in self._config:
+                current = self._read_byte(bit["offset"])
+                updated = (current | bit["mask"]) if off else (current & ~bit["mask"])
+                if updated != current:
+                    self._write_byte(bit["offset"], updated)
+            return True
+        except (OSError, IndexError, ValueError):
+            return False
+
+    # --- EC access -------------------------------------------------------------
+
+    def _writable(self) -> bool:
+        return os.path.exists(self._ec_io) and os.access(self._ec_io, os.W_OK)
+
+    def _module_present(self) -> bool:
+        try:
+            return subprocess.run(
+                ["modprobe", "-n", "ec_sys"], capture_output=True
+            ).returncode == 0
+        except Exception:
+            return False
+
+    def _ensure_loaded(self) -> bool:
+        if self._writable():
+            return True
+        try:
+            subprocess.run(
+                ["modprobe", "ec_sys", "write_support=1"],
+                check=False,
+                capture_output=True,
+            )
+        except Exception:
+            return False
+        return self._writable()
+
+    def _read_byte(self, offset: int) -> int:
+        with open(self._ec_io, "rb") as handle:
+            handle.seek(offset)
+            return handle.read(1)[0]
+
+    def _write_byte(self, offset: int, value: int) -> None:
+        with open(self._ec_io, "r+b") as handle:
+            handle.seek(offset)
+            handle.write(bytes([value & 0xFF]))
+            handle.flush()

--- a/src/api.ts
+++ b/src/api.ts
@@ -15,4 +15,5 @@ export const saveGradient = callable<[name: string, stops: number[][]], Gradient
 export const deleteGradient = callable<[name: string], GradientPreset[]>("delete_gradient");
 export const getVersion = callable<[], string>("get_version");
 export const setExperiment = callable<[feature: string, on: boolean], void>("set_experiment");
+export const setPowerLed = callable<[off: boolean], void>("set_power_led");
 export const reconnect = callable<[], boolean>("reconnect");

--- a/src/i18n/index.tsx
+++ b/src/i18n/index.tsx
@@ -100,6 +100,10 @@ const es: Record<string, string> = {
   "experimental.feature.brightness": "Brillo",
   "experimental.feature.effects": "Efectos",
   "experimental.feature.ambilight": "Ambilight",
+
+  "powerLed.section": "Luz del botón de encendido (experimental)",
+  "powerLed.label": "Apagar luz del botón de encendido",
+  "powerLed.warning": "Apaga el LED del botón de encendido.",
 };
 
 const en: Record<string, string> = {
@@ -197,6 +201,10 @@ const en: Record<string, string> = {
   "experimental.feature.brightness": "Brightness",
   "experimental.feature.effects": "Effects",
   "experimental.feature.ambilight": "Ambilight",
+
+  "powerLed.section": "Power button light (experimental)",
+  "powerLed.label": "Turn off power button light",
+  "powerLed.warning": "Turns off the power button LED.",
 };
 
 const DICTS: Record<Lang, Record<string, string>> = { es, en };

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -218,6 +218,7 @@ function Content() {
     saveGradient,
     deleteGradient,
     setExperiment,
+    setPowerLed,
     reconnect,
   } = useColores();
   const { t } = useI18n();
@@ -285,6 +286,7 @@ function Content() {
     mode,
     device,
     savedGradients,
+    powerLedOff,
   } = state;
   const hasLeds = caps.color || caps.brightness;
 
@@ -570,6 +572,40 @@ function Content() {
               </PanelSectionRow>
             </>
           )}
+        </>
+      )}
+
+      {caps.powerLed && (
+        <>
+          <PanelSectionRow>
+            <div
+              style={{ height: 1, background: "rgba(255,255,255,0.07)", margin: "14px 0 8px" }}
+            />
+          </PanelSectionRow>
+          <PanelSectionRow>
+            <div style={{ fontWeight: 600, fontSize: 13, padding: "2px 2px 6px" }}>
+              {t("powerLed.section")}
+            </div>
+          </PanelSectionRow>
+          <PanelSectionRow>
+            <ToggleField
+              label={t("powerLed.label")}
+              checked={powerLedOff}
+              onChange={setPowerLed}
+            />
+          </PanelSectionRow>
+          <PanelSectionRow>
+            <div
+              style={{
+                fontSize: 12,
+                color: "rgba(255,255,255,0.55)",
+                padding: "0 2px 4px",
+                lineHeight: 1.45,
+              }}
+            >
+              {t("powerLed.warning")}
+            </div>
+          </PanelSectionRow>
         </>
       )}
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -33,6 +33,7 @@ export interface Capabilities {
   experimental: string[];
   states: Record<string, "supported" | "experimental" | "unsupported">;
   enabledExperiments: string[];
+  powerLed: boolean;
 }
 
 export type Mode = "solid" | "gradient" | "effect" | "ambient";
@@ -63,6 +64,7 @@ export interface ColoresState {
   effect: EffectState;
   ambilight: AmbilightState;
   savedGradients: GradientPreset[];
+  powerLedOff: boolean;
 }
 
 export interface GradientPreset {

--- a/src/useColores.ts
+++ b/src/useColores.ts
@@ -133,6 +133,11 @@ export function useColores() {
       .catch((e) => console.error("Colores: deleteGradient failed", e));
   };
 
+  const setPowerLed = (off: boolean) => {
+    setState((s) => (s ? { ...s, powerLedOff: off } : s));
+    api.setPowerLed(off).catch((e) => console.error("Colores: setPowerLed failed", e));
+  };
+
   const setExperiment = (feature: string, on: boolean) => {
     api
       .setExperiment(feature, on)
@@ -163,6 +168,7 @@ export function useColores() {
     saveGradient,
     deleteGradient,
     setExperiment,
+    setPowerLed,
     reconnect,
   };
 }

--- a/tests/test_power_led.py
+++ b/tests/test_power_led.py
@@ -1,0 +1,78 @@
+import types
+
+import power_led
+from power_led import PowerLedController
+
+LPBL = [{"offset": 0x10, "mask": 0x40}]
+LEDPM = [{"offset": 0x52, "mask": 0x20}, {"offset": 0x58, "mask": 0x01}]
+
+
+def _ec(tmp_path, overrides=None):
+    data = bytearray(0x60)
+    for off, val in (overrides or {}).items():
+        data[off] = val
+    path = tmp_path / "ec_io"
+    path.write_bytes(bytes(data))
+    return str(path)
+
+
+def _byte(path, off):
+    with open(path, "rb") as handle:
+        return handle.read()[off]
+
+
+def test_unavailable_without_config(tmp_path):
+    assert PowerLedController([], ec_io=_ec(tmp_path)).available() is False
+
+
+def test_available_when_ec_writable(tmp_path):
+    assert PowerLedController(LPBL, ec_io=_ec(tmp_path)).available() is True
+
+
+def test_set_off_sets_bit_preserving_others(tmp_path):
+    path = _ec(tmp_path, {0x10: 0x05})
+    ctrl = PowerLedController(LPBL, ec_io=path)
+    assert ctrl.set(True) is True
+    assert _byte(path, 0x10) == 0x45  # 0x05 | 0x40, other bits kept
+    assert ctrl.get() is True
+
+
+def test_set_on_clears_bit_preserving_others(tmp_path):
+    path = _ec(tmp_path, {0x10: 0x45})
+    ctrl = PowerLedController(LPBL, ec_io=path)
+    assert ctrl.set(False) is True
+    assert _byte(path, 0x10) == 0x05
+    assert ctrl.get() is False
+
+
+def test_multi_field_device(tmp_path):
+    path = _ec(tmp_path)
+    ctrl = PowerLedController(LEDPM, ec_io=path)
+    assert ctrl.set(True) is True
+    assert _byte(path, 0x52) == 0x20 and _byte(path, 0x58) == 0x01
+    assert ctrl.get() is True
+    assert ctrl.set(False) is True
+    assert _byte(path, 0x52) == 0x00 and _byte(path, 0x58) == 0x00
+    assert ctrl.get() is False
+
+
+def test_short_ec_node_does_not_raise(tmp_path):
+    # EC node shorter than the configured offset: read(1) returns b"" -> must not
+    # raise (IndexError), so it never bricks plugin load. Degrades to None/False.
+    path = tmp_path / "ec_io"
+    path.write_bytes(bytes(4))  # only 4 bytes, offset 0x10 is past EOF
+    ctrl = PowerLedController(LPBL, ec_io=str(path))
+    assert ctrl.get() is None
+    assert ctrl.set(True) is False
+
+
+def test_missing_ec_is_safe(tmp_path, monkeypatch):
+    # No EC node and the module cannot be loaded -> degrade gracefully, never raise.
+    monkeypatch.setattr(
+        power_led.subprocess, "run",
+        lambda *a, **k: types.SimpleNamespace(returncode=1, stdout=b"", stderr=b""),
+    )
+    ctrl = PowerLedController(LPBL, ec_io=str(tmp_path / "nope"))
+    assert ctrl.available() is False
+    assert ctrl.set(True) is False
+    assert ctrl.get() is None


### PR DESCRIPTION
Adds a Legion-only experimental toggle that turns off the power-button ring LED.

The LED is a single Embedded Controller bit (reverse-engineered from each device's DSDT: `GZFD.WMAF` → `SLT2`), written via the in-tree `ec_sys` module. `acpi_call` is absent on current Bazzite kernels and the mainline `lenovo-wmi` "Lighting" interface isn't implemented yet, so the EC path is the only one that works today.

- `power_led.py`: `PowerLedController`, lazy `ec_sys` load (no kernel taint until used), never raises.
- Per-device EC config as data in `device_profiles.py`: Go S / Go 2 = `0x10`/bit6; Legion Go = `0x52`/bit5 + `0x58`/bit0.
- `powerLed` capability + `set_power_led` RPC, gated to Legion with a reachable EC.
- Dedicated experimental toggle in the QAM (ES/EN), shown only on Legion.
- Does not affect TDP/fan/battery. Verified on-device on all three Legions; tested via prerelease on the Legion Go 2.