### PR TITLE
fix: recupera los LEDs del ROG Ally/Ally X sin nodo sysfs vía HID | recover ROG Ally/Ally X LEDs with no sysfs node via HID

### DIFF
--- a/py_modules/asus_ally_hid.py
+++ b/py_modules/asus_ally_hid.py
@@ -1,4 +1,5 @@
-# Aura RGB protocol for the ASUS ROG Ally "N-KEY Device" (VID 0x0B05, PID 0x1ABE).
+# Aura RGB protocol for the ASUS ROG Ally line "N-KEY Device" (VID 0x0B05, Aura usage
+# page 0xFF31 / usage 0x0080; PID varies: 0x1ABE original Ally, others on Ally X/Xbox Ally).
 # The byte layout is an interface fact of the device, documented by asusctl/HHD; this
 # is an original implementation (no third-party code copied). Report ids: 0x5D for RGB
 # commands, 0x5A for brightness. All output reports are 64 bytes.
@@ -108,7 +109,7 @@ class AsusAllyTransport:
         for device in hid.enumerate():
             if device["vendor_id"] not in self._vid:
                 continue
-            if device["product_id"] not in self._pid:
+            if self._pid and device["product_id"] not in self._pid:
                 continue
             if device["usage_page"] in self._usage_page and device["usage"] in self._usage:
                 self.hid_device = hid.Device(path=device["path"])

--- a/py_modules/device.py
+++ b/py_modules/device.py
@@ -235,6 +235,18 @@ def build_device(sysfs_root="/", ambilight=False):
         )
         has_led = True
     else:
+        fallback = profile.get("fallback")
+        if fallback and HID_AVAILABLE and fallback.get("driver") in HID_DRIVERS:
+            fb_profile = dict(fallback)
+            fb_profile["name"] = profile["name"]
+            hid_ctx = _build_hid_context(fb_profile, ambilight, power_led, battery)
+            if hid_ctx is not None:
+                return {
+                    "info": info,
+                    "capabilities": hid_ctx["capabilities"],
+                    "device": hid_ctx["device"],
+                    "power_led": power_led,
+                }
         zones, max_brightness, device, has_led = 0, 255, NullDevice(), False
 
     if profile["driver"] not in _IMPLEMENTED_DRIVERS:

--- a/py_modules/device_profiles.py
+++ b/py_modules/device_profiles.py
@@ -65,6 +65,10 @@ GENERIC = {
     "experimental": ["color", "brightness", "effects", "ambilight"],
 }
 
+# The sysfs RGB node isn't guaranteed on every kernel/Bazzite build for the Ally line.
+# When it's missing, build_device drops to the Aura HID driver instead of "no LEDs".
+ASUS_SYSFS["fallback"] = ASUS_ALLY_HID
+
 
 def _copy_bits(bits):
     return [dict(bit) for bit in bits]
@@ -75,6 +79,8 @@ def _copy_profile(base):
     merged["experimental"] = list(base.get("experimental", []))
     if base.get("power_led"):
         merged["power_led"] = _copy_bits(base["power_led"])
+    if base.get("fallback"):
+        merged["fallback"] = _copy_profile(base["fallback"])
     return merged
 
 

--- a/py_modules/hid_adapters.py
+++ b/py_modules/hid_adapters.py
@@ -69,9 +69,12 @@ LEGION_GO_S_IDS = {
     "interface": 3,
 }
 
+# Match the Aura N-KEY interface by VID + usage only. The original Ally is PID 0x1ABE,
+# but the Ally X / Xbox Ally enumerate the same interface under different PIDs; an empty
+# pid list means "any PID", so one driver covers the whole ROG Ally line.
 ASUS_ALLY_IDS = {
     "vid": [0x0B05],
-    "pid": [0x1ABE],
+    "pid": [],
     "usage_page": [0xFF31],
     "usage": [0x0080],
 }

--- a/tests/test_device_profiles.py
+++ b/tests/test_device_profiles.py
@@ -75,6 +75,30 @@ def test_legion_keeps_spiral_effect():  # regression guard for the Legion-only s
         assert "spiral" in resolve_profile("", product)["supported_effects"]
 
 
+def test_asus_sysfs_profiles_expose_aura_hid_fallback():
+    # When the kernel sysfs RGB node is missing (varies by kernel/Bazzite version),
+    # build_device drops to this Aura HID driver instead of showing "no LEDs".
+    for board in ("RC72LA", "RC73XA", "RC73YA"):
+        p = resolve_profile(board, "whatever")
+        fb = p["fallback"]
+        assert fb["driver"] == "hid_asus_ally"
+        assert fb["conflicts_with_system_rgb"] is True
+        # spiral renders as the Legion-only "Espiral GO" under hardwareEffects — keep it out.
+        assert "spiral" not in fb["supported_effects"]
+
+
+def test_asus_fallback_is_private_copy():
+    first = resolve_profile("RC72LA", "x")
+    first["fallback"]["experimental"].append("mutated")
+    second = resolve_profile("RC72LA", "x")
+    assert "mutated" not in second["fallback"]["experimental"]
+
+
+def test_generic_and_hid_profiles_have_no_asus_fallback():
+    assert "fallback" not in resolve_profile("X", "MysteryHandheld")
+    assert "fallback" not in resolve_profile("RC71L", "ROG Ally RC71L_RC71L")
+
+
 def test_ally_x_stays_sysfs_not_hid():  # regression guard: do NOT touch Ally X
     for board in ("RC72LA", "RC73XA", "RC73YA"):
         p = resolve_profile(board, "whatever")

--- a/tests/test_hid_adapters.py
+++ b/tests/test_hid_adapters.py
@@ -394,9 +394,106 @@ def _ally_entry():
     }
 
 
+def _ally_x_entry():
+    # Ally X / Xbox Ally enumerate the same Aura N-KEY interface under a DIFFERENT PID
+    # than the original Ally (0x1ABE). We match by VID + usage, so the PID is irrelevant.
+    return {
+        "vendor_id": 0x0B05,
+        "product_id": 0x1B4C,
+        "usage_page": 0xFF31,
+        "usage": 0x0080,
+        "interface_number": 0,
+        "path": b"allyx",
+    }
+
+
 def test_ally_hid_registered(hid_env):
     adapters, _ = hid_env
     assert "hid_asus_ally" in adapters.HID_DRIVERS
+
+
+def test_ally_matches_by_vid_and_usage_ignoring_pid(hid_env):
+    adapters, _ = hid_env
+    sys.modules["lib_hid"].enumerate = lambda vid=0, pid=0: [_ally_x_entry()]
+    dev = adapters.AsusAllyHidDevice.create()
+    assert dev.available is True
+
+
+def test_ally_ignores_foreign_vid_even_with_matching_usage(hid_env):
+    adapters, _ = hid_env
+    foreign = dict(_ally_x_entry(), vendor_id=0x1234)
+    sys.modules["lib_hid"].enumerate = lambda vid=0, pid=0: [foreign]
+    dev = adapters.AsusAllyHidDevice.create()
+    assert dev.available is False
+
+
+def _make_ally_x_root(tmp_path, with_empty_leds=True):
+    import os
+
+    dmi = os.path.join(str(tmp_path), "sys/class/dmi/id")
+    os.makedirs(dmi)
+    with open(os.path.join(dmi, "board_name"), "w") as handle:
+        handle.write("RC72LA")
+    with open(os.path.join(dmi, "product_name"), "w") as handle:
+        handle.write("ROG Ally X RC72LA")
+    if with_empty_leds:
+        os.makedirs(os.path.join(str(tmp_path), "sys/class/leds"))
+    return str(tmp_path)
+
+
+def test_build_device_ally_x_falls_back_to_hid_without_sysfs(hid_env, tmp_path):
+    adapters, _ = hid_env
+    sys.modules["lib_hid"].enumerate = lambda vid=0, pid=0: [_ally_x_entry()]
+    device = _reload_device()
+    root = _make_ally_x_root(tmp_path)
+    ctx = device.build_device(sysfs_root=root, ambilight=False)
+    assert isinstance(ctx["device"], adapters.AsusAllyHidDevice)
+    caps = ctx["capabilities"]
+    assert caps["color"] is True
+    assert caps["hardwareEffects"] is True
+    assert caps["reconnectable"] is True
+    assert caps["conflictsWithSystemRgb"] is True
+    assert "spiral" not in caps["supportedEffects"]
+    assert ctx["info"]["name"] == "ROG Ally X"
+    sys.modules.pop("device", None)
+
+
+def test_build_device_ally_x_prefers_sysfs_when_node_present(hid_env, tmp_path):
+    import os
+
+    adapters, _ = hid_env
+    sys.modules["lib_hid"].enumerate = lambda vid=0, pid=0: [_ally_x_entry()]
+    device = _reload_device()
+    root = _make_ally_x_root(tmp_path, with_empty_leds=False)
+    led = os.path.join(root, "sys/class/leds", "ally:rgb:joystick_rings")
+    os.makedirs(led)
+    for name, content in {
+        "multi_intensity": "0 0 0 0",
+        "multi_index": "rgb rgb rgb rgb",
+        "max_brightness": "255",
+        "brightness": "0",
+    }.items():
+        with open(os.path.join(led, name), "w") as handle:
+            handle.write(content)
+    ctx = device.build_device(sysfs_root=root, ambilight=False)
+    from led_device import SysfsRgbDevice
+
+    assert isinstance(ctx["device"], SysfsRgbDevice)
+    assert ctx["capabilities"]["conflictsWithSystemRgb"] is False
+    sys.modules.pop("device", None)
+
+
+def test_build_device_ally_x_null_when_no_sysfs_and_no_hid(hid_env, tmp_path):
+    adapters, _ = hid_env
+    sys.modules["lib_hid"].enumerate = lambda vid=0, pid=0: []  # HID device absent too
+    device = _reload_device()
+    root = _make_ally_x_root(tmp_path)
+    ctx = device.build_device(sysfs_root=root, ambilight=False)
+    from led_device import NullDevice
+
+    assert isinstance(ctx["device"], NullDevice)
+    assert ctx["capabilities"]["color"] is False
+    sys.modules.pop("device", None)
 
 
 def test_ally_first_solid_sends_init_and_apply(hid_env):


### PR DESCRIPTION
## ES
Algunos ROG Ally X (y algún Ally) no muestran LEDs porque su kernel/Bazzite no crea el nodo sysfs `/sys/class/leds/*` con `multi_intensity`, y el perfil sysfs no tenía plan B. Ahora, si no hay nodo sysfs, el plugin habla con los LEDs por HID (interfaz Aura), igual que el Ally original.

- Match de la interfaz Aura por VID + usage (0xFF31/0x0080), ignorando el PID (Ally 0x1ABE, Ally X 0x1B4C).
- `fallback` de los perfiles ASUS sysfs al driver `hid_asus_ally`.
- Verificado en hardware: el protocolo Aura enciende los 4 anillos del Ally X por HID (per-zona incluido), incluso con el driver de kernel enganchado.

## EN
Some ROG Ally X (and some Ally) units show no LEDs because their kernel/Bazzite build doesn't create the `/sys/class/leds/*` `multi_intensity` node, and the sysfs profile had no fallback. Now, when there's no sysfs node, the plugin drives the LEDs over HID (Aura interface), like the original Ally.

- Match the Aura interface by VID + usage (0xFF31/0x0080), ignoring the PID.
- Add a `fallback` from the ASUS sysfs profiles to the `hid_asus_ally` driver.
- Hardware-verified: the Aura protocol lights all 4 Ally X rings over HID (per-zone included), even with the kernel driver bound.

Tests: 195 passing (8 new).