### PR TITLE
chore(release): reset Decky release boundary

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -2,14 +2,14 @@
   "$schema": "https://raw.githubusercontent.com/googleapis/release-please/main/schemas/config.json",
   "release-type": "node",
   "bootstrap-sha": "a764eaf57baed9ec22705cb48ad979d10d01257f",
+  "last-release-sha": "af885f14f8756734a72bfac876084585bf4ad056",
   "packages": {
     ".": {
       "exclude-paths": [
         ".github",
         "android",
-        "release-please-config.json",
         "shared",
-        "tests/test_release_routing.py",
+        "tests",
         "windows"
       ]
     }

--- a/tests/test_release_routing.py
+++ b/tests/test_release_routing.py
@@ -10,8 +10,14 @@ def test_release_please_excludes_non_decky_surfaces():
     assert excluded == {
         ".github",
         "android",
-        "release-please-config.json",
         "shared",
-        "tests/test_release_routing.py",
+        "tests",
         "windows",
     }
+
+
+def test_release_history_starts_after_android_foundation():
+    root = Path(__file__).resolve().parents[1]
+    config = json.loads((root / "release-please-config.json").read_text())
+
+    assert config["last-release-sha"] == "af885f14f8756734a72bfac876084585bf4ad056"


### PR DESCRIPTION
## Qué corrige

La PR #63 reapareció porque Release Please 17.3.0 solo aplica exclude-paths a directorios. Las entradas para archivos de primer nivel nunca podían excluir release-please-config.json, por lo que el commit histórico revert seguía considerándose pendiente.

## Solución

- Fija last-release-sha en el merge de #62 para cortar todo el historial Android y de infraestructura ya integrado.
- Mantiene exclude-paths únicamente con directorios que Release Please puede filtrar realmente.
- Excluye tests como superficie no publicable sin ocultar cambios que también toquen código Decky.
- Actualiza el contrato para proteger la frontera y el conjunto exacto de directorios.

## Verificación

- 287 tests Python, 0 fallos.
- Ruff limpio y JSON válido.
- Revisión independiente sin hallazgos Critical o Important.
- Release Please 17.3.0 ejecutado en dry-run contra esta rama: Would open 0 pull requests.

Esta PR no modifica la versión de Decky ni ningún archivo de la aplicación.