### PR TITLE
fix: recover LED config after a cold boot / recuperar la configuración de LEDs tras un arranque en frío

### DIFF
--- a/main.py
+++ b/main.py
@@ -1,3 +1,4 @@
+import asyncio
 import os
 import pwd
 import shutil
@@ -25,6 +26,14 @@ DEFAULTS = {
     "power_led_off": False,
 }
 
+# Cold-boot LED acquisition: the Ally's RGB node hangs off a USB HID device that can
+# enumerate late, so /sys/class/leds/...:rgb may not exist yet when the plugin loads.
+# Poll for it for a bounded window, then re-assert once more to beat any default the
+# firmware/another plugin writes shortly after load. Module-level so tests can shrink them.
+ACQUIRE_ATTEMPTS = 20
+ACQUIRE_INTERVAL = 1.0
+REASSERT_DELAY = 5.0
+
 
 def _rgb(values):
     return {"r": values[0], "g": values[1], "b": values[2]}
@@ -46,19 +55,26 @@ class Plugin:
     def _init(self) -> None:
         if getattr(self, "_ready", False):
             return
-        ambilight_available = shutil.which("gst-launch-1.0") is not None
-        ctx = build_device(ambilight=ambilight_available)
-        self._device = ctx["info"]
-        self._capabilities = ctx["capabilities"]
-        self._zones = self._capabilities.get("zones", 1) or 1
-        self._controller = ctx["device"]
-        self._power_led = ctx.get("power_led")
+        self._setup_device(self._build_context())
         self._store = SettingsStore(
             os.path.join(decky.DECKY_PLUGIN_SETTINGS_DIR, "state.json")
         )
         self._settings = self._store.load(DEFAULTS)
         self._settings["ambilight"] = {**DEFAULTS["ambilight"], **self._settings["ambilight"]}
         self._settings["effect"] = {**DEFAULTS["effect"], **self._settings["effect"]}
+        self._apply_power_led()
+        self._ready = True
+
+    def _build_context(self) -> dict:
+        ambilight_available = shutil.which("gst-launch-1.0") is not None
+        return build_device(ambilight=ambilight_available)
+
+    def _setup_device(self, ctx: dict) -> None:
+        self._device = ctx["info"]
+        self._capabilities = ctx["capabilities"]
+        self._zones = self._capabilities.get("zones", 1) or 1
+        self._controller = ctx["device"]
+        self._power_led = ctx.get("power_led")
         self._engine = EffectEngine(self._render, self._zones)
         runtime_dir, uid, gid = _user_creds()
         self._ambilight = Ambilight(
@@ -69,8 +85,40 @@ class Plugin:
             gid,
             layout=self._capabilities.get("layout"),
         )
-        self._apply_power_led()
-        self._ready = True
+
+    def _reprobe_device(self) -> bool:
+        # Recover a controller that wasn't present at load (late USB HID enumeration on
+        # cold boot). No-op once we already have a working LED — this guard is what keeps
+        # a healthy machine completely untouched (never rebuilds the engine mid-effect).
+        if self._controller.available:
+            return True
+        ctx = self._build_context()
+        if not ctx["device"].available:
+            return False
+        self._ambilight.stop()
+        self._engine.stop()
+        self._setup_device(ctx)
+        return True
+
+    async def _acquire_and_reassert(self) -> None:
+        try:
+            # H1: wait for the LED node to appear, applying as soon as it does.
+            for _ in range(ACQUIRE_ATTEMPTS):
+                if self._controller.available:
+                    break
+                await asyncio.sleep(ACQUIRE_INTERVAL)
+                if self._reprobe_device():
+                    self._apply()
+            # H2: a static write can be overwritten by a late firmware/other-plugin default.
+            # Re-assert once. Skip it when a render loop is active (effect/ambilight): that
+            # loop already rewrites ~30fps and wins on its own, so reapplying would only
+            # restart the effect at frame 0 — needless disruption of something that works.
+            await asyncio.sleep(REASSERT_DELAY)
+            self._reprobe_device()
+            if not self._wants_render_loop():
+                self._apply()
+        except Exception as error:  # never let the background task break plugin load
+            decky.logger.warning("Colores: acquire/reassert failed: %s", error)
 
     def _apply_power_led(self) -> None:
         # Reassert ONLY the "off" state on load. When the feature is off we leave the
@@ -177,6 +225,7 @@ class Plugin:
 
     async def reconnect(self) -> bool:
         self._init()
+        self._reprobe_device()
         ok = self._controller.reconnect()
         self._apply()
         return bool(ok)
@@ -289,6 +338,7 @@ class Plugin:
                     "saturation": amb["saturation"] / 100.0,
                     "smoothing": amb["smoothing"],
                     "fps": amb.get("fps", 10),
+                    "fallback": tuple(s["color"]),
                 }
             )
             return
@@ -322,18 +372,24 @@ class Plugin:
     async def _main(self):
         self._init()
         decky.logger.info(
-            "Colores v%s on %s (euid=%s color=%s zones=%s ambilight=%s ledPath=%s)",
+            "Colores v%s on %s (euid=%s color=%s zones=%s ambilight=%s available=%s ledPath=%s lastError=%s)",
             read_version(),
             self._device["name"],
             os.geteuid(),
             self._capabilities["color"],
             self._capabilities["zones"],
             self._capabilities["ambilight"],
-            self._capabilities.get("ledPath"),
+            self._controller.available,
+            self._controller.led_path,
+            self._controller.last_error,
         )
         self._apply()
+        self._reassert_task = asyncio.create_task(self._acquire_and_reassert())
 
     async def _unload(self):
+        task = getattr(self, "_reassert_task", None)
+        if task:
+            task.cancel()
         if getattr(self, "_ambilight", None):
             self._ambilight.stop()
         if getattr(self, "_engine", None):

--- a/py_modules/ambilight.py
+++ b/py_modules/ambilight.py
@@ -2,13 +2,18 @@ import asyncio
 import json
 import logging
 import os
-import subprocess
 
 logger = logging.getLogger("colores.ambilight")
 
 GAMESCOPE_NODE = "gamescope"
 CAP_W = 32
 CAP_H = 18
+
+# Seconds between reconnect attempts when the gamescope source is missing or the
+# stream drops. On a cold boot the user's PipeWire/gamescope session isn't ready when
+# the (root) plugin loads, so the capture must keep retrying instead of giving up —
+# otherwise ambient mode stays dark until the user manually re-selects it.
+RETRY_INTERVAL = 3.0
 
 _FULL_REGION = [0.0, 0.0, 1.0, 1.0]
 
@@ -84,6 +89,13 @@ class Ambilight:
     def running(self):
         return self._task is not None and not self._task.done()
 
+    def _fallback(self):
+        # Shown when there's no game source to sample (e.g. the Steam home screen, or a
+        # cold boot before the session is up) so the LEDs hold the user's last solid color
+        # instead of going dark. Routes through _apply, so brightness/power still apply.
+        color = self._options.get("fallback") or (0, 0, 0)
+        return [tuple(color)] * self._zones
+
     def _env(self):
         env = dict(os.environ)
         if self._runtime_dir:
@@ -95,15 +107,27 @@ class Ambilight:
             return {}
         return {"user": self._uid, "group": self._gid}
 
-    def _find_node(self):
+    async def _find_node(self):
+        # Async so the retry loop never blocks the event loop while waiting on pw-dump
+        # (it runs every RETRY_INTERVAL while the source is missing).
+        proc = None
         try:
-            result = subprocess.run(
-                ["pw-dump"], capture_output=True, text=True, env=self._env(), timeout=5,
+            proc = await asyncio.create_subprocess_exec(
+                "pw-dump",
+                stdout=asyncio.subprocess.PIPE,
+                stderr=asyncio.subprocess.DEVNULL,
+                env=self._env(),
                 **self._cred(),
             )
-            data = json.loads(result.stdout)
-        except (OSError, ValueError, subprocess.SubprocessError) as error:
+            out, _ = await asyncio.wait_for(proc.communicate(), timeout=5)
+            data = json.loads(out)
+        except (OSError, ValueError, asyncio.TimeoutError) as error:
             logger.warning("pw-dump failed: %s", error)
+            if proc is not None:
+                try:
+                    proc.kill()
+                except ProcessLookupError:
+                    pass
             return None
         for obj in data:
             props = (obj.get("info") or {}).get("props") or {}
@@ -136,49 +160,55 @@ class Ambilight:
             self._proc = None
 
     async def _run(self):
-        node = self._find_node()
-        if node is None:
-            logger.warning("gamescope PipeWire node not found; ambilight idle")
-            self.status = "no_source"
-            self._apply([(0, 0, 0)] * self._zones)
-            return
-
-        interval = 1.0 / max(1, int(self._options.get("fps", 10)))
-        command = _gst_command(node, CAP_W, CAP_H)
+        # Outer reconnect loop: keep trying to find the gamescope source and capture it
+        # until stop() cancels us. The source can be absent at boot (session not up yet)
+        # or vanish (leaving Game Mode) and reappear — we recover from both automatically.
         frame_bytes = CAP_W * CAP_H * 3
-        proc = None
-        logger.info("ambilight start: node=%s fps=%.0f", node, 1.0 / interval)
-        try:
-            proc = await asyncio.create_subprocess_exec(
-                *command,
-                stdout=asyncio.subprocess.PIPE,
-                stderr=asyncio.subprocess.PIPE,
-                env=self._env(),
-                **self._cred(),
-            )
-            self._proc = proc
-            self.status = "running"
-            while True:
-                frame = await proc.stdout.readexactly(frame_bytes)
-                self._update_targets(frame)
-                self._tick()
-                await asyncio.sleep(interval)
-        except asyncio.IncompleteReadError:
-            self.status = "no_source"
-            await self._log_exit(proc)
-            self._apply([(0, 0, 0)] * self._zones)
-        except asyncio.CancelledError:
-            raise
-        except Exception:
-            logger.exception("ambilight loop failed")
-        finally:
-            if proc is not None:
-                try:
-                    proc.kill()
-                except ProcessLookupError:
-                    pass
-            if self._proc is proc:
-                self._proc = None
+        while True:
+            node = await self._find_node()
+            if node is None:
+                logger.warning("gamescope PipeWire node not found; retrying")
+                self.status = "no_source"
+                self._apply(self._fallback())
+                await asyncio.sleep(RETRY_INTERVAL)
+                continue
+
+            interval = 1.0 / max(1, int(self._options.get("fps", 10)))
+            command = _gst_command(node, CAP_W, CAP_H)
+            proc = None
+            logger.info("ambilight start: node=%s fps=%.0f", node, 1.0 / interval)
+            try:
+                proc = await asyncio.create_subprocess_exec(
+                    *command,
+                    stdout=asyncio.subprocess.PIPE,
+                    stderr=asyncio.subprocess.PIPE,
+                    env=self._env(),
+                    **self._cred(),
+                )
+                self._proc = proc
+                self.status = "running"
+                while True:
+                    frame = await proc.stdout.readexactly(frame_bytes)
+                    self._update_targets(frame)
+                    self._tick()
+                    await asyncio.sleep(interval)
+            except asyncio.IncompleteReadError:
+                self.status = "no_source"
+                await self._log_exit(proc)
+                self._apply(self._fallback())
+            except asyncio.CancelledError:
+                raise
+            except Exception:
+                logger.exception("ambilight loop failed")
+            finally:
+                if proc is not None:
+                    try:
+                        proc.kill()
+                    except ProcessLookupError:
+                        pass
+                if self._proc is proc:
+                    self._proc = None
+            await asyncio.sleep(RETRY_INTERVAL)
 
     async def _log_exit(self, proc):
         if proc is None:

--- a/py_modules/led_device.py
+++ b/py_modules/led_device.py
@@ -10,6 +10,9 @@ def _clamp_pct(value):
 
 
 class LedDevice:
+    led_path = None
+    last_error = None
+
     @property
     def available(self):
         return False
@@ -54,6 +57,10 @@ class SysfsRgbDevice(LedDevice):
     @property
     def available(self):
         return bool(self._led_path)
+
+    @property
+    def led_path(self):
+        return self._led_path
 
     def supports_per_zone(self):
         return True

--- a/tests/test_ambilight.py
+++ b/tests/test_ambilight.py
@@ -1,4 +1,8 @@
+import asyncio
+
+import py_modules.ambilight as ambilight_mod
 from py_modules.ambilight import (
+    Ambilight,
     _gst_command,
     alpha_for,
     avg_region,
@@ -6,6 +10,61 @@ from py_modules.ambilight import (
     lerp,
     subdivide,
 )
+
+
+def test_run_retries_when_source_missing(monkeypatch):
+    # Cold boot: the gamescope node isn't there yet. The capture must keep retrying
+    # (and stay alive) instead of giving up after one miss — otherwise ambient mode
+    # never recovers without manual intervention.
+    monkeypatch.setattr(ambilight_mod, "RETRY_INTERVAL", 0.001)
+    applied = []
+    amb = Ambilight(lambda colors: applied.append(list(colors)), zones=4, runtime_dir=None)
+    async def _no_node():
+        return None
+
+    amb._find_node = _no_node
+
+    async def drive():
+        amb.start({"fps": 10})
+        task = amb._task
+        await asyncio.sleep(0.05)
+        assert amb.running
+        assert amb.status == "no_source"
+        assert len(applied) >= 2
+        assert applied[0] == [(0, 0, 0)] * 4
+        amb.stop()
+        try:
+            await task
+        except asyncio.CancelledError:
+            pass
+
+    asyncio.run(drive())
+    assert not amb.running
+
+
+def test_run_shows_fallback_color_when_source_missing(monkeypatch):
+    # No game source -> hold the user's last solid color instead of going dark.
+    monkeypatch.setattr(ambilight_mod, "RETRY_INTERVAL", 0.001)
+    applied = []
+    amb = Ambilight(lambda colors: applied.append(list(colors)), zones=4, runtime_dir=None)
+    async def _no_node():
+        return None
+
+    amb._find_node = _no_node
+
+    async def drive():
+        amb.start({"fps": 10, "fallback": (10, 20, 30)})
+        task = amb._task
+        await asyncio.sleep(0.02)
+        amb.stop()
+        try:
+            await task
+        except asyncio.CancelledError:
+            pass
+
+    asyncio.run(drive())
+    assert applied
+    assert applied[0] == [(10, 20, 30)] * 4
 
 
 def test_gst_command_uses_leaky_queue_before_scaling():

--- a/tests/test_main_routing.py
+++ b/tests/test_main_routing.py
@@ -34,6 +34,9 @@ class FakeController:
         self._per_zone = per_zone
         self.calls = []
         self.reconnected = False
+        self.available = True
+        self.led_path = None
+        self.last_error = None
 
     def supports_hardware_effects(self):
         return self._hw
@@ -244,3 +247,80 @@ def test_reconnect_resets_controller_and_reapplies(main_module):
     assert ok is True
     assert p._controller.reconnected is True
     assert any(c[0] == "solid" for c in p._controller.calls)
+
+
+def _late_ctx(device):
+    return {
+        "info": {"name": "ROG Xbox Ally X"},
+        "capabilities": {"zones": 4, "color": True, "ambilight": True, "layout": []},
+        "device": device,
+        "power_led": None,
+    }
+
+
+def test_reprobe_recovers_late_led_and_rebuilds_zones(main_module, monkeypatch):
+    # Cold-boot: the LED node wasn't present at load (NullDevice). Once it appears,
+    # _reprobe_device must swap in the real controller and rebuild the engine to the
+    # device's real zone count.
+    p = _plugin(main_module, "solid")
+    p._controller.available = False
+    new_ctrl = FakeController(hw=False, per_zone=True)
+    monkeypatch.setattr(main_module, "build_device", lambda **k: _late_ctx(new_ctrl))
+    assert p._reprobe_device() is True
+    assert p._controller is new_ctrl
+    assert p._zones == 4
+
+
+def test_reprobe_is_noop_when_already_available(main_module, monkeypatch):
+    # Healthy machine: a present LED must never trigger a re-probe (build_device must
+    # not even be called) — this is the guarantee that we don't disturb working setups.
+    p = _plugin(main_module, "solid")
+    monkeypatch.setattr(
+        main_module, "build_device",
+        lambda **k: (_ for _ in ()).throw(AssertionError("must not reprobe")),
+    )
+    assert p._reprobe_device() is True
+
+
+def test_acquire_applies_when_led_appears_late(main_module, monkeypatch):
+    monkeypatch.setattr(main_module, "ACQUIRE_INTERVAL", 0.001)
+    monkeypatch.setattr(main_module, "REASSERT_DELAY", 0.001)
+    p = _plugin(main_module, "solid")
+    p._controller.available = False
+    new_ctrl = FakeController(hw=False, per_zone=True)
+    monkeypatch.setattr(main_module, "build_device", lambda **k: _late_ctx(new_ctrl))
+    asyncio.run(p._acquire_and_reassert())
+    assert p._controller is new_ctrl
+    assert any(c[0] == "zones" for c in new_ctrl.calls)
+
+
+def test_reassert_reapplies_static_mode(main_module, monkeypatch):
+    # Static mode (solid): a single write can be lost to a late default, so re-assert.
+    monkeypatch.setattr(main_module, "ACQUIRE_INTERVAL", 0.001)
+    monkeypatch.setattr(main_module, "REASSERT_DELAY", 0.001)
+    p = _plugin(main_module, "solid", hw=False, per_zone=True)
+    asyncio.run(p._acquire_and_reassert())
+    assert any(e[0] == "static" for e in p._engine.events)
+
+
+def test_reassert_does_not_restart_running_effect(main_module, monkeypatch):
+    # No-regression: in a render-loop mode the engine already rewrites continuously, so
+    # the deferred re-assert must NOT reapply (which would restart the effect at frame 0)
+    # and must not rebuild/swap anything on a healthy machine.
+    monkeypatch.setattr(main_module, "ACQUIRE_INTERVAL", 0.001)
+    monkeypatch.setattr(main_module, "REASSERT_DELAY", 0.001)
+    monkeypatch.setattr(
+        main_module, "build_device",
+        lambda **k: (_ for _ in ()).throw(AssertionError("must not reprobe")),
+    )
+    p = _plugin(
+        main_module, "effect",
+        {"id": "breathing", "speed": 50, "use_gradient": True},
+        hw=False, per_zone=True,
+    )
+    engine = p._engine
+    ctrl = p._controller
+    asyncio.run(p._acquire_and_reassert())
+    assert p._engine is engine
+    assert p._controller is ctrl
+    assert not engine.events


### PR DESCRIPTION
## EN
Fixes LED config not surviving a full power-off → power-on, reported on the ROG Xbox Ally X in **ambient (ambilight)** mode.

**Root cause:** `Ambilight._run()` looked for the gamescope PipeWire source once; on a cold boot the user session/PipeWire/gamescope isn't ready when the (root) plugin loads, so it set `no_source` and ended the task forever. Nothing restarted capture, so the user had to re-select the mode.

**Changes:**
- `ambilight`: `_run()` is now a reconnect loop (retries every 3s) and recovers from both a missing-at-boot source and a mid-session drop. Shows the **last solid color as a fallback** when there is no source, instead of going dark.
- `ambilight`: `_find_node()` is now async so the retry loop never blocks the event loop.
- `main`/`led_device` (defensive, for static modes): re-probe a late-enumerating sysfs LED, re-assert the saved config shortly after load (skipped while a render loop is active), and log real diagnostics (`available`, `ledPath`, `lastError`).

**Validation:** 120 backend tests pass, ruff clean, frontend builds. Verified on-device: killing the capture process triggers an automatic reconnect ~3s later. A real cold boot showed `node not found; retrying` → `ambilight start` 3s later.

## ES
Arregla que la configuración de LEDs no sobrevivía a un apagado total y encendido, reportado en la ROG Xbox Ally X en modo **ambient (ambilight)**.

**Causa raíz:** `Ambilight._run()` buscaba la fuente de gamescope una sola vez; en un arranque en frío la sesión de usuario/PipeWire/gamescope no está lista cuando carga el plugin (root), así que ponía `no_source` y terminaba la tarea para siempre. Nada reiniciaba la captura, por lo que había que volver a seleccionar el modo.

**Cambios:**
- `ambilight`: `_run()` ahora es un bucle de reconexión (reintenta cada 3s) y se recupera tanto de una fuente ausente al arrancar como de una caída a mitad de sesión. Muestra el **último color sólido como respaldo** cuando no hay fuente, en vez de quedarse apagado.
- `ambilight`: `_find_node()` ahora es async para que el bucle de reintento no bloquee el bucle de eventos.
- `main`/`led_device` (defensivo, para modos estáticos): re-sondea un LED sysfs que enumera tarde, reafirma la configuración guardada poco después de cargar (se omite si hay un bucle de render activo) y registra diagnóstico real (`available`, `ledPath`, `lastError`).

**Validación:** 120 tests de backend en verde, ruff limpio, build de frontend correcto. Verificado en dispositivo: matar el proceso de captura provoca una reconexión automática ~3s después. Un arranque en frío real mostró `node not found; retrying` y `ambilight start` 3s después.
