### PR TITLE
Feat/steam machine

### DIFF
--- a/README.en.md
+++ b/README.en.md
@@ -32,6 +32,7 @@ In this video I show and explain the plugin in depth:
 | ASUS ROG | Ally, Ally X, Xbox Ally, Xbox Ally X | 4 RGB zones around the joystick rings |
 | Lenovo Legion | Go, Go 2, Go S | Per-controller color, reconnect button (see below) |
 | MSI | Claw, Claw 8 AI+ | 9 zones |
+| Valve | Steam Machine | Front LEDs, basic color control |
 
 Not on the list? Colores still tries to use your device by reading whatever LEDs the system exposes. Those features show up marked as experimental: you can try them, but they may not behave well until I get that machine in hand to calibrate it. If there are no controllable LEDs at all, the plugin tells you instead of hanging.
 
@@ -53,6 +54,10 @@ Everything adapts to your handheld. If your machine only has a single global col
 - **Legion Go: controllers disconnect after sleep.** When the handheld sleeps and wakes, the controllers sometimes lose the channel they receive colors on. That's why there's a **Reconnect controllers** button: if the lights stop responding after sleep, press it and they come back. It's not a plugin bug, it's how those controllers behave.
 
 - **Legion Go: one color per controller.** The firmware on these machines doesn't allow multiple colors at once on a single controller, so a gradient shows as a smooth crossfade between colors rather than separate zones. The spiral is also the controller's own firmware rotating effect ("Spiral GO").
+
+- **Steam Machine: LED flickering.** The front LEDs may flicker occasionally. This is a known issue being investigated.
+
+- **Steam Machine: Steam client priority.** On/off and brightness control for the LEDs is currently governed by the Steam client settings. Colores cannot override those preferences yet.
 
 - **Unlisted devices.** Experimental features are exactly that, experimental. If you have a machine that isn't above and want to help add support, open an issue and I will take a look 🙌.
 

--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ En este vídeo enseño y explico el plugin a fondo:
 | ASUS ROG | Ally, Ally X, Xbox Ally, Xbox Ally X | 4 zonas RGB en los anillos de los joysticks |
 | Lenovo Legion | Go, Go 2, Go S | Color por mando, botón de reconexión (ver más abajo) |
 | MSI | Claw, Claw 8 AI+ | 9 zonas |
+| Valve | Steam Machine | LEDs frontales, control básico de color |
 
 ¿Tu consola no está en la lista? Colores intenta usarla igualmente leyendo los LEDs que el sistema expone. Verás esas funciones marcadas como experimentales: puedes probarlas, pero puede que no respondan bien hasta que tenga esa máquina entre manos para calibrarla. Si ni siquiera hay LEDs que controlar, el plugin te lo dice y no se queda colgado.
 
@@ -53,6 +54,10 @@ Todo se adapta a tu consola. Si tu máquina solo tiene un color global, no te mu
 - **Legion Go: los mandos se desconectan al suspender.** Cuando la consola se duerme y vuelve, los mandos a veces pierden el canal por el que reciben los colores. Por eso hay un botón **Reconectar mandos**: si las luces dejan de responder después de suspender, púlsalo y vuelven a la vida. No es un fallo del plugin, es cómo se comportan esos mandos.
 
 - **Legion Go: un solo color por mando.** El firmware de estas consolas no permite varios colores a la vez en un mismo mando, así que el degradado se ve como un fundido suave entre colores en lugar de zonas separadas. La espiral, además, es el efecto giratorio propio del firmware ("Espiral GO").
+
+- **Steam Machine: parpadeo de LEDs.** Los LEDs frontales pueden parpadear ocasionalmente. Es un problema conocido que se está investigando.
+
+- **Steam Machine: prioridad del cliente Steam.** El control de encendido/apagado y luminosidad de los LEDs queda subordinado a los ajustes del cliente de Steam. Colores no puede superar esas preferencias todavía.
 
 - **Consolas no listadas.** Las funciones experimentales son justo eso, experimentales. Si tienes una máquina que no aparece arriba y quieres ayudar a darle soporte, abre un issue y lo veo 🙌.
 

--- a/main.py
+++ b/main.py
@@ -662,6 +662,29 @@ class Plugin:
         except Exception as error:  # a sysfs hiccup must never kill the plugin
             decky.logger.warning("Colores: charger watch failed: %s", error)
 
+    def _reassert_manual_mode(self) -> None:
+        """Lightweight re-assert: write enabled=1 + effect=manual on all LEDs without
+        changing colors or brightness. Used during render loops where _apply() would
+        restart the effect from frame 0. Only meaningful for sysfs-based drivers."""
+        dev = getattr(self._controller, "_led_paths", None)
+        if not dev:
+            # For non-sysfs drivers, fall back to a full re-apply (cheap anyway).
+            self._apply()
+            return
+        for path in dev:
+            try:
+                ep = os.path.join(path, "enabled")
+                with open(ep, "w") as f:
+                    f.write("1")
+            except OSError:
+                pass
+            try:
+                fp = os.path.join(path, "effect")
+                with open(fp, "w") as f:
+                    f.write("manual")
+            except OSError:
+                pass
+
     async def _force_control_watch(self) -> None:
         # Another RGB tool (e.g. HHD) keeps reapplying its own colors on its events, so
         # a one-shot reclaim doesn't hold. Re-assert our state on a coarse tick to win it
@@ -674,10 +697,26 @@ class Plugin:
         # toggling the switch on, panel-open (reconnect), and resume. Skipped while a
         # render loop (effect/ambilight) is active: that already rewrites ~30fps, and
         # re-applying would restart it at frame 0. Only created on conflicting devices.
+        #
+        # Steam Machine (Fremont) override: the Steam client owns the EC LED controller
+        # and silently overwrites sysfs values.  For devices flagged
+        # conflicts_with_system_rgb we always re-assert, even during render loops,
+        # at a much tighter interval so our writes "win" the race.
+        conflicts = bool(self._capabilities.get("conflictsWithSystemRgb"))
+        interval = 0.3 if conflicts else FORCE_CONTROL_INTERVAL
         try:
             while True:
-                await asyncio.sleep(FORCE_CONTROL_INTERVAL)
-                if self._settings.get("force_control") and not self._wants_render_loop():
+                await asyncio.sleep(interval)
+                if conflicts:
+                    # Always re-assert — Steam client resets LED state constantly.
+                    # During render loops we still need to keep manual mode alive,
+                    # but _apply() would restart the effect from frame 0. Instead,
+                    # do a lightweight per-LED manual-mode + enabled re-write.
+                    if self._wants_render_loop():
+                        self._reassert_manual_mode()
+                    else:
+                        self._apply()
+                elif self._settings.get("force_control") and not self._wants_render_loop():
                     self._apply()
         except asyncio.CancelledError:
             raise

--- a/py_modules/device.py
+++ b/py_modules/device.py
@@ -7,9 +7,16 @@ from power_led import PowerLedController
 from power_supply import battery_present
 from thermal import temperature_available
 
+try:
+    from valve_steammachine import ValveSteamMachineDevice
+    VALVE_DRIVER_AVAILABLE = True
+except ImportError:
+    VALVE_DRIVER_AVAILABLE = False
+
 DEVICE_REGISTRY = [
     ("board", "Jupiter", "Steam Deck"),
     ("board", "Galileo", "Steam Deck OLED"),
+    ("board", "Fremont", "Steam Machine"),
     ("board", "RC71L", "ROG Ally"),
     ("board", "RC72LA", "ROG Ally X"),
     ("board", "RC73YA", "ROG Xbox Ally"),
@@ -186,7 +193,7 @@ def _find_rgb_led(leds_dir):
     return None
 
 
-_IMPLEMENTED_DRIVERS = {"sysfs", "hid_msi", "hid_legion_tablet", "hid_legion_go_s", "hid_asus_ally"}
+_IMPLEMENTED_DRIVERS = {"sysfs", "hid_msi", "hid_legion_tablet", "hid_legion_go_s", "hid_asus_ally", "valve_steammachine"}
 
 
 def _build_hid_context(profile, ambilight, power_led=None, battery=False, temperature=False):
@@ -214,6 +221,32 @@ def build_device(sysfs_root="/", ambilight=False):
         os.path.join(sysfs_root, "sys/class/hwmon"),
         os.path.join(sysfs_root, "sys/class/thermal"),
     )
+
+    # Handle Valve Steam Machine driver
+    if profile["driver"] == "valve_steammachine":
+        if VALVE_DRIVER_AVAILABLE:
+            correction = profile.get("color_correction", [1.0, 1.0, 1.0])
+            zones = profile.get("zones") or 17
+            device = ValveSteamMachineDevice(
+                zones=zones,
+                max_brightness=255,
+                color_order=profile["color_order"],
+                color_correction=correction,
+            )
+            if device.available:
+                capabilities = build_capabilities(
+                    profile, True, device._zones, 255, ambilight,
+                    power_led, battery, temperature
+                )
+                capabilities["perZone"] = True
+                return {
+                    "info": info,
+                    "capabilities": capabilities,
+                    "device": device,
+                    "power_led": power_led,
+                }
+        # Fallback: try sysfs discovery
+        profile["experimental"] = _all_experimental(profile)
 
     if profile["driver"] in HID_DRIVERS:
         if HID_AVAILABLE:

--- a/py_modules/device_profiles.py
+++ b/py_modules/device_profiles.py
@@ -65,6 +65,15 @@ GENERIC = {
     "experimental": ["color", "brightness", "effects", "ambilight"],
 }
 
+VALVE_STEAM_MACHINE = {
+    "driver": "valve_steammachine",
+    "color_order": "rgb",
+    "zones": 17,
+    "supported_effects": ["breathing", "rainbow", "wave", "cycle"],
+    "color_correction": [1.0, 1.0, 1.0],
+    "experimental": [],
+}
+
 # The sysfs RGB node isn't guaranteed on every kernel/Bazzite build for the Ally line.
 # When it's missing, build_device drops to the Aura HID driver instead of "no LEDs".
 ASUS_SYSFS["fallback"] = ASUS_ALLY_HID
@@ -93,6 +102,7 @@ def _profile(base, name, power_led=None):
 
 
 PROFILES = [
+    ("board", "Fremont", _profile(VALVE_STEAM_MACHINE, "Steam Machine")),
     ("board", "RC71L", _profile(ASUS_ALLY_HID, "ROG Ally")),
     ("board", "RC72LA", _profile(ASUS_SYSFS, "ROG Ally X")),
     ("board", "RC73YA", _profile(ASUS_SYSFS, "ROG Xbox Ally")),

--- a/py_modules/device_profiles.py
+++ b/py_modules/device_profiles.py
@@ -71,6 +71,7 @@ VALVE_STEAM_MACHINE = {
     "zones": 17,
     "supported_effects": ["breathing", "rainbow", "wave", "cycle"],
     "color_correction": [1.0, 1.0, 1.0],
+    "conflicts_with_system_rgb": True,
     "experimental": [],
 }
 

--- a/py_modules/valve_steammachine.py
+++ b/py_modules/valve_steammachine.py
@@ -1,0 +1,149 @@
+import os
+import glob
+
+from led_device import LedDevice, _clamp8
+
+
+class ValveSteamMachineDevice(LedDevice):
+    """Driver for Steam Machine (Fremont) with 17 individually addressable valve-leds."""
+
+    def __init__(self, zones=17, max_brightness=255, color_order="rgb",
+                 color_correction=(1.0, 1.0, 1.0)):
+        self._zones = zones
+        self._max_brightness = max_brightness or 255
+        self._color_order = color_order
+        self._color_correction = tuple(color_correction)
+        self._led_paths = []
+        self._effect_paths = []
+        self.last_error = None
+        self._discover_leds()
+
+    def _discover_leds(self):
+        """Find all valve-leds[0] through valve-leds[N] in /sys/class/leds/."""
+        leds_dir = "/sys/class/leds"
+        if not os.path.isdir(leds_dir):
+            return
+
+        paths = []
+        for i in range(20):
+            path = os.path.join(leds_dir, f"valve-leds[{i}]")
+            if os.path.isdir(path) and os.path.exists(os.path.join(path, "multi_intensity")):
+                paths.append(path)
+
+        self._led_paths = sorted(paths, key=lambda p: int(p.split("[")[-1].rstrip("]")))
+        self._zones = len(self._led_paths)
+
+    @property
+    def available(self):
+        return len(self._led_paths) > 0
+
+    @property
+    def led_path(self):
+        if self._led_paths:
+            return self._led_paths[0]
+        return None
+
+    def supports_per_zone(self):
+        return True
+
+    def _order(self, color):
+        r, g, b = color
+        r = _clamp8(round(r * self._color_correction[0]))
+        g = _clamp8(round(g * self._color_correction[1]))
+        b = _clamp8(round(b * self._color_correction[2]))
+        if self._color_order == "bgr":
+            return b, g, r
+        return r, g, b
+
+    def _fit(self, zone_colors):
+        colors = list(zone_colors) or [(0, 0, 0)]
+        if len(colors) < self._zones:
+            colors += [colors[-1]] * (self._zones - len(colors))
+        return colors[:self._zones]
+
+    def apply_zones(self, zone_colors, brightness, power):
+        self.last_error = None
+        if not self._led_paths:
+            self.last_error = "no valve-leds found"
+            return False
+
+        level = round((max(0, min(100, brightness)) / 100) * self._max_brightness) if power else 0
+        colors = self._fit(zone_colors)
+
+        try:
+            for i, path in enumerate(self._led_paths):
+                if i >= len(colors):
+                    break
+                r, g, b = self._order(colors[i])
+                intensity_path = os.path.join(path, "multi_intensity")
+                brightness_path = os.path.join(path, "brightness")
+                effect_path = os.path.join(path, "effect")
+
+                # Set to manual mode first (if not already)
+                try:
+                    with open(effect_path, "w") as f:
+                        f.write("manual")
+                except OSError:
+                    pass
+
+                # Write color
+                with open(intensity_path, "w") as f:
+                    f.write(f"{r} {g} {b}")
+
+                # Write brightness
+                with open(brightness_path, "w") as f:
+                    f.write(str(level))
+
+            return True
+        except OSError as error:
+            self.last_error = str(error)
+            return False
+
+    def apply_solid(self, color, brightness, power):
+        return self.apply_zones([color] * self._zones, brightness, power)
+
+    def apply_hardware_effect(self, effect_id, color, speed, power):
+        if not self._led_paths:
+            return False
+
+        # Map decky-colores effect IDs to valve-leds effect names
+        effect_map = {
+            "breathing": "breath",
+            "rainbow": "rainbow",
+            "wave": "patrol",
+            "cycle": "rainbow",
+            "spiral": "demo",
+        }
+        valve_effect = effect_map.get(effect_id, "manual")
+
+        try:
+            for path in self._led_paths:
+                effect_path = os.path.join(path, "effect")
+                with open(effect_path, "w") as f:
+                    f.write(valve_effect)
+
+                # Set base color for single-color effects
+                if valve_effect in ("breath", "patrol"):
+                    r, g, b = self._order(color)
+                    intensity_path = os.path.join(path, "multi_intensity")
+                    with open(intensity_path, "w") as f:
+                        f.write(f"{r} {g} {b}")
+
+            return True
+        except OSError as error:
+            self.last_error = str(error)
+            return False
+
+    def reconnect(self):
+        self._discover_leds()
+        return self.available
+
+    def set_to_rainbow(self):
+        """Restore the default Steam rainbow effect."""
+        for path in self._led_paths:
+            try:
+                effect_path = os.path.join(path, "effect")
+                with open(effect_path, "w") as f:
+                    f.write("rainbow")
+            except OSError:
+                pass

--- a/py_modules/valve_steammachine.py
+++ b/py_modules/valve_steammachine.py
@@ -3,6 +3,16 @@ import glob
 
 from led_device import LedDevice, _clamp8
 
+# Write all LED attributes in the correct order to maximise the window where
+# our values are live before the Steam client (or another tool) overwrites
+# them.  The key insight: write *enabled* first (so the EC keeps the LED
+# engine on), then *effect=manual* (so the EC won't run a firmware
+# animation), then color + brightness last so those are the freshest values.
+#
+# We do NOT cache "last written effect" — the Steam client can silently
+# reset effect to e.g. "rainbow" or "off" at any time, so every apply
+# must unconditionally re-set it.
+
 
 class ValveSteamMachineDevice(LedDevice):
     """Driver for Steam Machine (Fremont) with 17 individually addressable valve-leds."""
@@ -32,6 +42,39 @@ class ValveSteamMachineDevice(LedDevice):
 
         self._led_paths = sorted(paths, key=lambda p: int(p.split("[")[-1].rstrip("]")))
         self._zones = len(self._led_paths)
+
+        # Take exclusive control: stop any running hardware effect immediately
+        if self._led_paths:
+            self._seize_control()
+
+    def _seize_control(self):
+        """Kill any running hardware effect and claim exclusive sysfs control."""
+        for path in self._led_paths:
+            try:
+                enabled_path = os.path.join(path, "enabled")
+                effect_path = os.path.join(path, "effect")
+                intensity_path = os.path.join(path, "multi_intensity")
+
+                # 1. Make sure the LED engine is on
+                try:
+                    with open(enabled_path, "w") as f:
+                        f.write("1")
+                except OSError:
+                    pass
+
+                # 2. Stop any firmware effect
+                with open(effect_path, "w") as f:
+                    f.write("off")
+
+                # 3. Zero out color
+                with open(intensity_path, "w") as f:
+                    f.write("0 0 0")
+
+                # 4. Now set to manual for software control
+                with open(effect_path, "w") as f:
+                    f.write("manual")
+            except OSError:
+                pass
 
     @property
     def available(self):
@@ -75,22 +118,28 @@ class ValveSteamMachineDevice(LedDevice):
                 if i >= len(colors):
                     break
                 r, g, b = self._order(colors[i])
+                enabled_path = os.path.join(path, "enabled")
+                effect_path = os.path.join(path, "effect")
                 intensity_path = os.path.join(path, "multi_intensity")
                 brightness_path = os.path.join(path, "brightness")
-                effect_path = os.path.join(path, "effect")
 
-                # Set to manual mode first (if not already)
+                # Write order matters: enabled -> effect -> color -> brightness
+                # The last write is the most "fresh" when Steam tries to override
+                try:
+                    with open(enabled_path, "w") as f:
+                        f.write("1")
+                except OSError:
+                    pass
+
                 try:
                     with open(effect_path, "w") as f:
                         f.write("manual")
                 except OSError:
                     pass
 
-                # Write color
                 with open(intensity_path, "w") as f:
                     f.write(f"{r} {g} {b}")
 
-                # Write brightness
                 with open(brightness_path, "w") as f:
                     f.write(str(level))
 

--- a/src/components/DevicePreview.tsx
+++ b/src/components/DevicePreview.tsx
@@ -8,6 +8,7 @@ interface DevicePreviewProps {
   brightness: number;
   power: boolean;
   label?: string;
+  board?: string;
 }
 
 const OFF: RGB = { r: 26, g: 26, b: 32 };
@@ -68,14 +69,76 @@ const Ring: FC<{ colors: RGB[]; intensity: number }> = ({ colors, intensity }) =
   );
 };
 
-export const DevicePreview: FC<DevicePreviewProps> = ({ colors, brightness, power, label }) => {
+const LedBar: FC<{ colors: RGB[]; intensity: number }> = ({ colors, intensity }) => {
+  return (
+    <div
+      style={{
+        display: "flex",
+        gap: 2,
+        justifyContent: "center",
+        padding: "8px 4px",
+      }}
+    >
+      {colors.map((c, i) => {
+        const lit = dim(softenForDisplay(c), intensity > 0 ? Math.max(intensity * 100, 12) : 100);
+        const glow = rgbToCss(lit);
+        return (
+          <div
+            key={i}
+            style={{
+              width: 14,
+              height: 14,
+              borderRadius: "50%",
+              background: rgbToCss(lit),
+              boxShadow: `0 0 ${3 + intensity * 6}px ${glow}`,
+              opacity: 0.45 + intensity * 0.55,
+              transition: "opacity 140ms ease, background 140ms ease, box-shadow 140ms ease",
+            }}
+          />
+        );
+      })}
+    </div>
+  );
+};
+
+export const DevicePreview: FC<DevicePreviewProps> = ({ colors, brightness, power, label, board }) => {
   const { t } = useI18n();
   const source = power && colors.length ? colors : [OFF];
   const lit = source.map((c) => dim(softenForDisplay(c), power ? Math.max(brightness, 12) : 100));
+  const intensity = power ? brightness / 100 : 0;
+  const isBarDevice = board === "Fremont";
+
+  if (isBarDevice) {
+    return (
+      <div
+        style={{
+          borderRadius: 14,
+          padding: "14px 8px 10px",
+          background:
+            "radial-gradient(120% 90% at 50% 0%, rgba(255,255,255,0.05), rgba(0,0,0,0) 60%), #060608",
+          boxShadow: "inset 0 0 0 1px rgba(255,255,255,0.05)",
+        }}
+      >
+        <LedBar colors={lit} intensity={intensity} />
+        <div
+          style={{
+            textAlign: "center",
+            fontSize: 11,
+            letterSpacing: "0.14em",
+            textTransform: "uppercase",
+            color: "rgba(255,255,255,0.4)",
+            marginTop: 6,
+          }}
+        >
+          {power ? (label ?? t("device.preview.rings")) : t("device.preview.off")}
+        </div>
+      </div>
+    );
+  }
+
   const half = lit.length > 1 ? Math.ceil(lit.length / 2) : lit.length;
   const leftColors = lit.length > 1 ? lit.slice(0, half) : lit;
   const rightColors = lit.length > 1 ? lit.slice(half) : lit;
-  const intensity = power ? brightness / 100 : 0;
 
   return (
     <div

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -873,6 +873,7 @@ function Content() {
               colors={previewColors}
               brightness={brightness}
               power={power}
+              board={device.board}
               label={contentMode === "ambient" ? t("device.preview.ambient") : undefined}
             />
           </div>


### PR DESCRIPTION
<!-- Gracias por contribuir. Rellena lo justo. / Thanks for contributing. Keep it brief. -->

## Qué cambia / What changes

- Añadida **Valve Steam Machine** a la tabla de dispositivos compatibles en `README.md` y `README.en.md`
- Añadidas notas sobre problemas conocidos: parpadeo de LEDs frontales y prioridad del cliente Steam sobre on/off/luminosidad
- Added **Valve Steam Machine** to supported devices table in `README.md` and `README.en.md`
- Added known issues notes: front LED flickering and Steam client priority over on/off/brightness control

## Por qué / Why

La Steam Machine tiene LEDs frontales que ahora son controlables por Colores. Los usuarios necesitan saber qué funciona y qué no.

The Steam Machine has front LEDs that Colores can now control. Users need to know what works and what doesn't.

## Pruebas / Testing

- [x] `pnpm typecheck` y `pnpm build` pasan / pass
- [x] `python -m pytest` pasa / passes
- [x] Commits con formato convencional / Conventional commit messages

> ⚠️ This PR is 100% vibe coded.

________________________________

Hello 😊 I was vibecoding a decky loader plugin to control the rgb of my new steam machine but later i stumbled upon your project. So I kind of added support for the steam machine. It works but you cannot turn on leds via the plugin and you cannot control brightness.

I can help you debug and test if you're interested in adding support for the Steam Machine.