### PR TITLE
feat: modo Temperatura en la pestaña Sensores | Temperature mode under a Sensors tab

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ __pycache__/
 .ruff_cache/
 *.zip
 *.tar.gz
+.superpowers/

--- a/main.py
+++ b/main.py
@@ -12,6 +12,7 @@ from settings_store import SettingsStore
 from effects import EffectEngine, interpolate_gradient
 from ambilight import Ambilight
 from power_supply import charger_online, battery_level
+from thermal import apu_temperature
 from saved_gradients import upsert_gradient, remove_gradient
 import self_updater
 from report import collector as report_collector
@@ -37,6 +38,7 @@ DEFAULTS = {
     "charger_only": False,
     "force_control": False,
     "battery_breathe": True,
+    "temperature_breathe": True,
 }
 
 # How often the background watcher samples the AC adapter to react to plug/unplug
@@ -87,6 +89,7 @@ class Plugin:
         self._ac_online = charger_online()
         level = battery_level()
         self._battery_level = 100 if level is None else level
+        self._apu_temp = apu_temperature()
         self._apply_power_led()
         self._ready = True
 
@@ -351,6 +354,8 @@ class Plugin:
             "forceControl": s.get("force_control", False),
             "batteryBreathe": s.get("battery_breathe", True),
             "batteryLevel": getattr(self, "_battery_level", 100),
+            "temperatureBreathe": s.get("temperature_breathe", True),
+            "temperature": getattr(self, "_apu_temp", None),
         }
 
     async def set_power(self, on: bool) -> None:
@@ -379,6 +384,15 @@ class Plugin:
         # The battery loop reads this live via _battery_state, so persisting is
         # enough; no restart needed. Re-apply is a cheap no-op unless idle.
         self._save_and_apply()
+
+    async def set_temperature_breathe(self, on: bool) -> None:
+        self._init()
+        self._settings["temperature_breathe"] = on
+        self._save_and_apply()
+
+    async def get_temperature(self):
+        self._init()
+        return getattr(self, "_apu_temp", None)
 
     async def set_brightness(self, value: int) -> None:
         self._init()
@@ -480,6 +494,12 @@ class Plugin:
             "breathe": self._settings.get("battery_breathe", True),
         }
 
+    def _temperature_state(self) -> dict:
+        return {
+            "temp": getattr(self, "_apu_temp", None),
+            "breathe": self._settings.get("temperature_breathe", True),
+        }
+
     def _render(self, zone_colors) -> None:
         self._controller.apply_zones(
             zone_colors, self._settings["brightness"], self._effective_power()
@@ -500,7 +520,7 @@ class Plugin:
         # (per-zone or per-controller). Single-color devices render wave with
         # their native hardware effect instead of collapsing it to a flat color.
         s = self._settings
-        if s["mode"] in ("ambient", "battery"):
+        if s["mode"] in ("ambient", "battery", "temperature"):
             return True
         if s["mode"] == "gradient":
             return not self._controller.supports_per_zone()
@@ -570,6 +590,8 @@ class Plugin:
 
         if s["mode"] == "battery":
             self._engine.start_battery(self._battery_state)
+        elif s["mode"] == "temperature":
+            self._engine.start_temperature(self._temperature_state)
         elif s["mode"] == "effect":
             effect = s["effect"]
             self._engine.start_effect(
@@ -627,6 +649,9 @@ class Plugin:
                 level = battery_level()
                 if level is not None:
                     self._battery_level = level
+                temp = apu_temperature()
+                if temp is not None:
+                    self._apu_temp = temp
                 online = charger_online()
                 if online != getattr(self, "_ac_online", True):
                     self._ac_online = online

--- a/py_modules/device.py
+++ b/py_modules/device.py
@@ -5,6 +5,7 @@ from led_device import SysfsRgbDevice, NullDevice
 from hid_adapters import HID_AVAILABLE, HID_DRIVERS, build_hid_device
 from power_led import PowerLedController
 from power_supply import battery_present
+from thermal import temperature_available
 
 DEVICE_REGISTRY = [
     ("board", "Jupiter", "Steam Deck"),
@@ -136,7 +137,7 @@ def _feature_state(profile, feature, present):
     return "supported" if present else "unsupported"
 
 
-def build_capabilities(profile, has_led, zones, max_brightness, ambilight, power_led=None, battery=False):
+def build_capabilities(profile, has_led, zones, max_brightness, ambilight, power_led=None, battery=False, temperature=False):
     present = {
         "color": has_led,
         "brightness": has_led,
@@ -162,6 +163,7 @@ def build_capabilities(profile, has_led, zones, max_brightness, ambilight, power
         "experimental": list(profile.get("experimental", [])),
         "powerLed": bool(power_led and power_led.available()),
         "batteryMode": bool(battery) and active["color"],
+        "temperatureMode": bool(temperature) and active["color"],
         "conflictsWithSystemRgb": bool(profile.get("conflicts_with_system_rgb", False)),
         "layout": build_layout(zones, profile.get("swap_sticks", False)),
     }
@@ -187,7 +189,7 @@ def _find_rgb_led(leds_dir):
 _IMPLEMENTED_DRIVERS = {"sysfs", "hid_msi", "hid_legion_tablet", "hid_legion_go_s", "hid_asus_ally"}
 
 
-def _build_hid_context(profile, ambilight, power_led=None, battery=False):
+def _build_hid_context(profile, ambilight, power_led=None, battery=False, temperature=False):
     device = build_hid_device(profile["driver"])
     if device is None or not device.available:
         return None
@@ -195,7 +197,7 @@ def _build_hid_context(profile, ambilight, power_led=None, battery=False):
     if correction and hasattr(device, "set_color_correction"):
         device.set_color_correction(correction)
     zones = profile.get("zones") or 1
-    capabilities = build_capabilities(profile, True, zones, 100, ambilight, power_led, battery)
+    capabilities = build_capabilities(profile, True, zones, 100, ambilight, power_led, battery, temperature)
     capabilities["perZone"] = device.supports_per_zone()
     capabilities["hardwareEffects"] = device.supports_hardware_effects()
     capabilities["reconnectable"] = True
@@ -208,10 +210,14 @@ def build_device(sysfs_root="/", ambilight=False):
     info["name"] = profile["name"]
     power_led = PowerLedController(profile.get("power_led"))
     battery = battery_present(os.path.join(sysfs_root, "sys/class/power_supply"))
+    temperature = temperature_available(
+        os.path.join(sysfs_root, "sys/class/hwmon"),
+        os.path.join(sysfs_root, "sys/class/thermal"),
+    )
 
     if profile["driver"] in HID_DRIVERS:
         if HID_AVAILABLE:
-            hid_ctx = _build_hid_context(profile, ambilight, power_led, battery)
+            hid_ctx = _build_hid_context(profile, ambilight, power_led, battery, temperature)
             if hid_ctx is not None:
                 return {
                     "info": info,
@@ -239,7 +245,7 @@ def build_device(sysfs_root="/", ambilight=False):
         if fallback and HID_AVAILABLE and fallback.get("driver") in HID_DRIVERS:
             fb_profile = dict(fallback)
             fb_profile["name"] = profile["name"]
-            hid_ctx = _build_hid_context(fb_profile, ambilight, power_led, battery)
+            hid_ctx = _build_hid_context(fb_profile, ambilight, power_led, battery, temperature)
             if hid_ctx is not None:
                 return {
                     "info": info,
@@ -252,7 +258,7 @@ def build_device(sysfs_root="/", ambilight=False):
     if profile["driver"] not in _IMPLEMENTED_DRIVERS:
         profile["experimental"] = _all_experimental(profile)
 
-    capabilities = build_capabilities(profile, has_led, zones, max_brightness, ambilight, power_led, battery)
+    capabilities = build_capabilities(profile, has_led, zones, max_brightness, ambilight, power_led, battery, temperature)
     return {
         "info": info,
         "capabilities": capabilities,

--- a/py_modules/effects.py
+++ b/py_modules/effects.py
@@ -6,10 +6,9 @@ logger = logging.getLogger("colores.effects")
 
 FRAME_INTERVAL = 1.0 / 30.0
 
-# Battery mode: fixed color bands by charge level (blue full -> red empty). All
-# zones show the same band color; it is a status indicator, not a spatial effect.
-# Each entry is (min_level_inclusive, rgb); scanned high to low. Keep in sync with
-# the frontend BATTERY_BANDS (src/palette.ts) used for the legend and preview.
+# Status-indicator color bands (battery %, APU temperature C). Each entry is
+# (min_value_inclusive, rgb), scanned high to low. Keep in sync with the frontend
+# copies in src/palette.ts (those drive the legend/preview; the LED render is here).
 BATTERY_BANDS = (
     (81, (0, 120, 255)),
     (61, (0, 200, 60)),
@@ -17,16 +16,19 @@ BATTERY_BANDS = (
     (21, (255, 110, 0)),
     (0, (255, 30, 20)),
 )
-# Per-frame easing factor toward the target band color: gives a smooth ~1.3s
-# crossfade when crossing a band boundary and makes the exact threshold jitter-free
-# (implicit hysteresis), so we never need explicit threshold bookkeeping.
-BATTERY_EASE = 0.12
-# Below this per-channel delta the color has settled: stop the 30fps loop and idle
-# on a coarse tick (still polling state) so a static indicator costs ~no CPU.
-BATTERY_CONVERGE_EPS = 1.0
-BATTERY_IDLE_INTERVAL = 0.5
-# Calm breathing while charging (~2s period), well below the effect breathing range.
-BATTERY_BREATHE_SPEED = 22
+TEMPERATURE_BANDS = (
+    (90, (255, 30, 20)),
+    (80, (255, 110, 0)),
+    (68, (255, 200, 0)),
+    (55, (0, 200, 60)),
+    (0, (0, 120, 255)),
+)
+TEMPERATURE_CRITICAL = 90
+
+INDICATOR_EASE = 0.12
+INDICATOR_CONVERGE_EPS = 1.0
+INDICATOR_IDLE_INTERVAL = 0.5
+INDICATOR_BREATHE_SPEED = 22
 
 
 def clamp8(x):
@@ -166,6 +168,13 @@ def battery_band_color(level):
     return BATTERY_BANDS[-1][1]
 
 
+def temperature_band_color(temp):
+    for threshold, color in TEMPERATURE_BANDS:
+        if temp >= threshold:
+            return color
+    return TEMPERATURE_BANDS[-1][1]
+
+
 class EffectEngine:
     def __init__(self, apply_zones, zones):
         self._apply_zones = apply_zones
@@ -192,17 +201,34 @@ class EffectEngine:
         self._task = loop.create_task(self._run(effect_id, speed, params))
 
     def start_battery(self, state_fn):
-        # state_fn() returns the LIVE {level, charging, breathe} each frame, so the
-        # loop reacts to charge/plug changes without a restart. Fixed signature: a
-        # re-apply (e.g. a brightness change) is a no-op while it runs, which keeps
-        # the easing/breathing from resetting.
-        sig = ("__battery__",)
+        self._start_indicator(
+            "__battery__",
+            state_fn,
+            lambda st: battery_band_color(st.get("level", 100)),
+            lambda st: bool(st.get("charging")) and bool(st.get("breathe")) and st.get("level", 100) < 100,
+            "battery",
+        )
+
+    def start_temperature(self, state_fn):
+        self._start_indicator(
+            "__temperature__",
+            state_fn,
+            lambda st: None if st.get("temp") is None else temperature_band_color(st["temp"]),
+            lambda st: bool(st.get("breathe")) and st.get("temp") is not None and st["temp"] >= TEMPERATURE_CRITICAL,
+            "temperature",
+        )
+
+    def _start_indicator(self, sig_key, state_fn, target_fn, breathe_fn, label):
+        # state_fn() returns the LIVE state each frame, so the loop reacts without a
+        # restart. Fixed per-mode signature: a re-apply (e.g. a brightness change) is
+        # a no-op while it runs, keeping the easing/breathing from resetting.
+        sig = (sig_key,)
         if self.running and sig == self._sig:
             return
         self.stop()
         self._sig = sig
         loop = asyncio.get_event_loop()
-        self._task = loop.create_task(self._run_battery(state_fn))
+        self._task = loop.create_task(self._run_indicator(state_fn, target_fn, breathe_fn, label))
 
     def stop(self):
         if self._task is not None:
@@ -229,37 +255,41 @@ class EffectEngine:
             return frame_gradient_sweep(params.get("stops", [(255, 255, 255)]), self._zones, t, speed)
         return [(0, 0, 0) for _ in range(self._zones)]
 
-    async def _run_battery(self, state_fn):
+    async def _run_indicator(self, state_fn, target_fn, breathe_fn, label):
+        # Shared render loop for the status indicators (battery %, APU temperature):
+        # snap to the band on entry, ease toward it at 30fps while crossfading or
+        # breathing, and hold on a coarse tick once settled so a static color costs
+        # ~no CPU. target_fn(st) -> rgb, or None to hold the last frame (unreadable).
         loop = asyncio.get_event_loop()
         start = loop.time()
         displayed = None
         while True:
             try:
                 st = state_fn() or {}
-                level = st.get("level", 100)
-                target = battery_band_color(level)
+                target = target_fn(st)
+                if target is None:
+                    await asyncio.sleep(INDICATOR_IDLE_INTERVAL)
+                    continue
                 if displayed is None:
-                    displayed = target  # snap to the band on entry, no fade from black
-                breathing = bool(st.get("charging")) and bool(st.get("breathe")) and level < 100
+                    displayed = target
+                breathing = breathe_fn(st)
 
-                # Settled and static: hold the band color on a coarse tick (~no CPU).
-                if not breathing and max(abs(displayed[i] - target[i]) for i in range(3)) <= BATTERY_CONVERGE_EPS:
+                if not breathing and max(abs(displayed[i] - target[i]) for i in range(3)) <= INDICATOR_CONVERGE_EPS:
                     displayed = target
                     self._apply_zones([target] * self._zones)
-                    await asyncio.sleep(BATTERY_IDLE_INTERVAL)
+                    await asyncio.sleep(INDICATOR_IDLE_INTERVAL)
                     continue
 
-                # Crossfading and/or breathing: ease toward the band at 30fps.
-                displayed = tuple(_lerp(displayed[i], target[i], BATTERY_EASE) for i in range(3))
-                factor = breathe_factor(loop.time() - start, BATTERY_BREATHE_SPEED) if breathing else 1.0
+                displayed = tuple(_lerp(displayed[i], target[i], INDICATOR_EASE) for i in range(3))
+                factor = breathe_factor(loop.time() - start, INDICATOR_BREATHE_SPEED) if breathing else 1.0
                 frame = tuple(clamp8(c * factor) for c in displayed)
                 self._apply_zones([frame] * self._zones)
                 await asyncio.sleep(FRAME_INTERVAL)
             except asyncio.CancelledError:
                 raise
             except Exception:
-                logger.exception("battery frame failed")
-                await asyncio.sleep(BATTERY_IDLE_INTERVAL)
+                logger.exception("%s frame failed", label)
+                await asyncio.sleep(INDICATOR_IDLE_INTERVAL)
 
     async def _run(self, effect_id, speed, params):
         loop = asyncio.get_event_loop()

--- a/py_modules/thermal.py
+++ b/py_modules/thermal.py
@@ -1,0 +1,75 @@
+import os
+
+HWMON_ROOT = "/sys/class/hwmon"
+THERMAL_ROOT = "/sys/class/thermal"
+
+# AMD APU package (Tctl) first, then Intel package (MSI Claw), then the AMD GPU edge.
+_HWMON_PREFERENCE = ("k10temp", "coretemp", "amdgpu")
+
+
+def _read(path):
+    try:
+        with open(path, "r") as handle:
+            return handle.read().strip()
+    except OSError:
+        return None
+
+
+def _millidegrees(raw):
+    if raw is None or not raw.lstrip("-").isdigit():
+        return None
+    return int(raw) / 1000.0
+
+
+def _hwmon_chips(root):
+    try:
+        entries = os.listdir(root)
+    except OSError:
+        return {}
+    chips = {}
+    for name in sorted(entries):
+        chip = os.path.join(root, name)
+        label = _read(os.path.join(chip, "name"))
+        if label:
+            chips.setdefault(label, chip)
+    return chips
+
+
+def _thermal_zone_temp(root):
+    try:
+        entries = os.listdir(root)
+    except OSError:
+        return None
+    best = None
+    for name in entries:
+        if not name.startswith("thermal_zone"):
+            continue
+        zone = os.path.join(root, name)
+        value = _millidegrees(_read(os.path.join(zone, "temp")))
+        if value is None:
+            continue
+        if "x86_pkg_temp" in (_read(os.path.join(zone, "type")) or ""):
+            return value
+        best = value if best is None else max(best, value)
+    return best
+
+
+def apu_temperature(hwmon_root=HWMON_ROOT, thermal_root=THERMAL_ROOT):
+    chips = _hwmon_chips(hwmon_root)
+    for pref in _HWMON_PREFERENCE:
+        if pref in chips:
+            value = _millidegrees(_read(os.path.join(chips[pref], "temp1_input")))
+            if value is not None:
+                return value
+    zone = _thermal_zone_temp(thermal_root)
+    if zone is not None:
+        return zone
+    for chip in chips.values():
+        value = _millidegrees(_read(os.path.join(chip, "temp1_input")))
+        if value is not None:
+            return value
+    return None
+
+
+def temperature_available(hwmon_root=HWMON_ROOT, thermal_root=THERMAL_ROOT):
+    return apu_temperature(hwmon_root, thermal_root) is not None

--- a/src/api.ts
+++ b/src/api.ts
@@ -20,6 +20,8 @@ export const setPowerLed = callable<[off: boolean], void>("set_power_led");
 export const reconnect = callable<[], boolean>("reconnect");
 export const setForceControl = callable<[on: boolean], void>("set_force_control");
 export const setBatteryBreathe = callable<[on: boolean], void>("set_battery_breathe");
+export const setTemperatureBreathe = callable<[on: boolean], void>("set_temperature_breathe");
+export const getTemperature = callable<[], number | null>("get_temperature");
 
 // ── Self-updater ──
 

--- a/src/i18n/index.tsx
+++ b/src/i18n/index.tsx
@@ -29,7 +29,9 @@ const es: Record<string, string> = {
   "mode.effect": "Efecto",
   "mode.ambient": "Ambilight",
   "mode.battery": "Batería",
+  "mode.temperature": "Temperatura",
 
+  "nav.sensors": "Sensores",
   "nav.settings": "Ajustes",
   "settings.language": "Idioma",
   "customize.title": "Personalización",
@@ -103,10 +105,19 @@ const es: Record<string, string> = {
   "ambient.smoothing": "Suavizado",
   "ambient.captureRate": "Tasa de captura",
 
+  "sensors.battery": "Batería",
+  "sensors.temperature": "Temperatura",
+
   "battery.hint": "Las luces muestran el nivel de batería con un color que va del azul al rojo.",
   "battery.level": "{n}%",
   "battery.breathe.label": "Respirar al cargar",
   "battery.breathe.hint": "Mientras se carga, el color respira suavemente.",
+
+  "temperature.hint": "Las luces siguen la temperatura del procesador, del azul en frío al rojo cuando se calienta.",
+  "temperature.reading": "{n} °C",
+  "temperature.noReading": "Sin lectura",
+  "temperature.breathe.label": "Avisar en caliente",
+  "temperature.breathe.hint": "Cuando el procesador se pone muy caliente, el color late como aviso.",
 
   "brightness.label": "Brillo",
 
@@ -185,7 +196,9 @@ const en: Record<string, string> = {
   "mode.effect": "Effect",
   "mode.ambient": "Ambient",
   "mode.battery": "Battery",
+  "mode.temperature": "Temperature",
 
+  "nav.sensors": "Sensors",
   "nav.settings": "Settings",
   "settings.language": "Language",
   "customize.title": "Customization",
@@ -259,10 +272,19 @@ const en: Record<string, string> = {
   "ambient.smoothing": "Smoothing",
   "ambient.captureRate": "Capture rate",
 
+  "sensors.battery": "Battery",
+  "sensors.temperature": "Temperature",
+
   "battery.hint": "The lights show the battery level with a color from blue to red.",
   "battery.level": "{n}%",
   "battery.breathe.label": "Breathe while charging",
   "battery.breathe.hint": "While charging, the color gently breathes.",
+
+  "temperature.hint": "The lights follow the processor temperature, from blue when cool to red when it heats up.",
+  "temperature.reading": "{n} °C",
+  "temperature.noReading": "No reading",
+  "temperature.breathe.label": "Warn when hot",
+  "temperature.breathe.hint": "When the processor gets very hot, the color pulses as a warning.",
 
   "brightness.label": "Brightness",
 

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -14,7 +14,7 @@ import { definePlugin } from "@decky/api";
 import { useCallback, useEffect, useMemo, useState } from "react";
 
 import { useColores } from "./useColores";
-import { getAmbilightStatus, reconnect as apiReconnect } from "./api";
+import { getAmbilightStatus, getTemperature, reconnect as apiReconnect } from "./api";
 import { rgbToCss, gradientCss } from "./color";
 import { Mode, RGB, ZoneGroup, GradientPreset, EffectColorNeed, Capabilities } from "./types";
 import { DevicePreview } from "./components/DevicePreview";
@@ -25,15 +25,24 @@ import { TabBar } from "./components/TabBar";
 import { SettingsSection } from "./components/SettingsSection";
 import { Divider } from "./components/Divider";
 import { ColorWheelIcon } from "./components/ColorWheelIcon";
-import { GRADIENT_PRESETS, EFFECT_PRESETS, BATTERY_BANDS, batteryBandColor } from "./palette";
+import {
+  GRADIENT_PRESETS,
+  EFFECT_PRESETS,
+  BATTERY_BANDS,
+  batteryBandColor,
+  TEMPERATURE_BANDS,
+  TEMPERATURE_RANGE,
+  temperatureBandColor,
+} from "./palette";
+import { Tabs } from "./components/Tabs";
 import { I18nProvider, useI18n } from "./i18n";
 import { useUpdate } from "./updater/useUpdate";
 import { AlertDot } from "./updater/AlertDot";
 import { useLayout } from "./nav/store";
 import { visibleIds } from "./nav/layout";
-import { PINNED_TAB, tabMeta, TAB_META } from "./nav/manifest";
+import { PINNED_TAB, tabMeta, TAB_META, SENSOR_TAB, SENSOR_MODES, tabForMode } from "./nav/manifest";
 import { useShoulderNav } from "./nav/useShoulderNav";
-import { readActiveTab, writeActiveTab } from "./nav/activeTab";
+import { readActiveTab, writeActiveTab, readSensorMode, writeSensorMode } from "./nav/activeTab";
 
 function DeviceHeader({ name, color }: { name: string; color: RGB }) {
   const css = rgbToCss(color);
@@ -234,21 +243,31 @@ function EffectSource({
   );
 }
 
-function BatteryPanel({
-  level,
+function SensorMeter({
+  hint,
+  barStops,
+  markerPct,
+  leftLabel,
+  centerLabel,
+  rightLabel,
+  breatheLabel,
+  breatheHint,
   breathe,
   disabled,
   onBreathe,
 }: {
-  level: number;
+  hint: string;
+  barStops: RGB[];
+  markerPct: number | null;
+  leftLabel: string;
+  centerLabel: string;
+  rightLabel: string;
+  breatheLabel: string;
+  breatheHint: string;
   breathe: boolean;
   disabled?: boolean;
   onBreathe: (on: boolean) => void;
 }) {
-  const { t } = useI18n();
-  // Left (0%) -> right (100%): red ... blue. BATTERY_BANDS is high-to-low, so reverse.
-  const barStops = [...BATTERY_BANDS].reverse().map((b) => b.color);
-  const marker = Math.max(0, Math.min(100, level));
   return (
     <>
       <PanelSectionRow>
@@ -260,7 +279,7 @@ function BatteryPanel({
             lineHeight: 1.45,
           }}
         >
-          {t("battery.hint")}
+          {hint}
         </div>
       </PanelSectionRow>
       <PanelSectionRow>
@@ -274,18 +293,20 @@ function BatteryPanel({
               boxShadow: "inset 0 0 0 1px rgba(255,255,255,0.12)",
             }}
           >
-            <div
-              style={{
-                position: "absolute",
-                top: -3,
-                bottom: -3,
-                left: `calc(${marker}% - 2px)`,
-                width: 4,
-                borderRadius: 2,
-                background: "#fff",
-                boxShadow: "0 0 4px rgba(0,0,0,0.6)",
-              }}
-            />
+            {markerPct !== null && (
+              <div
+                style={{
+                  position: "absolute",
+                  top: -3,
+                  bottom: -3,
+                  left: `calc(${markerPct}% - 2px)`,
+                  width: 4,
+                  borderRadius: 2,
+                  background: "#fff",
+                  boxShadow: "0 0 4px rgba(0,0,0,0.6)",
+                }}
+              />
+            )}
           </div>
           <div
             style={{
@@ -296,18 +317,16 @@ function BatteryPanel({
               padding: "6px 1px 0",
             }}
           >
-            <span>0%</span>
-            <span style={{ color: "rgba(255,255,255,0.8)", fontWeight: 600 }}>
-              {t("battery.level", { n: marker })}
-            </span>
-            <span>100%</span>
+            <span>{leftLabel}</span>
+            <span style={{ color: "rgba(255,255,255,0.8)", fontWeight: 600 }}>{centerLabel}</span>
+            <span>{rightLabel}</span>
           </div>
         </div>
       </PanelSectionRow>
       <PanelSectionRow>
         <ToggleField
-          label={t("battery.breathe.label")}
-          description={t("battery.breathe.hint")}
+          label={breatheLabel}
+          description={breatheHint}
           checked={breathe}
           disabled={disabled}
           onChange={onBreathe}
@@ -318,23 +337,136 @@ function BatteryPanel({
   );
 }
 
+function BatteryPanel({
+  level,
+  breathe,
+  disabled,
+  onBreathe,
+}: {
+  level: number;
+  breathe: boolean;
+  disabled?: boolean;
+  onBreathe: (on: boolean) => void;
+}) {
+  const { t } = useI18n();
+  const marker = Math.max(0, Math.min(100, level));
+  return (
+    <SensorMeter
+      hint={t("battery.hint")}
+      barStops={[...BATTERY_BANDS].reverse().map((b) => b.color)}
+      markerPct={marker}
+      leftLabel="0%"
+      centerLabel={t("battery.level", { n: marker })}
+      rightLabel="100%"
+      breatheLabel={t("battery.breathe.label")}
+      breatheHint={t("battery.breathe.hint")}
+      breathe={breathe}
+      disabled={disabled}
+      onBreathe={onBreathe}
+    />
+  );
+}
+
+function TemperaturePanel({
+  temp,
+  breathe,
+  disabled,
+  onBreathe,
+}: {
+  temp: number | null;
+  breathe: boolean;
+  disabled?: boolean;
+  onBreathe: (on: boolean) => void;
+}) {
+  const { t } = useI18n();
+  const { min, max } = TEMPERATURE_RANGE;
+  const markerPct =
+    temp === null ? null : Math.max(0, Math.min(100, ((temp - min) / (max - min)) * 100));
+  return (
+    <SensorMeter
+      hint={t("temperature.hint")}
+      barStops={[...TEMPERATURE_BANDS].reverse().map((b) => b.color)}
+      markerPct={markerPct}
+      leftLabel={`${min}°`}
+      centerLabel={
+        temp === null ? t("temperature.noReading") : t("temperature.reading", { n: Math.round(temp) })
+      }
+      rightLabel={`${max}°`}
+      breatheLabel={t("temperature.breathe.label")}
+      breatheHint={t("temperature.breathe.hint")}
+      breathe={breathe}
+      disabled={disabled}
+      onBreathe={onBreathe}
+    />
+  );
+}
+
+function SensorsPanel({
+  mode,
+  availableModes,
+  level,
+  temp,
+  batteryBreathe,
+  temperatureBreathe,
+  disabled,
+  onSelectMode,
+  onBatteryBreathe,
+  onTemperatureBreathe,
+}: {
+  mode: Mode;
+  availableModes: Mode[];
+  level: number;
+  temp: number | null;
+  batteryBreathe: boolean;
+  temperatureBreathe: boolean;
+  disabled?: boolean;
+  onSelectMode: (m: Mode) => void;
+  onBatteryBreathe: (on: boolean) => void;
+  onTemperatureBreathe: (on: boolean) => void;
+}) {
+  const { t } = useI18n();
+  return (
+    <>
+      {availableModes.length > 1 && (
+        <PanelSectionRow>
+          <div style={{ padding: "2px 0 6px" }}>
+            <Tabs<Mode>
+              value={mode}
+              tabs={availableModes}
+              onChange={onSelectMode}
+              label={(m) => t(`sensors.${m}` as "sensors.battery" | "sensors.temperature")}
+            />
+          </div>
+        </PanelSectionRow>
+      )}
+      {mode === "temperature" ? (
+        <TemperaturePanel
+          temp={temp}
+          breathe={temperatureBreathe}
+          disabled={disabled}
+          onBreathe={onTemperatureBreathe}
+        />
+      ) : (
+        <BatteryPanel
+          level={level}
+          breathe={batteryBreathe}
+          disabled={disabled}
+          onBreathe={onBatteryBreathe}
+        />
+      )}
+    </>
+  );
+}
+
 function modeIdsFor(caps: Capabilities | null): Mode[] {
   if (!caps || !caps.color) return [];
-  return TAB_META.filter((m) => {
-    switch (m.id) {
-      case "solid":
-      case "effect":
-        return true;
-      case "gradient":
-        return caps.zones >= 1;
-      case "battery":
-        return caps.batteryMode;
-      case "ambient":
-        return caps.ambilight;
-      default:
-        return false;
-    }
-  }).map((m) => m.id as Mode);
+  const modes: Mode[] = ["solid"];
+  if (caps.zones >= 1) modes.push("gradient");
+  modes.push("effect");
+  if (caps.batteryMode) modes.push("battery");
+  if (caps.temperatureMode) modes.push("temperature");
+  if (caps.ambilight) modes.push("ambient");
+  return modes;
 }
 
 function Content() {
@@ -359,11 +491,13 @@ function Content() {
     setPowerLed,
     setForceControl,
     setBatteryBreathe,
+    setTemperatureBreathe,
     reconnect,
   } = useColores();
   const { t, lang } = useI18n();
   const { hasUpdate } = useUpdate(lang);
   const [ambStatus, setAmbStatus] = useState<string>("idle");
+  const [tempReading, setTempReading] = useState<number | null>(null);
   const [viewingSettings, setViewingSettings] = useState<boolean>(
     () => readActiveTab() === PINNED_TAB,
   );
@@ -371,14 +505,35 @@ function Content() {
 
   const caps = state?.capabilities ?? null;
   const modeIds = modeIdsFor(caps);
-  const availableTabIds = [...modeIds, PINNED_TAB];
+  const availableTabSet = new Set(modeIds.map((m) => tabForMode(m)));
+  const availableTabIds = [
+    ...TAB_META.filter((m) => m.id !== PINNED_TAB && availableTabSet.has(m.id)).map((m) => m.id),
+    PINNED_TAB,
+  ];
   const visibleTabIds = visibleIds(availableTabIds, layout.tabs, [PINNED_TAB]);
   const visibleModeCount = visibleTabIds.filter((id) => id !== PINNED_TAB).length;
-  const desiredTab = viewingSettings || !state ? PINNED_TAB : state.mode;
+  const availableSensorModes = SENSOR_MODES.filter((m) => modeIds.includes(m)) as Mode[];
+  const desiredTab = viewingSettings || !state ? PINNED_TAB : tabForMode(state.mode);
   const activeTab = visibleTabIds.includes(desiredTab) ? desiredTab : PINNED_TAB;
+  const currentSensorMode: Mode | null =
+    state && availableSensorModes.includes(state.mode)
+      ? state.mode
+      : (availableSensorModes[0] ?? null);
   const contentMode: Mode | null =
-    activeTab !== PINNED_TAB && modeIds.includes(activeTab as Mode) ? (activeTab as Mode) : null;
+    activeTab === PINNED_TAB
+      ? null
+      : activeTab === SENSOR_TAB
+        ? currentSensorMode
+        : (activeTab as Mode);
   const highlight = activeTab;
+
+  const selectSensorMode = useCallback(
+    (m: Mode) => {
+      writeSensorMode(m);
+      setMode(m);
+    },
+    [setMode],
+  );
 
   const select = useCallback(
     (id: string) => {
@@ -388,10 +543,19 @@ function Content() {
       } else {
         setViewingSettings(false);
         writeActiveTab(id);
-        setMode(id as Mode);
+        if (id === SENSOR_TAB) {
+          const last = readSensorMode();
+          const target =
+            last && availableSensorModes.includes(last as Mode)
+              ? (last as Mode)
+              : availableSensorModes[0];
+          if (target) setMode(target);
+        } else {
+          setMode(id as Mode);
+        }
       }
     },
-    [setMode],
+    [setMode, availableSensorModes],
   );
 
   const ambientActive = state?.mode === "ambient" && state?.power;
@@ -409,6 +573,22 @@ function Content() {
       clearInterval(timer);
     };
   }, [ambientActive]);
+
+  const temperatureActive = state?.mode === "temperature";
+  useEffect(() => {
+    if (!temperatureActive) return;
+    let alive = true;
+    const poll = () =>
+      getTemperature()
+        .then((v) => alive && setTempReading(v))
+        .catch(() => {});
+    poll();
+    const timer = setInterval(poll, 2000);
+    return () => {
+      alive = false;
+      clearInterval(timer);
+    };
+  }, [temperatureActive]);
 
   useEffect(() => {
     if (!state?.capabilities.conflictsWithSystemRgb || !state?.forceControl) return;
@@ -468,7 +648,9 @@ function Content() {
     forceControl,
     batteryBreathe,
     batteryLevel,
+    temperatureBreathe,
   } = state;
+  const currentTemp = tempReading ?? state.temperature;
   const hasLeds = capabilities.color || capabilities.brightness;
   const showDeviceControls = hasLeds && (contentMode !== null || visibleModeCount === 0);
 
@@ -495,16 +677,23 @@ function Content() {
     return [color];
   };
 
-  const previewColors: RGB[] =
-    mode === "gradient"
-      ? gradient
-      : mode === "effect"
-        ? effectPreview()
-        : mode === "ambient"
-          ? AMBIENT_HINT
-          : mode === "battery"
-            ? [batteryBandColor(batteryLevel)]
-            : [color];
+  const previewColorsFor = (): RGB[] => {
+    switch (mode) {
+      case "gradient":
+        return gradient;
+      case "effect":
+        return effectPreview();
+      case "ambient":
+        return AMBIENT_HINT;
+      case "battery":
+        return [batteryBandColor(batteryLevel)];
+      case "temperature":
+        return [temperatureBandColor(currentTemp ?? TEMPERATURE_RANGE.min)];
+      default:
+        return [color];
+    }
+  };
+  const previewColors: RGB[] = previewColorsFor();
 
   const tabItems = visibleTabIds.map((id) => {
     const meta = tabMeta(id);
@@ -648,12 +837,19 @@ function Content() {
           </>
         );
       case "battery":
+      case "temperature":
         return (
-          <BatteryPanel
+          <SensorsPanel
+            mode={contentMode}
+            availableModes={availableSensorModes}
             level={batteryLevel}
-            breathe={batteryBreathe}
+            temp={currentTemp}
+            batteryBreathe={batteryBreathe}
+            temperatureBreathe={temperatureBreathe}
             disabled={!power}
-            onBreathe={setBatteryBreathe}
+            onSelectMode={selectSensorMode}
+            onBatteryBreathe={setBatteryBreathe}
+            onTemperatureBreathe={setTemperatureBreathe}
           />
         );
       default:

--- a/src/nav/activeTab.ts
+++ b/src/nav/activeTab.ts
@@ -1,4 +1,5 @@
 const KEY = "colores:activeTab";
+const SENSOR_KEY = "colores:sensorMode";
 
 export function readActiveTab(): string | null {
   try {
@@ -11,6 +12,22 @@ export function readActiveTab(): string | null {
 export function writeActiveTab(id: string): void {
   try {
     localStorage.setItem(KEY, id);
+  } catch {
+    void 0;
+  }
+}
+
+export function readSensorMode(): string | null {
+  try {
+    return localStorage.getItem(SENSOR_KEY);
+  } catch {
+    return null;
+  }
+}
+
+export function writeSensorMode(id: string): void {
+  try {
+    localStorage.setItem(SENSOR_KEY, id);
   } catch {
     void 0;
   }

--- a/src/nav/layout.ts
+++ b/src/nav/layout.ts
@@ -53,9 +53,13 @@ export function toggle(set: string[], id: string): string[] {
 const strArray = (v: unknown): string[] =>
   Array.isArray(v) ? v.filter((x): x is string => typeof x === "string") : [];
 
+// Tab ids that were renamed, so a saved order/hidden preference carries over.
+const RENAMED_TABS: Record<string, string> = { battery: "sensors" };
+
 const asPref = (v: unknown): ListPref => {
   const o = (v && typeof v === "object" ? v : {}) as { order?: unknown; hidden?: unknown };
-  return { order: strArray(o.order), hidden: strArray(o.hidden) };
+  const rename = (ids: string[]) => ids.map((id) => RENAMED_TABS[id] ?? id);
+  return { order: rename(strArray(o.order)), hidden: rename(strArray(o.hidden)) };
 };
 
 // Tolerant of corrupt/old localStorage shapes: anything unrecognized degrades to

--- a/src/nav/manifest.tsx
+++ b/src/nav/manifest.tsx
@@ -1,5 +1,5 @@
 import { ReactNode } from "react";
-import { LuCircle, LuBlend, LuSparkles, LuBatteryFull, LuTv, LuSettings } from "react-icons/lu";
+import { LuCircle, LuBlend, LuSparkles, LuGauge, LuTv, LuSettings } from "react-icons/lu";
 
 export interface TabMeta {
   id: string;
@@ -9,13 +9,21 @@ export interface TabMeta {
 
 export const PINNED_TAB = "settings";
 
+// Container tab: its id is not a backend mode; battery/temperature map onto it.
+export const SENSOR_TAB = "sensors";
+export const SENSOR_MODES = ["battery", "temperature"] as const;
+
+export function tabForMode(mode: string): string {
+  return (SENSOR_MODES as readonly string[]).includes(mode) ? SENSOR_TAB : mode;
+}
+
 const ICON = 15;
 
 export const TAB_META: TabMeta[] = [
   { id: "solid", labelKey: "mode.solid", icon: <LuCircle size={ICON} /> },
   { id: "gradient", labelKey: "mode.gradient", icon: <LuBlend size={ICON} /> },
   { id: "effect", labelKey: "mode.effect", icon: <LuSparkles size={ICON} /> },
-  { id: "battery", labelKey: "mode.battery", icon: <LuBatteryFull size={ICON} /> },
+  { id: SENSOR_TAB, labelKey: "nav.sensors", icon: <LuGauge size={ICON} /> },
   { id: "ambient", labelKey: "mode.ambient", icon: <LuTv size={ICON} /> },
   { id: PINNED_TAB, labelKey: "nav.settings", icon: <LuSettings size={ICON} /> },
 ];

--- a/src/palette.ts
+++ b/src/palette.ts
@@ -174,6 +174,24 @@ export function batteryBandColor(level: number): RGB {
   return BATTERY_BANDS[BATTERY_BANDS.length - 1].color;
 }
 
+// Keep in sync with the backend TEMPERATURE_BANDS (py_modules/effects.py).
+export const TEMPERATURE_BANDS: { min: number; color: RGB }[] = [
+  { min: 90, color: { r: 255, g: 30, b: 20 } },
+  { min: 80, color: { r: 255, g: 110, b: 0 } },
+  { min: 68, color: { r: 255, g: 200, b: 0 } },
+  { min: 55, color: { r: 0, g: 200, b: 60 } },
+  { min: 0, color: { r: 0, g: 120, b: 255 } },
+];
+
+export const TEMPERATURE_RANGE = { min: 40, max: 95 };
+
+export function temperatureBandColor(temp: number): RGB {
+  for (const band of TEMPERATURE_BANDS) {
+    if (temp >= band.min) return band.color;
+  }
+  return TEMPERATURE_BANDS[TEMPERATURE_BANDS.length - 1].color;
+}
+
 const NAME_PARTS: Record<"es" | "en", { adjectives: string[]; nouns: string[] }> = {
   es: {
     adjectives: ["Borracho", "Eléctrico", "Cósmico", "Disco", "Pastel", "Neón", "Salvaje", "Turbo", "Místico", "Picante"],

--- a/src/types.ts
+++ b/src/types.ts
@@ -35,10 +35,11 @@ export interface Capabilities {
   enabledExperiments: string[];
   powerLed: boolean;
   batteryMode: boolean;
+  temperatureMode: boolean;
   conflictsWithSystemRgb: boolean;
 }
 
-export type Mode = "solid" | "gradient" | "effect" | "ambient" | "battery";
+export type Mode = "solid" | "gradient" | "effect" | "ambient" | "battery" | "temperature";
 
 export interface AmbilightState {
   saturation: number;
@@ -71,6 +72,8 @@ export interface ColoresState {
   forceControl: boolean;
   batteryBreathe: boolean;
   batteryLevel: number;
+  temperatureBreathe: boolean;
+  temperature: number | null;
 }
 
 export interface GradientPreset {

--- a/src/useColores.ts
+++ b/src/useColores.ts
@@ -178,6 +178,13 @@ export function useColores() {
     );
   };
 
+  const setTemperatureBreathe = (temperatureBreathe: boolean) => {
+    setState((s) => (s ? { ...s, temperatureBreathe } : s));
+    api.setTemperatureBreathe(temperatureBreathe).catch((e) =>
+      console.error("Colores: setTemperatureBreathe failed", e),
+    );
+  };
+
   const setExperiment = (feature: string, on: boolean) => {
     api
       .setExperiment(feature, on)
@@ -212,6 +219,7 @@ export function useColores() {
     setPowerLed,
     setForceControl,
     setBatteryBreathe,
+    setTemperatureBreathe,
     reconnect,
   };
 }

--- a/tests/test_effects.py
+++ b/tests/test_effects.py
@@ -1,6 +1,8 @@
 from py_modules.effects import (
     BATTERY_BANDS,
+    TEMPERATURE_BANDS,
     battery_band_color,
+    temperature_band_color,
     frame_breathing,
     frame_cycle,
     frame_gradient_sweep,
@@ -132,3 +134,23 @@ def test_battery_bands_cover_full_range_descending():
     assert thresholds == sorted(thresholds, reverse=True)
     assert thresholds[-1] == 0
     assert all(_valid(color) for _, color in BATTERY_BANDS)
+
+
+def test_temperature_band_color_thresholds():
+    assert temperature_band_color(30) == (0, 120, 255)
+    assert temperature_band_color(54) == (0, 120, 255)
+    assert temperature_band_color(55) == (0, 200, 60)
+    assert temperature_band_color(67) == (0, 200, 60)
+    assert temperature_band_color(68) == (255, 200, 0)
+    assert temperature_band_color(79) == (255, 200, 0)
+    assert temperature_band_color(80) == (255, 110, 0)
+    assert temperature_band_color(89) == (255, 110, 0)
+    assert temperature_band_color(90) == (255, 30, 20)
+    assert temperature_band_color(105) == (255, 30, 20)
+
+
+def test_temperature_bands_cover_full_range_descending():
+    thresholds = [b[0] for b in TEMPERATURE_BANDS]
+    assert thresholds == sorted(thresholds, reverse=True)
+    assert thresholds[-1] == 0
+    assert all(_valid(color) for _, color in TEMPERATURE_BANDS)

--- a/tests/test_main_routing.py
+++ b/tests/test_main_routing.py
@@ -81,6 +81,9 @@ class FakeEngine:
     def start_battery(self, state_fn):
         self.events.append(("battery", state_fn()))
 
+    def start_temperature(self, state_fn):
+        self.events.append(("temperature", state_fn()))
+
 
 class FakeAmbilight:
     def __init__(self):
@@ -422,6 +425,35 @@ def test_battery_mode_gated_off_when_power_off(main_module):
     p._apply()
     assert ("static", [(0, 0, 0)] * p._zones) in p._engine.events
     assert not any(e[0] == "battery" for e in p._engine.events)
+
+
+def test_temperature_mode_starts_temperature_loop(main_module):
+    p = _plugin(main_module, "temperature", hw=False, per_zone=True)
+    p._apu_temp = 73.0
+    p._apply()
+    temp = next(e for e in p._engine.events if e[0] == "temperature")
+    assert temp[1] == {"temp": 73.0, "breathe": True}
+    assert not any(c[0] == "hw_effect" for c in p._controller.calls)
+
+
+def test_temperature_mode_wants_render_loop(main_module):
+    p = _plugin(main_module, "temperature")
+    assert p._wants_render_loop() is True
+
+
+def test_temperature_mode_on_hardware_device_stays_software(main_module):
+    p = _plugin(main_module, "temperature", hw=True, per_zone=False, per_controller=True)
+    p._apu_temp = 91.0
+    p._apply()
+    assert any(e[0] == "temperature" for e in p._engine.events)
+    assert not any(c[0] == "hw_effect" for c in p._controller.calls)
+
+
+def test_temperature_mode_gated_off_when_power_off(main_module):
+    p = _plugin(main_module, "temperature", hw=False, per_zone=True, power=False)
+    p._apply()
+    assert ("static", [(0, 0, 0)] * p._zones) in p._engine.events
+    assert not any(e[0] == "temperature" for e in p._engine.events)
 
 
 def test_battery_breathe_default_is_true(main_module):

--- a/tests/test_thermal.py
+++ b/tests/test_thermal.py
@@ -1,0 +1,78 @@
+import os
+
+from py_modules.thermal import apu_temperature, temperature_available
+
+
+def _hwmon(root, name, chip_name, temp1=None):
+    path = os.path.join(root, name)
+    os.makedirs(path)
+    with open(os.path.join(path, "name"), "w") as handle:
+        handle.write(chip_name + "\n")
+    if temp1 is not None:
+        with open(os.path.join(path, "temp1_input"), "w") as handle:
+            handle.write(str(temp1) + "\n")
+
+
+def _zone(root, name, temp, ztype=None):
+    path = os.path.join(root, name)
+    os.makedirs(path)
+    with open(os.path.join(path, "temp"), "w") as handle:
+        handle.write(str(temp) + "\n")
+    if ztype is not None:
+        with open(os.path.join(path, "type"), "w") as handle:
+            handle.write(ztype + "\n")
+
+
+def test_reads_k10temp_in_celsius(tmp_path):
+    hw = str(tmp_path / "hwmon")
+    _hwmon(hw, "hwmon0", "k10temp", 72000)
+    assert apu_temperature(hw, str(tmp_path / "thermal")) == 72.0
+
+
+def test_prefers_k10temp_over_amdgpu(tmp_path):
+    hw = str(tmp_path / "hwmon")
+    _hwmon(hw, "hwmon0", "amdgpu", 55000)
+    _hwmon(hw, "hwmon1", "k10temp", 80000)
+    assert apu_temperature(hw, str(tmp_path / "thermal")) == 80.0
+
+
+def test_reads_intel_coretemp(tmp_path):
+    hw = str(tmp_path / "hwmon")
+    _hwmon(hw, "hwmon0", "coretemp", 61000)
+    assert apu_temperature(hw, str(tmp_path / "thermal")) == 61.0
+
+
+def test_falls_back_to_thermal_zone(tmp_path):
+    hw = str(tmp_path / "hwmon")
+    os.makedirs(hw)
+    th = str(tmp_path / "thermal")
+    _zone(th, "thermal_zone0", 48000, "acpitz")
+    _zone(th, "thermal_zone1", 66000, "x86_pkg_temp")
+    # x86_pkg_temp is preferred even when another zone is hotter/cooler.
+    assert apu_temperature(hw, th) == 66.0
+
+
+def test_thermal_zone_hottest_when_no_pkg(tmp_path):
+    hw = str(tmp_path / "hwmon")
+    os.makedirs(hw)
+    th = str(tmp_path / "thermal")
+    _zone(th, "thermal_zone0", 40000, "acpitz")
+    _zone(th, "thermal_zone1", 52000, "acpitz")
+    assert apu_temperature(hw, th) == 52.0
+
+
+def test_none_when_nothing_readable(tmp_path):
+    hw = str(tmp_path / "hwmon")
+    _hwmon(hw, "hwmon0", "nvme")  # a chip with no temp1_input
+    assert apu_temperature(hw, str(tmp_path / "thermal")) is None
+    assert temperature_available(hw, str(tmp_path / "thermal")) is False
+
+
+def test_available_true_when_sensor_present(tmp_path):
+    hw = str(tmp_path / "hwmon")
+    _hwmon(hw, "hwmon0", "k10temp", 50000)
+    assert temperature_available(hw, str(tmp_path / "thermal")) is True
+
+
+def test_missing_roots_return_none(tmp_path):
+    assert apu_temperature(str(tmp_path / "no_hw"), str(tmp_path / "no_th")) is None


### PR DESCRIPTION
## Qué hace | What it does

La pestaña **Batería** pasa a ser **Sensores** y agrupa dos modos con un selector arriba:

- **Batería** — igual que antes.
- **Temperatura** — colorea los LEDs según la temperatura del APU (frío azul → caliente rojo), con las mismas bandas fijas, cruce suave y respiración que el modo Batería (respira en banda crítica ≥90 °C).

The **Battery** tab becomes **Sensors**, grouping two modes behind a sub-mode picker: **Battery** (unchanged) and **Temperature**, which colors the LEDs by APU temperature (cool blue → hot red) using the same fixed bands, easing, and breathing as Battery (breathes in the critical band ≥90 °C).

## Bandas | Bands

`<55` azul · `55–67` verde · `68–79` amarillo · `80–89` naranja · `≥90` rojo. Mismos colores que Batería para que se vean como una familia.

## Cómo funciona | How it works

- **Sensor** (`py_modules/thermal.py`): sysfs universal como `power_supply.py`. Prefiere `k10temp` (APU AMD) → `coretemp` (Intel/Claw) → `amdgpu`, con fallback a `thermal_zone`.
- **Cacheado** en el watcher de 3s (`_charger_watch`) igual que el nivel de batería — cero I/O de sysfs en el loop de render.
- **Un solo loop de render** (`_run_indicator`) parametrizado sirve a Batería y Temperatura (antes eran dos loops casi idénticos).
- **Capacidad** `temperatureMode` detectada por sensor presente; la UI solo muestra lo que el equipo soporta.
- La pestaña `sensors` es un contenedor; `battery`/`temperature` mapean a ella. Las preferencias de layout guardadas para la antigua pestaña `battery` migran a `sensors`.

## Pruebas | Tests

- `pytest`: 236 en verde (nuevos `test_thermal.py`, bandas de temperatura, routing del modo).
- `tsc --noEmit` limpio, `rollup` build ok, `ruff` limpio.
- **On-device (ROG Xbox Ally X)**: sensor `k10temp` leído, `temperatureMode=True`, banda correcta, y los 4 anillos escriben el color por la ruta de render real. Re-verificación del loop unificado en hardware pendiente (equipo suspendido al momento del refactor); lógica idéntica a la de batería ya probada.