### PR TITLE
feat: encender LEDs solo con el cargador conectado

### DIFF
--- a/main.py
+++ b/main.py
@@ -10,6 +10,7 @@ from device import build_device
 from settings_store import SettingsStore
 from effects import EffectEngine, interpolate_gradient
 from ambilight import Ambilight
+from power_supply import charger_online
 from saved_gradients import upsert_gradient, remove_gradient
 
 DEFAULTS = {
@@ -24,7 +25,12 @@ DEFAULTS = {
     "saved_gradients": [],
     "enabled_experiments": [],
     "power_led_off": False,
+    "charger_only": False,
 }
+
+# How often the background watcher samples the AC adapter to react to plug/unplug
+# while the menu is closed. A couple of sysfs reads every few seconds is negligible.
+CHARGER_POLL_INTERVAL = 3.0
 
 # Cold-boot LED acquisition: the Ally's RGB node hangs off a USB HID device that can
 # enumerate late, so /sys/class/leds/...:rgb may not exist yet when the plugin loads.
@@ -62,6 +68,7 @@ class Plugin:
         self._settings = self._store.load(DEFAULTS)
         self._settings["ambilight"] = {**DEFAULTS["ambilight"], **self._settings["ambilight"]}
         self._settings["effect"] = {**DEFAULTS["effect"], **self._settings["effect"]}
+        self._ac_online = charger_online()
         self._apply_power_led()
         self._ready = True
 
@@ -170,11 +177,19 @@ class Plugin:
             "ambilight": s["ambilight"],
             "savedGradients": self._serialized_saved(),
             "powerLedOff": s.get("power_led_off", False),
+            "chargerOnly": s.get("charger_only", False),
         }
 
     async def set_power(self, on: bool) -> None:
         self._init()
         self._settings["power"] = on
+        self._save_and_apply()
+
+    async def set_charger_only(self, on: bool) -> None:
+        self._init()
+        self._settings["charger_only"] = on
+        if on:
+            self._ac_online = charger_online()
         self._save_and_apply()
 
     async def set_brightness(self, value: int) -> None:
@@ -257,9 +272,19 @@ class Plugin:
         self._settings["enabled_experiments"] = sorted(enabled)
         self._store.save(self._settings)
 
+    def _effective_power(self) -> bool:
+        # The manual power switch is the master. "Charger only" is a modifier on top:
+        # when on and running on battery, the LEDs are gated off WITHOUT touching the
+        # user's mode/effect/color — flipping back on at the wall restores it exactly.
+        if not self._settings["power"]:
+            return False
+        if self._settings.get("charger_only", False):
+            return bool(getattr(self, "_ac_online", True))
+        return True
+
     def _render(self, zone_colors) -> None:
         self._controller.apply_zones(
-            zone_colors, self._settings["brightness"], self._settings["power"]
+            zone_colors, self._settings["brightness"], self._effective_power()
         )
 
     def _save_and_apply(self) -> None:
@@ -307,7 +332,7 @@ class Plugin:
         self._ambilight.stop()
         self._engine.stop()
         brightness = s["brightness"]
-        power = s["power"]
+        power = self._effective_power()
         if not power:
             self._controller.apply_solid((0, 0, 0), 0, False)
             return
@@ -325,7 +350,7 @@ class Plugin:
 
     def _apply_per_zone(self) -> None:
         s = self._settings
-        if not s["power"]:
+        if not self._effective_power():
             self._ambilight.stop()
             self._engine.set_static([(0, 0, 0)] * self._zones)
             return
@@ -385,11 +410,31 @@ class Plugin:
         )
         self._apply()
         self._reassert_task = asyncio.create_task(self._acquire_and_reassert())
+        self._charger_task = asyncio.create_task(self._charger_watch())
+
+    async def _charger_watch(self) -> None:
+        # React to plug/unplug live, even with the menu closed. Reapply ONLY on the
+        # edge (state actually changed), never every tick — so a running effect is
+        # not restarted at frame 0. The "charger only" gate is read inside
+        # _effective_power, so this stays a cheap no-op when the feature is off.
+        try:
+            while True:
+                await asyncio.sleep(CHARGER_POLL_INTERVAL)
+                online = charger_online()
+                if online != getattr(self, "_ac_online", True):
+                    self._ac_online = online
+                    if self._settings.get("charger_only", False):
+                        self._apply()
+        except asyncio.CancelledError:
+            raise
+        except Exception as error:  # a sysfs hiccup must never kill the plugin
+            decky.logger.warning("Colores: charger watch failed: %s", error)
 
     async def _unload(self):
-        task = getattr(self, "_reassert_task", None)
-        if task:
-            task.cancel()
+        for attr in ("_reassert_task", "_charger_task"):
+            task = getattr(self, attr, None)
+            if task:
+                task.cancel()
         if getattr(self, "_ambilight", None):
             self._ambilight.stop()
         if getattr(self, "_engine", None):

--- a/py_modules/power_supply.py
+++ b/py_modules/power_supply.py
@@ -1,0 +1,35 @@
+import os
+
+POWER_SUPPLY_ROOT = "/sys/class/power_supply"
+_ADAPTER_TYPES = ("Mains", "USB")
+
+
+def _read(path):
+    try:
+        with open(path, "r") as handle:
+            return handle.read().strip()
+    except OSError:
+        return None
+
+
+def charger_online(root=POWER_SUPPLY_ROOT):
+    # Universal across handhelds: the AC/USB adapter exposes `online` (1 = plugged)
+    # in the standard Linux power_supply class, independent of the LED driver. If
+    # nothing can be read (no adapter node, permission error), assume plugged so the
+    # gate never strands a device with its LEDs dark by mistake.
+    try:
+        entries = os.listdir(root)
+    except OSError:
+        return True
+    saw_adapter = False
+    for name in entries:
+        supply = os.path.join(root, name)
+        if _read(os.path.join(supply, "type")) not in _ADAPTER_TYPES:
+            continue
+        online = _read(os.path.join(supply, "online"))
+        if online is None:
+            continue
+        if online == "1":
+            return True
+        saw_adapter = True
+    return not saw_adapter

--- a/src/api.ts
+++ b/src/api.ts
@@ -3,6 +3,7 @@ import { ColoresState, GradientPreset } from "./types";
 
 export const getState = callable<[], ColoresState>("get_state");
 export const setPower = callable<[on: boolean], void>("set_power");
+export const setChargerOnly = callable<[on: boolean], void>("set_charger_only");
 export const setBrightness = callable<[value: number], void>("set_brightness");
 export const setMode = callable<[mode: string], void>("set_mode");
 export const setSolid = callable<[r: number, g: number, b: number], void>("set_solid");

--- a/src/i18n/index.tsx
+++ b/src/i18n/index.tsx
@@ -15,6 +15,8 @@ const es: Record<string, string> = {
   "device.preview.ambient": "Siguiendo la pantalla",
 
   "power.label": "Encendido",
+  "chargerOnly.label": "Solo con cargador",
+  "chargerOnly.hint": "Las luces se encienden solo cuando el cargador está conectado.",
   "reconnect.label": "Reconectar mandos",
   "reconnect.hint": "¿Las luces no responden tras suspender? Reinicia la conexión con los mandos.",
 
@@ -116,6 +118,8 @@ const en: Record<string, string> = {
   "device.preview.ambient": "Reacting to screen",
 
   "power.label": "Power",
+  "chargerOnly.label": "Only while charging",
+  "chargerOnly.hint": "The lights turn on only when the charger is connected.",
   "reconnect.label": "Reconnect controllers",
   "reconnect.hint": "Lights not responding after sleep? Restart the connection to the controllers.",
 

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -207,6 +207,7 @@ function Content() {
     retry,
     setBrightness,
     setPower,
+    setChargerOnly,
     setMode,
     setColor,
     setGradient,
@@ -287,6 +288,7 @@ function Content() {
     device,
     savedGradients,
     powerLedOff,
+    chargerOnly,
   } = state;
   const hasLeds = caps.color || caps.brightness;
 
@@ -365,7 +367,17 @@ function Content() {
           </PanelSectionRow>
 
           <PanelSectionRow>
-            <ToggleField label={t("power.label")} checked={power} onChange={setPower} bottomSeparator="thick" />
+            <ToggleField label={t("power.label")} checked={power} onChange={setPower} bottomSeparator="none" />
+          </PanelSectionRow>
+          <PanelSectionRow>
+            <ToggleField
+              label={t("chargerOnly.label")}
+              description={t("chargerOnly.hint")}
+              checked={chargerOnly}
+              onChange={setChargerOnly}
+              disabled={!power}
+              bottomSeparator="thick"
+            />
           </PanelSectionRow>
 
           {caps.color && (

--- a/src/types.ts
+++ b/src/types.ts
@@ -65,6 +65,7 @@ export interface ColoresState {
   ambilight: AmbilightState;
   savedGradients: GradientPreset[];
   powerLedOff: boolean;
+  chargerOnly: boolean;
 }
 
 export interface GradientPreset {

--- a/src/useColores.ts
+++ b/src/useColores.ts
@@ -78,6 +78,13 @@ export function useColores() {
     api.setPower(power);
   };
 
+  const setChargerOnly = (chargerOnly: boolean) => {
+    setState((s) => (s ? { ...s, chargerOnly } : s));
+    api.setChargerOnly(chargerOnly).catch((e) =>
+      console.error("Colores: setChargerOnly failed", e),
+    );
+  };
+
   const setMode = (mode: Mode) => {
     setState((s) => (s ? { ...s, mode } : s));
     api.setMode(mode);
@@ -157,6 +164,7 @@ export function useColores() {
     retry: refreshState,
     setBrightness,
     setPower,
+    setChargerOnly,
     setMode,
     setColor,
     setGradient,

--- a/tests/test_main_routing.py
+++ b/tests/test_main_routing.py
@@ -120,6 +120,66 @@ def _plugin(
     return p
 
 
+@pytest.mark.parametrize(
+    "power,charger_only,ac_online,expected",
+    [
+        (False, False, True, False),
+        (False, True, True, False),
+        (True, False, False, True),
+        (True, True, True, True),
+        (True, True, False, False),
+    ],
+)
+def test_effective_power_truth_table(main_module, power, charger_only, ac_online, expected):
+    p = _plugin(main_module, "solid", power=power)
+    p._settings["charger_only"] = charger_only
+    p._ac_online = ac_online
+    assert p._effective_power() is expected
+
+
+def test_charger_only_on_battery_gates_per_zone_off(main_module):
+    # Charger-only active + on battery: the per-zone path writes black WITHOUT
+    # changing the stored mode/color (it's a gate, not a config change).
+    p = _plugin(main_module, "solid", hw=False, per_zone=True)
+    p._settings["charger_only"] = True
+    p._ac_online = False
+    p._apply()
+    assert ("static", [(0, 0, 0)] * p._zones) in p._engine.events
+    assert p._settings["mode"] == "solid"
+
+
+def test_charger_only_plugged_in_renders_normally(main_module):
+    p = _plugin(main_module, "solid", hw=False, per_zone=True)
+    p._settings["charger_only"] = True
+    p._ac_online = True
+    p._apply()
+    assert ("static", [(255, 0, 0)] * p._zones) in p._engine.events
+
+
+def test_charger_watch_reapplies_only_on_edge(main_module, monkeypatch):
+    # The watcher must reapply when the plug state flips (and the gate is on), and
+    # must NOT touch anything when the feature is off.
+    monkeypatch.setattr(main_module, "CHARGER_POLL_INTERVAL", 0.001)
+    p = _plugin(main_module, "solid", hw=False, per_zone=True)
+    p._settings["charger_only"] = True
+    p._ac_online = True
+    states = iter([False, False, True])
+    monkeypatch.setattr(main_module, "charger_online", lambda: next(states, True))
+
+    async def drive():
+        task = asyncio.create_task(p._charger_watch())
+        await asyncio.sleep(0.02)
+        task.cancel()
+        try:
+            await task
+        except asyncio.CancelledError:
+            pass
+
+    asyncio.run(drive())
+    assert p._ac_online is True
+    assert any(e[0] == "static" for e in p._engine.events)
+
+
 def test_wave_on_single_color_device_uses_hardware_effect(main_module):
     # Legion Go S-like: hardware effects, single-color zones, no per-controller.
     # Wave must use the native firmware effect (a single solid color), not the

--- a/tests/test_power_supply.py
+++ b/tests/test_power_supply.py
@@ -1,0 +1,52 @@
+import os
+
+from py_modules.power_supply import charger_online
+
+
+def _supply(root, name, kind, online=None):
+    path = os.path.join(root, name)
+    os.makedirs(path)
+    with open(os.path.join(path, "type"), "w") as handle:
+        handle.write(kind + "\n")
+    if online is not None:
+        with open(os.path.join(path, "online"), "w") as handle:
+            handle.write(online + "\n")
+
+
+def test_plugged_in_when_mains_online(tmp_path):
+    root = str(tmp_path)
+    _supply(root, "BAT0", "Battery")
+    _supply(root, "ADP0", "Mains", "1")
+    assert charger_online(root) is True
+
+
+def test_on_battery_when_mains_offline(tmp_path):
+    root = str(tmp_path)
+    _supply(root, "BAT0", "Battery")
+    _supply(root, "ADP0", "Mains", "0")
+    assert charger_online(root) is False
+
+
+def test_usb_pd_adapter_counts_as_charger(tmp_path):
+    root = str(tmp_path)
+    _supply(root, "ucsi-source", "USB", "1")
+    assert charger_online(root) is True
+
+
+def test_any_adapter_online_wins(tmp_path):
+    root = str(tmp_path)
+    _supply(root, "ADP0", "Mains", "0")
+    _supply(root, "ucsi-source", "USB", "1")
+    assert charger_online(root) is True
+
+
+def test_battery_only_node_is_ignored(tmp_path):
+    # A device that reports only a battery (no adapter node) must assume plugged,
+    # never strand its LEDs off.
+    root = str(tmp_path)
+    _supply(root, "BAT0", "Battery")
+    assert charger_online(root) is True
+
+
+def test_missing_root_assumes_plugged(tmp_path):
+    assert charger_online(os.path.join(str(tmp_path), "nope")) is True


### PR DESCRIPTION
## Qué hace
Añade una casilla **"Solo con cargador"** bajo el interruptor de Encendido. Cuando está activa, los LEDs se encienden solo mientras el cargador está conectado y se apagan en modo batería, **sin perder** el modo/efecto/color configurado (es una compuerta, no un cambio de config: al enchufar restaura exactamente lo que tenías).

El interruptor de Encendido manual sigue mandando: la casilla queda deshabilitada cuando apagas el encendido, conservando tu preferencia.

## Cómo funciona (y por qué va en todas las máquinas)
- El estado del cargador se lee de `/sys/class/power_supply/*/online`, la interfaz estándar de Linux, **independiente del driver de LED** → cero código por dispositivo.
- Adaptadores emparejados por `type` (`Mains`/`USB`), no por nombre de nodo (es `AC0` en la Ally y `ACAD` en las Legion Go; el cargador USB-C PD aparece bajo nodos `USB`). Si no se puede leer nada, asume "enchufado" para no dejar nunca los LEDs apagados por error.
- Un único seam `_effective_power() = power AND (not charger_only OR ac_online)` gobierna los tres caminos de escritura al hardware.
- `_charger_watch` (asyncio, sondeo cada 3 s) reacciona a enchufar/desenchufar en vivo, reaplicando solo en el flanco.

## Pruebas
- 134 tests backend en verde (tabla de verdad del power efectivo, gating en batería, watcher solo en flanco, detección con sysfs falso).
- `tsc --noEmit` limpio, `pnpm build` OK.
- Verificado en hardware real: ROG Xbox Ally X, Legion Go 1 y Legion Go 2 (detección correcta a batería/enchufado pese a nodos con distinto nombre).

## Nota
Queda un detalle cosmético menor pendiente (seguimiento aparte): la vista previa en pantalla usa el `power` crudo, así que muestra los anillos encendidos aunque estén apagados por batería con la función activa.