### PR TITLE
chore(release): isolate non-Decky infrastructure

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -4,7 +4,14 @@
   "bootstrap-sha": "a764eaf57baed9ec22705cb48ad979d10d01257f",
   "packages": {
     ".": {
-      "exclude-paths": ["android", "shared", "windows"]
+      "exclude-paths": [
+        ".github",
+        "android",
+        "release-please-config.json",
+        "shared",
+        "tests/test_release_routing.py",
+        "windows"
+      ]
     }
   }
 }

--- a/tests/test_release_routing.py
+++ b/tests/test_release_routing.py
@@ -1,0 +1,17 @@
+import json
+from pathlib import Path
+
+
+def test_release_please_excludes_non_decky_surfaces():
+    root = Path(__file__).resolve().parents[1]
+    config = json.loads((root / "release-please-config.json").read_text())
+    excluded = set(config["packages"]["."]["exclude-paths"])
+
+    assert excluded == {
+        ".github",
+        "android",
+        "release-please-config.json",
+        "shared",
+        "tests/test_release_routing.py",
+        "windows",
+    }


### PR DESCRIPTION
## Qué corrige

Release Please seguía considerando commits de CI y de su propia configuración aunque Android, shared y Windows ya estaban excluidos. Eso generó por error la PR #61 para Decky 0.20.1.

## Cambio

- Excluye .github y release-please-config.json del cálculo de versiones Decky.
- Excluye la prueba de contrato para que esta corrección tampoco cuente como cambio de producto.
- Añade una prueba con el conjunto exacto de rutas para evitar tanto nuevos falsos releases como exclusiones accidentales de código Decky.

## Verificación

- 286 tests Python
- Ruff limpio
- JSON válido
- Revisión independiente sin hallazgos Critical o Important

Al fusionar esta PR, #61 debe permanecer cerrada y los cambios Android o de infraestructura no incrementarán la versión Decky.