### PR TITLE
docs: add support/status badges and the video thumbnail to the README header

### DIFF
--- a/README.en.md
+++ b/README.en.md
@@ -4,9 +4,26 @@ RGB lighting control for handheld PCs, as a [Decky Loader](https://github.com/St
 
 [Español](README.md) · English
 
+<p align="center">
+  <a href="https://ko-fi.com/hooandee"><img src="https://img.shields.io/badge/Ko--fi-Buy%20me%20a%20coffee-FF5E5B?style=for-the-badge&logo=ko-fi&logoColor=white" alt="Ko-fi"></a>
+  <a href="https://www.patreon.com/hooandee"><img src="https://img.shields.io/badge/Patreon-Support%20me-FF424D?style=for-the-badge&logo=patreon&logoColor=white" alt="Patreon"></a>
+  <a href="https://www.youtube.com/channel/UCDsSJByXklp6xc_WwQJI7Lw/join"><img src="https://img.shields.io/badge/YouTube-Become%20a%20member-FF0000?style=for-the-badge&logo=youtube&logoColor=white" alt="YouTube"></a>
+  <a href="https://discord.gg/x2ZNARy"><img src="https://img.shields.io/badge/Discord-Join-5865F2?style=for-the-badge&logo=discord&logoColor=white" alt="Discord"></a>
+  <a href="https://linktr.ee/hooandee"><img src="https://img.shields.io/badge/All%20my%20links-Linktree-43E660?style=for-the-badge&logo=linktree&logoColor=white" alt="Linktree"></a>
+</p>
+
+<p align="center">
+  <a href="https://github.com/Hooandee/decky-colores/actions/workflows/ci.yml"><img src="https://github.com/Hooandee/decky-colores/actions/workflows/ci.yml/badge.svg" alt="CI status"></a>
+  <a href="https://github.com/Hooandee/decky-colores/releases/latest"><img src="https://img.shields.io/github/v/release/Hooandee/decky-colores?label=latest%20release&color=blue" alt="Latest release"></a>
+</p>
+
 Colores detects your handheld at startup and shows you only what your machine can actually do. No config, no editing files, no picking your model from a list. Open it from the quick access menu and you're set.
 
-https://youtu.be/ug5Nh0YtadE
+## Video
+
+In this video I show and explain the plugin in depth:
+
+[![Colores in action](https://img.youtube.com/vi/ug5Nh0YtadE/maxresdefault.jpg)](https://youtu.be/ug5Nh0YtadE)
 
 ## Supported devices
 

--- a/README.md
+++ b/README.md
@@ -4,9 +4,26 @@ Control de luces RGB para PCs portátiles, como plugin de [Decky Loader](https:/
 
 Español · [English](README.en.md)
 
+<p align="center">
+  <a href="https://ko-fi.com/hooandee"><img src="https://img.shields.io/badge/Ko--fi-Inv%C3%ADtame%20un%20caf%C3%A9-FF5E5B?style=for-the-badge&logo=ko-fi&logoColor=white" alt="Ko-fi"></a>
+  <a href="https://www.patreon.com/hooandee"><img src="https://img.shields.io/badge/Patreon-Ap%C3%B3yame-FF424D?style=for-the-badge&logo=patreon&logoColor=white" alt="Patreon"></a>
+  <a href="https://www.youtube.com/channel/UCDsSJByXklp6xc_WwQJI7Lw/join"><img src="https://img.shields.io/badge/YouTube-Hazte%20miembro-FF0000?style=for-the-badge&logo=youtube&logoColor=white" alt="YouTube"></a>
+  <a href="https://discord.gg/x2ZNARy"><img src="https://img.shields.io/badge/Discord-%C3%9Anete-5865F2?style=for-the-badge&logo=discord&logoColor=white" alt="Discord"></a>
+  <a href="https://linktr.ee/hooandee"><img src="https://img.shields.io/badge/Todos%20mis%20enlaces-Linktree-43E660?style=for-the-badge&logo=linktree&logoColor=white" alt="Linktree"></a>
+</p>
+
+<p align="center">
+  <a href="https://github.com/Hooandee/decky-colores/actions/workflows/ci.yml"><img src="https://github.com/Hooandee/decky-colores/actions/workflows/ci.yml/badge.svg" alt="Estado del CI"></a>
+  <a href="https://github.com/Hooandee/decky-colores/releases/latest"><img src="https://img.shields.io/github/v/release/Hooandee/decky-colores?label=%C3%BAltima%20versi%C3%B3n&color=blue" alt="Última versión"></a>
+</p>
+
 Colores detecta tu consola al arrancar y te muestra solo lo que tu máquina puede hacer de verdad. Sin configuración, sin tocar archivos, sin elegir tu modelo en una lista. Lo abres desde el menú de acceso rápido y ya está.
 
-https://youtu.be/ug5Nh0YtadE
+## Vídeo
+
+En este vídeo enseño y explico el plugin a fondo:
+
+[![Colores en acción](https://img.youtube.com/vi/ug5Nh0YtadE/maxresdefault.jpg)](https://youtu.be/ug5Nh0YtadE)
 
 ## Dispositivos compatibles
 


### PR DESCRIPTION
Igual que en Panel de Control. En la cabecera de ambos README, bajo el selector de idioma:

- **Apoyo:** Ko-fi, Patreon, YouTube (hazte miembro), Discord y Linktree, con logo y color de marca.
- **Estado:** badge del CI en vivo y de la última versión (lee la release más reciente de GitHub).
- **Vídeo:** el enlace pelado de YouTube pasa a una miniatura con botón de play (igual que en Panel de Control), en su propia sección.

ES y EN en sync.

---

Same as in Panel de Control. In both READMEs' header, below the language switcher:

- **Support:** Ko-fi, Patreon, YouTube (become a member), Discord and Linktree, with brand logos and colors.
- **Status:** live CI badge and latest-release badge (reads the most recent GitHub release).
- **Video:** the bare YouTube link becomes a clickable thumbnail with a play button (like in Panel de Control), in its own section.

ES and EN stay in sync.