### PR TITLE
feat(android): generic LED discovery + Anbernic hardware effects

### DIFF
--- a/android/app/src/main/java/com/hooandee/colores/control/LightingController.kt
+++ b/android/app/src/main/java/com/hooandee/colores/control/LightingController.kt
@@ -220,7 +220,11 @@ class LightingController(
     private suspend fun onReassert() {
         val binding = binding ?: return
         runCatching { binding.device.invalidate() }
-        if (!intent.mode.isDynamic) applyStatic()
+        val hwEffect = hardwareEffect(binding)
+        when {
+            hwEffect != null -> applyHardwareEffect(binding, hwEffect)
+            !intent.mode.isDynamic -> applyStatic()
+        }
     }
 
     private suspend fun onReading(command: Command.WatchReading) {
@@ -229,8 +233,13 @@ class LightingController(
         batteryLevel = command.levelPercent
         batteryPresent = command.present
         temperatureCelsius = command.temperatureCelsius
-        if (effectivePower() != previousEffective && !intent.mode.isDynamic) {
-            applyStatic()
+        if (effectivePower() != previousEffective) {
+            val binding = binding
+            val hwEffect = binding?.let { hardwareEffect(it) }
+            when {
+                hwEffect != null -> applyHardwareEffect(binding, hwEffect)
+                !intent.mode.isDynamic -> applyStatic()
+            }
         }
         publishSnapshot()
     }
@@ -242,15 +251,40 @@ class LightingController(
 
     private fun effectivePower(): Boolean = intent.power && (!intent.chargerOnly || charging)
 
+    private fun hardwareEffect(binding: LightingBinding): String? =
+        if (intent.mode == AppMode.EFFECT) {
+            binding.device.hardwareEffects.firstOrNull { it.id == intent.effectId }?.id
+        } else {
+            null
+        }
+
     private suspend fun reconcile() {
         val binding = binding ?: run { publishSnapshot(); return }
         updateService()
-        if (intent.mode.isDynamic) {
-            ensureRenderJob(binding)
-        } else {
-            stopRenderJob()
-            applyStatic()
+        val hwEffect = hardwareEffect(binding)
+        when {
+            hwEffect != null -> {
+                stopRenderJob()
+                applyHardwareEffect(binding, hwEffect)
+            }
+            intent.mode.isDynamic -> ensureRenderJob(binding)
+            else -> {
+                stopRenderJob()
+                applyStatic()
+            }
         }
+        publishSnapshot()
+    }
+
+    private suspend fun applyHardwareEffect(
+        binding: LightingBinding,
+        effectId: String,
+    ) {
+        val effective = effectivePower()
+        runCatching {
+            binding.device.applyHardwareEffect(effectId, intent.solidColor, intent.brightness, intent.speed, effective)
+        }.rethrowCancellation()
+        lastFrame = if (effective) List(binding.zones) { intent.solidColor } else List(binding.zones) { RgbColor(0, 0, 0) }
         publishSnapshot()
     }
 

--- a/android/app/src/main/java/com/hooandee/colores/control/LightingController.kt
+++ b/android/app/src/main/java/com/hooandee/colores/control/LightingController.kt
@@ -281,10 +281,17 @@ class LightingController(
         effectId: String,
     ) {
         val effective = effectivePower()
+        val stops = binding.device.hardwareEffects.firstOrNull { it.id == effectId }?.colorStops ?: 1
+        val palette = intent.gradientStops.ifEmpty { listOf(intent.solidColor) }
+        val colors =
+            when {
+                stops >= 2 -> listOf(palette.first(), palette.last())
+                else -> listOf(intent.solidColor)
+            }
         runCatching {
-            binding.device.applyHardwareEffect(effectId, intent.solidColor, intent.brightness, intent.speed, effective)
+            binding.device.applyHardwareEffect(effectId, colors, intent.brightness, intent.speed, effective)
         }.rethrowCancellation()
-        lastFrame = if (effective) List(binding.zones) { intent.solidColor } else List(binding.zones) { RgbColor(0, 0, 0) }
+        lastFrame = if (effective) List(binding.zones) { colors.first() } else List(binding.zones) { RgbColor(0, 0, 0) }
         publishSnapshot()
     }
 

--- a/android/app/src/main/java/com/hooandee/colores/control/LightingController.kt
+++ b/android/app/src/main/java/com/hooandee/colores/control/LightingController.kt
@@ -11,6 +11,7 @@ import com.hooandee.colores.engine.PerformanceRenderer
 import com.hooandee.colores.engine.Renderer
 import com.hooandee.colores.engine.StatusTargets
 import com.hooandee.colores.gradient.GradientInterpolator
+import com.hooandee.colores.led.HardwareEffect
 import com.hooandee.colores.led.LedDevice
 import com.hooandee.colores.led.RgbColor
 import com.hooandee.colores.sensor.BatterySource
@@ -220,11 +221,7 @@ class LightingController(
     private suspend fun onReassert() {
         val binding = binding ?: return
         runCatching { binding.device.invalidate() }
-        val hwEffect = hardwareEffect(binding)
-        when {
-            hwEffect != null -> applyHardwareEffect(binding, hwEffect)
-            !intent.mode.isDynamic -> applyStatic()
-        }
+        applyCurrent(binding, manageRenderJob = false)
     }
 
     private suspend fun onReading(command: Command.WatchReading) {
@@ -234,12 +231,7 @@ class LightingController(
         batteryPresent = command.present
         temperatureCelsius = command.temperatureCelsius
         if (effectivePower() != previousEffective) {
-            val binding = binding
-            val hwEffect = binding?.let { hardwareEffect(it) }
-            when {
-                hwEffect != null -> applyHardwareEffect(binding, hwEffect)
-                !intent.mode.isDynamic -> applyStatic()
-            }
+            binding?.let { applyCurrent(it, manageRenderJob = false) }
         }
         publishSnapshot()
     }
@@ -251,9 +243,9 @@ class LightingController(
 
     private fun effectivePower(): Boolean = intent.power && (!intent.chargerOnly || charging)
 
-    private fun hardwareEffect(binding: LightingBinding): String? =
+    private fun hardwareEffect(binding: LightingBinding): HardwareEffect? =
         if (intent.mode == AppMode.EFFECT) {
-            binding.device.hardwareEffects.firstOrNull { it.id == intent.effectId }?.id
+            binding.device.hardwareEffects.firstOrNull { it.id == intent.effectId }
         } else {
             null
         }
@@ -261,35 +253,38 @@ class LightingController(
     private suspend fun reconcile() {
         val binding = binding ?: run { publishSnapshot(); return }
         updateService()
+        applyCurrent(binding, manageRenderJob = true)
+        publishSnapshot()
+    }
+
+    private suspend fun applyCurrent(
+        binding: LightingBinding,
+        manageRenderJob: Boolean,
+    ) {
         val hwEffect = hardwareEffect(binding)
         when {
             hwEffect != null -> {
-                stopRenderJob()
+                if (manageRenderJob) stopRenderJob()
                 applyHardwareEffect(binding, hwEffect)
             }
-            intent.mode.isDynamic -> ensureRenderJob(binding)
+            intent.mode.isDynamic -> if (manageRenderJob) ensureRenderJob(binding)
             else -> {
-                stopRenderJob()
+                if (manageRenderJob) stopRenderJob()
                 applyStatic()
             }
         }
-        publishSnapshot()
     }
 
     private suspend fun applyHardwareEffect(
         binding: LightingBinding,
-        effectId: String,
+        effect: HardwareEffect,
     ) {
         val effective = effectivePower()
-        val stops = binding.device.hardwareEffects.firstOrNull { it.id == effectId }?.colorStops ?: 1
         val palette = intent.gradientStops.ifEmpty { listOf(intent.solidColor) }
         val colors =
-            when {
-                stops >= 2 -> listOf(palette.first(), palette.last())
-                else -> listOf(intent.solidColor)
-            }
+            if (effect.colorStops >= 2) listOf(palette.first(), palette.last()) else listOf(intent.solidColor)
         runCatching {
-            binding.device.applyHardwareEffect(effectId, colors, intent.brightness, intent.speed, effective)
+            binding.device.applyHardwareEffect(effect.id, colors, intent.brightness, intent.speed, effective)
         }.rethrowCancellation()
         lastFrame = if (effective) List(binding.zones) { colors.first() } else List(binding.zones) { RgbColor(0, 0, 0) }
         publishSnapshot()

--- a/android/app/src/main/java/com/hooandee/colores/device/AndroidDeviceDetector.kt
+++ b/android/app/src/main/java/com/hooandee/colores/device/AndroidDeviceDetector.kt
@@ -50,11 +50,12 @@ class AndroidDeviceDetector(
             runCatching { readIdentity() }.getOrElse {
                 AndroidDeviceIdentity(model = "", device = "", manufacturer = "", productProperties = emptyMap())
             }
+        val pserver = runCatching { pserverAvailable() }.getOrDefault(false)
         return modelMatch(identity)
             ?: GenericLedResolver.vendor(
                 identity,
-                pserverAvailable = runCatching { pserverAvailable() }.getOrDefault(false),
-                colorKeyValue = runCatching { readSetting(GenericVendorLed.COLOR_KEY) }.getOrNull(),
+                pserverAvailable = pserver,
+                colorKeyValue = if (pserver) runCatching { readSetting(GenericVendorLed.COLOR_KEY) }.getOrNull() else null,
             )
             ?: GenericLedResolver.joypad(identity, runCatching { scanJoypad() }.getOrNull())
             ?: GenericLedResolver.sysfs(identity, runCatching { scanSysfs() }.getOrNull())

--- a/android/app/src/main/java/com/hooandee/colores/device/AndroidDeviceDetector.kt
+++ b/android/app/src/main/java/com/hooandee/colores/device/AndroidDeviceDetector.kt
@@ -2,6 +2,10 @@ package com.hooandee.colores.device
 
 import android.content.Context
 import android.os.Build
+import android.provider.Settings
+import com.hooandee.colores.led.AndroidPServerCommandExecutor
+import com.hooandee.colores.led.LedDescriptor
+import com.hooandee.colores.led.SysfsRgbDescriptor
 import java.util.concurrent.TimeUnit
 
 data class AndroidDeviceIdentity(
@@ -15,13 +19,17 @@ data class DetectedAndroidDevice(
     val id: String,
     val friendlyName: String,
     val capabilities: DeviceCapabilities,
-    val led: com.hooandee.colores.led.SettingsProviderDescriptor,
+    val led: LedDescriptor,
     val previewProfileId: String?,
     val previewCalibration: LedPreviewCalibration?,
+    val gridLayout: List<LedGridCell>? = null,
 )
 
 class AndroidDeviceDetector(
     private val context: Context,
+    private val pserverAvailable: () -> Boolean = { AndroidPServerCommandExecutor().available },
+    private val readSetting: (String) -> String? = { key -> Settings.System.getString(context.contentResolver, key) },
+    private val scanSysfs: () -> SysfsRgbDescriptor? = { SysfsRgbDiscovery.scan() },
 ) {
     fun readIdentity(): AndroidDeviceIdentity {
         val properties =
@@ -35,12 +43,26 @@ class AndroidDeviceDetector(
         )
     }
 
-    fun detect(): DetectedAndroidDevice? =
+    fun detect(): DetectedAndroidDevice? {
+        val identity =
+            runCatching { readIdentity() }.getOrElse {
+                AndroidDeviceIdentity(model = "", device = "", manufacturer = "", productProperties = emptyMap())
+            }
+        return modelMatch(identity)
+            ?: GenericLedResolver.vendor(
+                identity,
+                pserverAvailable = runCatching { pserverAvailable() }.getOrDefault(false),
+                colorKeyValue = runCatching { readSetting(GenericVendorLed.COLOR_KEY) }.getOrNull(),
+            )
+            ?: GenericLedResolver.sysfs(identity, runCatching { scanSysfs() }.getOrNull())
+    }
+
+    private fun modelMatch(identity: AndroidDeviceIdentity): DetectedAndroidDevice? =
         runCatching {
             DeviceRegistry.parse(
                 devicesJson = context.readAsset("devices.json"),
                 previewProfilesJson = context.readAsset("led-preview-profiles.json"),
-            ).match(readIdentity())
+            ).match(identity)
         }.getOrNull()
 
     private fun readProperty(name: String): String =

--- a/android/app/src/main/java/com/hooandee/colores/device/AndroidDeviceDetector.kt
+++ b/android/app/src/main/java/com/hooandee/colores/device/AndroidDeviceDetector.kt
@@ -5,6 +5,7 @@ import android.os.Build
 import android.provider.Settings
 import com.hooandee.colores.led.AndroidPServerCommandExecutor
 import com.hooandee.colores.led.LedDescriptor
+import com.hooandee.colores.led.SingleAdcJoypadDescriptor
 import com.hooandee.colores.led.SysfsRgbDescriptor
 import java.util.concurrent.TimeUnit
 
@@ -29,6 +30,7 @@ class AndroidDeviceDetector(
     private val context: Context,
     private val pserverAvailable: () -> Boolean = { AndroidPServerCommandExecutor().available },
     private val readSetting: (String) -> String? = { key -> Settings.System.getString(context.contentResolver, key) },
+    private val scanJoypad: () -> SingleAdcJoypadDescriptor? = { SingleAdcJoypadDiscovery.scan() },
     private val scanSysfs: () -> SysfsRgbDescriptor? = { SysfsRgbDiscovery.scan() },
 ) {
     fun readIdentity(): AndroidDeviceIdentity {
@@ -54,6 +56,7 @@ class AndroidDeviceDetector(
                 pserverAvailable = runCatching { pserverAvailable() }.getOrDefault(false),
                 colorKeyValue = runCatching { readSetting(GenericVendorLed.COLOR_KEY) }.getOrNull(),
             )
+            ?: GenericLedResolver.joypad(identity, runCatching { scanJoypad() }.getOrNull())
             ?: GenericLedResolver.sysfs(identity, runCatching { scanSysfs() }.getOrNull())
     }
 

--- a/android/app/src/main/java/com/hooandee/colores/device/DeviceRegistry.kt
+++ b/android/app/src/main/java/com/hooandee/colores/device/DeviceRegistry.kt
@@ -63,6 +63,7 @@ class DeviceRegistry internal constructor(
                                     }
                                 }
                             val previewProfileId = entry.optString("previewProfile").takeIf(String::isNotBlank)
+                            val gridLayout = parseGridLayout(android.optJSONArray("gridLayout"), zones)
                             AndroidDeviceDefinition(
                                 models = android.getStringList("model"),
                                 devices = android.getStringList("device"),
@@ -100,6 +101,7 @@ class DeviceRegistry internal constructor(
                                             ),
                                         previewProfileId = previewProfileId,
                                         previewCalibration = previewProfileId?.let(previewProfiles::get),
+                                        gridLayout = gridLayout,
                                     ),
                             )
                         }.getOrNull()
@@ -107,6 +109,36 @@ class DeviceRegistry internal constructor(
                 DeviceRegistry(definitions)
             }.getOrElse { DeviceRegistry(emptyList()) }
     }
+}
+
+private val GRID_POSITIONS =
+    setOf("top", "left", "bottom", "right", "top_left", "top_right", "bottom_left", "bottom_right")
+
+private fun parseGridLayout(
+    array: org.json.JSONArray?,
+    zones: Int,
+): List<LedGridCell>? {
+    if (array == null) return null
+    return runCatching {
+        val cells =
+            (0 until array.length()).map { index ->
+                val cell = array.getJSONObject(index)
+                val position =
+                    if (cell.isNull("position")) {
+                        null
+                    } else {
+                        cell.getString("position").lowercase().also { require(it in GRID_POSITIONS) }
+                    }
+                LedGridCell(
+                    stick = if (cell.isNull("stick")) null else cell.getInt("stick"),
+                    row = cell.getInt("row"),
+                    col = cell.getInt("col"),
+                    position = position,
+                )
+            }
+        require(cells.size == zones)
+        cells
+    }.getOrNull()
 }
 
 private fun parsePreviewProfiles(json: String): Map<String, LedPreviewCalibration> =

--- a/android/app/src/main/java/com/hooandee/colores/device/GenericLedResolver.kt
+++ b/android/app/src/main/java/com/hooandee/colores/device/GenericLedResolver.kt
@@ -1,5 +1,6 @@
 package com.hooandee.colores.device
 
+import com.hooandee.colores.led.LedDescriptor
 import com.hooandee.colores.led.SingleAdcJoypadDescriptor
 import com.hooandee.colores.led.SysfsRgbDescriptor
 
@@ -8,21 +9,6 @@ internal object GenericLedResolver {
     const val SYSFS_ID = "generic-sysfs"
     const val JOYPAD_ID = "generic-joypad"
 
-    fun joypad(
-        identity: AndroidDeviceIdentity,
-        descriptor: SingleAdcJoypadDescriptor?,
-    ): DetectedAndroidDevice? {
-        if (descriptor == null) return null
-        return DetectedAndroidDevice(
-            id = JOYPAD_ID,
-            friendlyName = identity.friendlyName(),
-            capabilities = DeviceCapabilities(color = true, brightness = true, perZone = false, zones = 1),
-            led = descriptor,
-            previewProfileId = null,
-            previewCalibration = null,
-        )
-    }
-
     fun vendor(
         identity: AndroidDeviceIdentity,
         pserverAvailable: Boolean,
@@ -30,36 +16,33 @@ internal object GenericLedResolver {
     ): DetectedAndroidDevice? {
         if (!pserverAvailable || colorKeyValue.isNullOrBlank()) return null
         val zones = GenericVendorLed.DEFAULT_ZONES
-        return DetectedAndroidDevice(
-            id = VENDOR_ID,
-            friendlyName = identity.friendlyName(),
-            capabilities = DeviceCapabilities(color = true, brightness = true, perZone = zones > 1, zones = zones),
-            led = GenericVendorLed.descriptor(zones),
-            previewProfileId = null,
-            previewCalibration = null,
-        )
+        return build(VENDOR_ID, identity, zones, GenericVendorLed.descriptor(zones))
     }
+
+    fun joypad(
+        identity: AndroidDeviceIdentity,
+        descriptor: SingleAdcJoypadDescriptor?,
+    ): DetectedAndroidDevice? = descriptor?.let { build(JOYPAD_ID, identity, 1, it) }
 
     fun sysfs(
         identity: AndroidDeviceIdentity,
         descriptor: SysfsRgbDescriptor?,
-    ): DetectedAndroidDevice? {
-        if (descriptor == null) return null
-        return DetectedAndroidDevice(
-            id = SYSFS_ID,
+    ): DetectedAndroidDevice? = descriptor?.let { build(SYSFS_ID, identity, it.zones, it) }
+
+    private fun build(
+        id: String,
+        identity: AndroidDeviceIdentity,
+        zones: Int,
+        led: LedDescriptor,
+    ): DetectedAndroidDevice =
+        DetectedAndroidDevice(
+            id = id,
             friendlyName = identity.friendlyName(),
-            capabilities =
-                DeviceCapabilities(
-                    color = true,
-                    brightness = true,
-                    perZone = descriptor.zones > 1,
-                    zones = descriptor.zones,
-                ),
-            led = descriptor,
+            capabilities = DeviceCapabilities(color = true, brightness = true, perZone = zones > 1, zones = zones),
+            led = led,
             previewProfileId = null,
             previewCalibration = null,
         )
-    }
 
     private fun AndroidDeviceIdentity.friendlyName(): String =
         model.ifBlank { manufacturer }.ifBlank { device }.ifBlank { "RGB" }

--- a/android/app/src/main/java/com/hooandee/colores/device/GenericLedResolver.kt
+++ b/android/app/src/main/java/com/hooandee/colores/device/GenericLedResolver.kt
@@ -1,0 +1,49 @@
+package com.hooandee.colores.device
+
+import com.hooandee.colores.led.SysfsRgbDescriptor
+
+internal object GenericLedResolver {
+    const val VENDOR_ID = "generic-vendor"
+    const val SYSFS_ID = "generic-sysfs"
+
+    fun vendor(
+        identity: AndroidDeviceIdentity,
+        pserverAvailable: Boolean,
+        colorKeyValue: String?,
+    ): DetectedAndroidDevice? {
+        if (!pserverAvailable || colorKeyValue.isNullOrBlank()) return null
+        val zones = GenericVendorLed.DEFAULT_ZONES
+        return DetectedAndroidDevice(
+            id = VENDOR_ID,
+            friendlyName = identity.friendlyName(),
+            capabilities = DeviceCapabilities(color = true, brightness = true, perZone = zones > 1, zones = zones),
+            led = GenericVendorLed.descriptor(zones),
+            previewProfileId = null,
+            previewCalibration = null,
+        )
+    }
+
+    fun sysfs(
+        identity: AndroidDeviceIdentity,
+        descriptor: SysfsRgbDescriptor?,
+    ): DetectedAndroidDevice? {
+        if (descriptor == null) return null
+        return DetectedAndroidDevice(
+            id = SYSFS_ID,
+            friendlyName = identity.friendlyName(),
+            capabilities =
+                DeviceCapabilities(
+                    color = true,
+                    brightness = true,
+                    perZone = descriptor.zones > 1,
+                    zones = descriptor.zones,
+                ),
+            led = descriptor,
+            previewProfileId = null,
+            previewCalibration = null,
+        )
+    }
+
+    private fun AndroidDeviceIdentity.friendlyName(): String =
+        model.ifBlank { manufacturer }.ifBlank { device }.ifBlank { "RGB" }
+}

--- a/android/app/src/main/java/com/hooandee/colores/device/GenericLedResolver.kt
+++ b/android/app/src/main/java/com/hooandee/colores/device/GenericLedResolver.kt
@@ -1,10 +1,27 @@
 package com.hooandee.colores.device
 
+import com.hooandee.colores.led.SingleAdcJoypadDescriptor
 import com.hooandee.colores.led.SysfsRgbDescriptor
 
 internal object GenericLedResolver {
     const val VENDOR_ID = "generic-vendor"
     const val SYSFS_ID = "generic-sysfs"
+    const val JOYPAD_ID = "generic-joypad"
+
+    fun joypad(
+        identity: AndroidDeviceIdentity,
+        descriptor: SingleAdcJoypadDescriptor?,
+    ): DetectedAndroidDevice? {
+        if (descriptor == null) return null
+        return DetectedAndroidDevice(
+            id = JOYPAD_ID,
+            friendlyName = identity.friendlyName(),
+            capabilities = DeviceCapabilities(color = true, brightness = true, perZone = false, zones = 1),
+            led = descriptor,
+            previewProfileId = null,
+            previewCalibration = null,
+        )
+    }
 
     fun vendor(
         identity: AndroidDeviceIdentity,

--- a/android/app/src/main/java/com/hooandee/colores/device/GenericVendorLed.kt
+++ b/android/app/src/main/java/com/hooandee/colores/device/GenericVendorLed.kt
@@ -5,7 +5,14 @@ import com.hooandee.colores.led.SettingsProviderDescriptor
 internal object GenericVendorLed {
     const val COLOR_KEY = "joystick_led_light_picker_color"
     const val BRIGHTNESS_KEY = "led_light_brightness_percent"
-    val ENABLE_KEYS = listOf("joystick_light_enabled", "left_joystick_light_enabled", "right_joystick_light_enabled")
+    val ENABLE_KEYS =
+        listOf(
+            "joystick_light_enabled",
+            "left_joystick_light_enabled",
+            "right_joystick_light_enabled",
+            "left_handle_light_enabled",
+            "right_handle_light_enabled",
+        )
     const val DEFAULT_ZONES = 2
 
     fun descriptor(zones: Int = DEFAULT_ZONES): SettingsProviderDescriptor =

--- a/android/app/src/main/java/com/hooandee/colores/device/GenericVendorLed.kt
+++ b/android/app/src/main/java/com/hooandee/colores/device/GenericVendorLed.kt
@@ -1,0 +1,24 @@
+package com.hooandee.colores.device
+
+import com.hooandee.colores.led.SettingsProviderDescriptor
+
+internal object GenericVendorLed {
+    const val COLOR_KEY = "joystick_led_light_picker_color"
+    const val BRIGHTNESS_KEY = "led_light_brightness_percent"
+    val ENABLE_KEYS = listOf("joystick_light_enabled", "left_joystick_light_enabled", "right_joystick_light_enabled")
+    const val DEFAULT_ZONES = 2
+
+    fun descriptor(zones: Int = DEFAULT_ZONES): SettingsProviderDescriptor =
+        SettingsProviderDescriptor(
+            driver = "settings_provider",
+            transport = "pserver",
+            colorKey = COLOR_KEY,
+            colorFormat = "argb_hex_csv",
+            brightnessKey = BRIGHTNESS_KEY,
+            brightnessRange = 0f..1f,
+            enableKeys = ENABLE_KEYS,
+            zones = zones,
+            requiresPermission = null,
+            vendorService = "",
+        )
+}

--- a/android/app/src/main/java/com/hooandee/colores/device/LedGridLayout.kt
+++ b/android/app/src/main/java/com/hooandee/colores/device/LedGridLayout.kt
@@ -1,0 +1,8 @@
+package com.hooandee.colores.device
+
+data class LedGridCell(
+    val stick: Int?,
+    val row: Int,
+    val col: Int,
+    val position: String?,
+)

--- a/android/app/src/main/java/com/hooandee/colores/device/SingleAdcJoypadDiscovery.kt
+++ b/android/app/src/main/java/com/hooandee/colores/device/SingleAdcJoypadDiscovery.kt
@@ -1,0 +1,17 @@
+package com.hooandee.colores.device
+
+import com.hooandee.colores.led.FileSysfsAccess
+import com.hooandee.colores.led.SingleAdcJoypadDescriptor
+import com.hooandee.colores.led.SysfsAccess
+
+object SingleAdcJoypadDiscovery {
+    fun scan(
+        basePath: String = SingleAdcJoypadDescriptor.DEFAULT_BASE_PATH,
+        access: SysfsAccess = FileSysfsAccess,
+    ): SingleAdcJoypadDescriptor? {
+        val color = "$basePath/custum_rgb_r"
+        val commit = "$basePath/led_set"
+        if (!access.exists(color) || !access.canWrite(color) || !access.canWrite(commit)) return null
+        return SingleAdcJoypadDescriptor(basePath)
+    }
+}

--- a/android/app/src/main/java/com/hooandee/colores/device/SysfsRgbDiscovery.kt
+++ b/android/app/src/main/java/com/hooandee/colores/device/SysfsRgbDiscovery.kt
@@ -1,0 +1,78 @@
+package com.hooandee.colores.device
+
+import com.hooandee.colores.led.FileSysfsAccess
+import com.hooandee.colores.led.SysfsAccess
+import com.hooandee.colores.led.SysfsColorKind
+import com.hooandee.colores.led.SysfsRgbDescriptor
+import java.io.File
+
+data class SysfsLedNode(
+    val name: String,
+    val path: String,
+)
+
+object SysfsRgbDiscovery {
+    private const val DEFAULT_ROOT = "/sys/class/leds"
+    private val CHANNEL_NAMES = setOf("red", "green", "blue")
+    private val EXCLUDED_NAME =
+        Regex(
+            "notif|status|charg|button|kbd|keyboard|backlight|lcd|flash|torch|indicator|mic|wlan|wifi|bt|lte|caps|numlock|mmc|power|batt",
+            RegexOption.IGNORE_CASE,
+        )
+    private val PREFERRED_NAME =
+        Regex("joystick|stick|ring|rgb|gamepad", RegexOption.IGNORE_CASE)
+
+    fun scan(
+        root: String = DEFAULT_ROOT,
+        access: SysfsAccess = FileSysfsAccess,
+    ): SysfsRgbDescriptor? = discover(readNodes(root), access)
+
+    fun discover(
+        nodes: List<SysfsLedNode>,
+        access: SysfsAccess,
+    ): SysfsRgbDescriptor? {
+        val candidates =
+            nodes
+                .filterNot { EXCLUDED_NAME.containsMatchIn(it.name) }
+                .sortedBy { if (PREFERRED_NAME.containsMatchIn(it.name)) 0 else 1 }
+        return candidates.firstNotNullOfOrNull { describe(it, access) }
+    }
+
+    private fun describe(
+        node: SysfsLedNode,
+        access: SysfsAccess,
+    ): SysfsRgbDescriptor? {
+        val multiIntensity = "${node.path}/multi_intensity"
+        if (access.exists(multiIntensity) && access.canWrite(multiIntensity)) {
+            val tokens = access.read("${node.path}/multi_index").orEmpty().split(Regex("\\s+")).filter(String::isNotBlank)
+            val decimal = tokens.isNotEmpty() && tokens.all { it.lowercase() in CHANNEL_NAMES }
+            val zones = if (decimal) maxOf(1, tokens.size / 3) else maxOf(1, tokens.size)
+            return SysfsRgbDescriptor(
+                nodePath = node.path,
+                zones = zones,
+                maxBrightness = maxBrightness(node, access),
+                kind = if (decimal) SysfsColorKind.MULTI_INTENSITY_DECIMAL else SysfsColorKind.MULTI_INTENSITY_HEX,
+            )
+        }
+        val channels = CHANNEL_NAMES.map { "${node.path}/$it" }
+        if (channels.all(access::exists) && channels.all(access::canWrite)) {
+            return SysfsRgbDescriptor(
+                nodePath = node.path,
+                zones = 1,
+                maxBrightness = maxBrightness(node, access),
+                kind = SysfsColorKind.RGB_CHANNELS,
+            )
+        }
+        return null
+    }
+
+    private fun maxBrightness(
+        node: SysfsLedNode,
+        access: SysfsAccess,
+    ): Int = access.read("${node.path}/max_brightness")?.toIntOrNull()?.takeIf { it > 0 } ?: 255
+
+    private fun readNodes(root: String): List<SysfsLedNode> =
+        runCatching {
+            File(root).listFiles()?.filter(File::isDirectory)?.map { SysfsLedNode(it.name, it.absolutePath) }.orEmpty()
+        }.getOrDefault(emptyList())
+}

--- a/android/app/src/main/java/com/hooandee/colores/led/Htr3212LedDevice.kt
+++ b/android/app/src/main/java/com/hooandee/colores/led/Htr3212LedDevice.kt
@@ -172,7 +172,7 @@ internal class Htr3212LedDevice internal constructor(
         }
         if (previous?.power != state.power) {
             changed = true
-            val values = SettingsProviderCodec.encodePower(state.power, STICKS)
+            val values = SettingsProviderCodec.encodePower(state.power, STICKS, descriptor.enableKeys.size)
             descriptor.enableKeys.zip(values).forEach { (key, value) ->
                 if (!store.put(key, value)) succeeded = false
             }

--- a/android/app/src/main/java/com/hooandee/colores/led/LedDevice.kt
+++ b/android/app/src/main/java/com/hooandee/colores/led/LedDevice.kt
@@ -14,10 +14,13 @@ data class LedState(
 
 data class HardwareEffect(
     val id: String,
-    val needsColor: Boolean,
+    val colorStops: Int,
     val defaultSpeed: Int,
     val colors: List<RgbColor>,
-)
+) {
+    val needsColor: Boolean
+        get() = colorStops > 0
+}
 
 interface LedDevice {
     val available: Boolean
@@ -45,7 +48,7 @@ interface LedDevice {
 
     suspend fun applyHardwareEffect(
         effectId: String,
-        color: RgbColor,
+        colors: List<RgbColor>,
         brightness: Int,
         speed: Int,
         power: Boolean,

--- a/android/app/src/main/java/com/hooandee/colores/led/LedDevice.kt
+++ b/android/app/src/main/java/com/hooandee/colores/led/LedDevice.kt
@@ -12,9 +12,19 @@ data class LedState(
     val power: Boolean,
 )
 
+data class HardwareEffect(
+    val id: String,
+    val needsColor: Boolean,
+    val defaultSpeed: Int,
+    val colors: List<RgbColor>,
+)
+
 interface LedDevice {
     val available: Boolean
     val supportsPerZone: Boolean
+
+    val hardwareEffects: List<HardwareEffect>
+        get() = emptyList()
 
     val recommendedFrameIntervalMs: Long
         get() = 80L
@@ -32,6 +42,14 @@ interface LedDevice {
         brightness: Int,
         power: Boolean,
     ): Boolean
+
+    suspend fun applyHardwareEffect(
+        effectId: String,
+        color: RgbColor,
+        brightness: Int,
+        speed: Int,
+        power: Boolean,
+    ): Boolean = false
 
     fun invalidate()
 }

--- a/android/app/src/main/java/com/hooandee/colores/led/LedDevice.kt
+++ b/android/app/src/main/java/com/hooandee/colores/led/LedDevice.kt
@@ -56,3 +56,8 @@ interface LedDevice {
 
     fun invalidate()
 }
+
+internal fun List<RgbColor>.fitZones(zones: Int): List<RgbColor> {
+    val fallback = firstOrNull() ?: RgbColor(255, 255, 255)
+    return List(zones.coerceAtLeast(1)) { getOrNull(it) ?: fallback }
+}

--- a/android/app/src/main/java/com/hooandee/colores/led/LedDeviceFactory.kt
+++ b/android/app/src/main/java/com/hooandee/colores/led/LedDeviceFactory.kt
@@ -17,5 +17,6 @@ internal object LedDeviceFactory {
                     else -> null
                 }
             is SysfsRgbDescriptor -> SysfsRgbDevice(descriptor, scope)
+            is SingleAdcJoypadDescriptor -> SingleAdcJoypadLedDevice(descriptor, scope)
         }
 }

--- a/android/app/src/main/java/com/hooandee/colores/led/LedDeviceFactory.kt
+++ b/android/app/src/main/java/com/hooandee/colores/led/LedDeviceFactory.kt
@@ -6,12 +6,16 @@ import kotlinx.coroutines.CoroutineScope
 internal object LedDeviceFactory {
     fun create(
         context: Context,
-        descriptor: SettingsProviderDescriptor,
+        descriptor: LedDescriptor,
         scope: CoroutineScope,
     ): LedDevice? =
-        when (descriptor.driver) {
-            "settings_provider" -> SettingsProviderLedDevice(context, descriptor, scope)
-            "htr3212" -> Htr3212LedDevice(context, descriptor, scope)
-            else -> null
+        when (descriptor) {
+            is SettingsProviderDescriptor ->
+                when (descriptor.driver) {
+                    "settings_provider" -> SettingsProviderLedDevice(context, descriptor, scope)
+                    "htr3212" -> Htr3212LedDevice(context, descriptor, scope)
+                    else -> null
+                }
+            is SysfsRgbDescriptor -> SysfsRgbDevice(descriptor, scope)
         }
 }

--- a/android/app/src/main/java/com/hooandee/colores/led/SettingsProviderLedDevice.kt
+++ b/android/app/src/main/java/com/hooandee/colores/led/SettingsProviderLedDevice.kt
@@ -10,6 +10,8 @@ import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 import kotlin.math.roundToInt
 
+sealed interface LedDescriptor
+
 data class SettingsProviderDescriptor(
     val driver: String,
     val transport: String = "direct",
@@ -22,7 +24,7 @@ data class SettingsProviderDescriptor(
     val requiresPermission: String?,
     val vendorService: String,
     val htr3212: Htr3212Descriptor? = null,
-)
+) : LedDescriptor
 
 data class Htr3212Descriptor(
     val leftBus: Int,

--- a/android/app/src/main/java/com/hooandee/colores/led/SettingsProviderLedDevice.kt
+++ b/android/app/src/main/java/com/hooandee/colores/led/SettingsProviderLedDevice.kt
@@ -69,7 +69,6 @@ class SettingsProviderLedDevice internal constructor(
                 power = descriptor.enableKeys.mapNotNull(store::get).joinToString(",").ifBlank { null },
                 descriptor = descriptor,
             )
-        cachedState = state
         return state
     }
 
@@ -103,7 +102,7 @@ class SettingsProviderLedDevice internal constructor(
             }
         }
         if (previous?.power != state.power) {
-            val values = SettingsProviderCodec.encodePower(state.power, descriptor.zones)
+            val values = SettingsProviderCodec.encodePower(state.power, descriptor.zones, descriptor.enableKeys.size)
             descriptor.enableKeys.zip(values).forEach { (key, value) ->
                 if (!store.put(key, value)) succeeded = false
             }
@@ -168,9 +167,11 @@ internal object SettingsProviderCodec {
     fun encodePower(
         power: Boolean,
         zones: Int,
+        keyCount: Int = 3,
     ): List<String> {
         val value = if (power) "1" else "0"
-        return listOf(List(zones) { value }.joinToString(","), value, value)
+        val master = List(zones) { value }.joinToString(",")
+        return List(keyCount.coerceAtLeast(1)) { index -> if (index == 0) master else value }
     }
 
     fun decode(

--- a/android/app/src/main/java/com/hooandee/colores/led/SettingsProviderLedDevice.kt
+++ b/android/app/src/main/java/com/hooandee/colores/led/SettingsProviderLedDevice.kt
@@ -243,7 +243,3 @@ internal class ConflatedLedWriter<T>(
     fun submit(value: T): Boolean = channel.trySend(value).isSuccess
 }
 
-private fun List<RgbColor>.fitZones(zones: Int): List<RgbColor> {
-    val fallback = firstOrNull() ?: RgbColor(255, 255, 255)
-    return List(zones.coerceAtLeast(1)) { index -> getOrNull(index) ?: fallback }
-}

--- a/android/app/src/main/java/com/hooandee/colores/led/SingleAdcJoypadLedDevice.kt
+++ b/android/app/src/main/java/com/hooandee/colores/led/SingleAdcJoypadLedDevice.kt
@@ -3,6 +3,7 @@ package com.hooandee.colores.led
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
+import kotlin.math.roundToInt
 
 data class SingleAdcJoypadDescriptor(
     val basePath: String = DEFAULT_BASE_PATH,
@@ -22,12 +23,15 @@ class SingleAdcJoypadLedDevice internal constructor(
         scope: CoroutineScope = CoroutineScope(SupervisorJob() + Dispatchers.IO),
     ) : this(descriptor, FileSysfsAccess, scope)
 
-    private val writer = ConflatedLedWriter(scope, WRITE_INTERVAL_MS, write = ::writeState)
+    private val writer = ConflatedLedWriter(scope, WRITE_INTERVAL_MS, write = ::writeFrame)
 
     override val available: Boolean
         get() = access.canWrite(node("custum_rgb_r")) && access.canWrite(node("led_set"))
 
     override val supportsPerZone: Boolean = false
+
+    override val hardwareEffects: List<HardwareEffect> =
+        EFFECTS.map { HardwareEffect(it.id, it.needsColor, it.defaultSpeed, it.previewColors) }
 
     override suspend fun readState(): LedState {
         val color =
@@ -47,7 +51,17 @@ class SingleAdcJoypadLedDevice internal constructor(
         colors: List<RgbColor>,
         brightness: Int,
         power: Boolean,
-    ): Boolean = writer.submit(LedState(listOf(colors.firstOrNull() ?: RgbColor(255, 255, 255)), brightness.coerceIn(0, 100), power))
+    ): Boolean =
+        writer.submit(
+            Frame(
+                color = colors.firstOrNull() ?: RgbColor(255, 255, 255),
+                brightness = brightness.coerceIn(0, 100),
+                power = power,
+                ledMode = STATIC_MODE,
+                speed = 0,
+                colored = true,
+            ),
+        )
 
     override suspend fun applySolid(
         color: RgbColor,
@@ -55,10 +69,29 @@ class SingleAdcJoypadLedDevice internal constructor(
         power: Boolean,
     ): Boolean = applyZones(listOf(color), brightness, power)
 
+    override suspend fun applyHardwareEffect(
+        effectId: String,
+        color: RgbColor,
+        brightness: Int,
+        speed: Int,
+        power: Boolean,
+    ): Boolean {
+        val spec = EFFECTS.firstOrNull { it.id == effectId } ?: return false
+        return writer.submit(
+            Frame(
+                color = color,
+                brightness = brightness.coerceIn(0, 100),
+                power = power,
+                ledMode = spec.ledMode,
+                speed = mapSpeed(speed),
+                colored = spec.needsColor,
+            ),
+        )
+    }
+
     override fun invalidate() = Unit
 
-    private fun writeState(state: LedState): Boolean {
-        val color = state.zoneColors.first()
+    private fun writeFrame(frame: Frame): Boolean {
         var succeeded = true
         fun put(
             name: String,
@@ -66,19 +99,31 @@ class SingleAdcJoypadLedDevice internal constructor(
         ) {
             if (!access.write(node(name), "$value\n")) succeeded = false
         }
-        if (state.power) {
-            put("custum_rgb_r", color.red.coerceIn(0, 255))
-            put("custum_rgb_g", color.green.coerceIn(0, 255))
-            put("custum_rgb_b", color.blue.coerceIn(0, 255))
-            put("led_level", state.brightness)
-            put("led_mode", STATIC_MODE)
-            put("led_switch", 1)
-        } else {
+        if (!frame.power) {
             put("led_switch", 0)
+            put("led_set", 1)
+            return succeeded
         }
+        val c = frame.color
+        put("custum_rgb_r", c.red.coerceIn(0, 255))
+        put("custum_rgb_g", c.green.coerceIn(0, 255))
+        put("custum_rgb_b", c.blue.coerceIn(0, 255))
+        val zone = if (frame.colored) c else RgbColor(0, 0, 0)
+        put("Led_rgb_r1", zone.red.coerceIn(0, 255))
+        put("Led_rgb_g1", zone.green.coerceIn(0, 255))
+        put("Led_rgb_b1", zone.blue.coerceIn(0, 255))
+        put("Led_rgb_r2", zone.red.coerceIn(0, 255))
+        put("Led_rgb_g2", zone.green.coerceIn(0, 255))
+        put("Led_rgb_b2", zone.blue.coerceIn(0, 255))
+        put("led_level", frame.brightness)
+        put("led_speed", frame.speed)
+        put("led_mode", frame.ledMode)
+        put("led_switch", 1)
         put("led_set", 1)
         return succeeded
     }
+
+    private fun mapSpeed(percent: Int): Int = ((percent.coerceIn(0, 100) / 100.0) * MAX_SPEED).roundToInt().coerceIn(0, MAX_SPEED)
 
     private fun readInt(
         name: String,
@@ -87,8 +132,38 @@ class SingleAdcJoypadLedDevice internal constructor(
 
     private fun node(name: String): String = "${descriptor.basePath}/$name"
 
+    private data class Frame(
+        val color: RgbColor,
+        val brightness: Int,
+        val power: Boolean,
+        val ledMode: Int,
+        val speed: Int,
+        val colored: Boolean,
+    )
+
+    private data class EffectSpec(
+        val id: String,
+        val ledMode: Int,
+        val needsColor: Boolean,
+        val defaultSpeed: Int,
+        val previewColors: List<RgbColor>,
+    )
+
     private companion object {
         const val WRITE_INTERVAL_MS = 80L
         const val STATIC_MODE = 1
+        const val MAX_SPEED = 8
+
+        private val RAINBOW =
+            listOf(RgbColor(255, 0, 0), RgbColor(0, 255, 0), RgbColor(0, 0, 255))
+
+        val EFFECTS =
+            listOf(
+                EffectSpec("breathing", ledMode = 2, needsColor = true, defaultSpeed = 50, previewColors = listOf(RgbColor(93, 81, 255))),
+                EffectSpec("rainbow", ledMode = 3, needsColor = false, defaultSpeed = 50, previewColors = RAINBOW),
+                EffectSpec("marquee", ledMode = 4, needsColor = false, defaultSpeed = 50, previewColors = RAINBOW),
+                EffectSpec("chasing", ledMode = 5, needsColor = true, defaultSpeed = 50, previewColors = listOf(RgbColor(93, 81, 255))),
+                EffectSpec("gaming", ledMode = 6, needsColor = false, defaultSpeed = 50, previewColors = RAINBOW),
+            )
     }
 }

--- a/android/app/src/main/java/com/hooandee/colores/led/SingleAdcJoypadLedDevice.kt
+++ b/android/app/src/main/java/com/hooandee/colores/led/SingleAdcJoypadLedDevice.kt
@@ -110,18 +110,19 @@ class SingleAdcJoypadLedDevice internal constructor(
             put("led_set", 1)
             return succeeded
         }
-        val c = frame.color
-        put("custum_rgb_r", c.red.coerceIn(0, 255))
-        put("custum_rgb_g", c.green.coerceIn(0, 255))
-        put("custum_rgb_b", c.blue.coerceIn(0, 255))
-        val zone1 = if (frame.colored) c else RgbColor(0, 0, 0)
-        val zone2 = if (frame.colored) frame.secondColor else RgbColor(0, 0, 0)
-        put("Led_rgb_r1", zone1.red.coerceIn(0, 255))
-        put("Led_rgb_g1", zone1.green.coerceIn(0, 255))
-        put("Led_rgb_b1", zone1.blue.coerceIn(0, 255))
-        put("Led_rgb_r2", zone2.red.coerceIn(0, 255))
-        put("Led_rgb_g2", zone2.green.coerceIn(0, 255))
-        put("Led_rgb_b2", zone2.blue.coerceIn(0, 255))
+        val main = frame.color
+        val follow = if (frame.colored) frame.secondColor else main
+        put("custum_rgb_r", main.red.coerceIn(0, 255))
+        put("custum_rgb_g", main.green.coerceIn(0, 255))
+        put("custum_rgb_b", main.blue.coerceIn(0, 255))
+        val slotMain = if (frame.colored) main else RgbColor(0, 0, 0)
+        val slotFollow = if (frame.colored) follow else RgbColor(0, 0, 0)
+        put("Led_rgb_r2", slotMain.red.coerceIn(0, 255))
+        put("Led_rgb_g2", slotMain.green.coerceIn(0, 255))
+        put("Led_rgb_b2", slotMain.blue.coerceIn(0, 255))
+        put("Led_rgb_r1", slotFollow.red.coerceIn(0, 255))
+        put("Led_rgb_g1", slotFollow.green.coerceIn(0, 255))
+        put("Led_rgb_b1", slotFollow.blue.coerceIn(0, 255))
         put("led_level", frame.brightness)
         put("led_speed", frame.speed)
         put("led_mode", frame.ledMode)

--- a/android/app/src/main/java/com/hooandee/colores/led/SingleAdcJoypadLedDevice.kt
+++ b/android/app/src/main/java/com/hooandee/colores/led/SingleAdcJoypadLedDevice.kt
@@ -1,0 +1,94 @@
+package com.hooandee.colores.led
+
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+
+data class SingleAdcJoypadDescriptor(
+    val basePath: String = DEFAULT_BASE_PATH,
+) : LedDescriptor {
+    companion object {
+        const val DEFAULT_BASE_PATH = "/sys/bus/platform/devices/singleadc-joypad"
+    }
+}
+
+class SingleAdcJoypadLedDevice internal constructor(
+    private val descriptor: SingleAdcJoypadDescriptor,
+    private val access: SysfsAccess,
+    scope: CoroutineScope,
+) : LedDevice {
+    constructor(
+        descriptor: SingleAdcJoypadDescriptor,
+        scope: CoroutineScope = CoroutineScope(SupervisorJob() + Dispatchers.IO),
+    ) : this(descriptor, FileSysfsAccess, scope)
+
+    private val writer = ConflatedLedWriter(scope, WRITE_INTERVAL_MS, write = ::writeState)
+
+    override val available: Boolean
+        get() = access.canWrite(node("custum_rgb_r")) && access.canWrite(node("led_set"))
+
+    override val supportsPerZone: Boolean = false
+
+    override suspend fun readState(): LedState {
+        val color =
+            RgbColor(
+                red = readInt("custum_rgb_r", 0),
+                green = readInt("custum_rgb_g", 0),
+                blue = readInt("custum_rgb_b", 0),
+            )
+        return LedState(
+            zoneColors = listOf(color),
+            brightness = readInt("led_level", 100).coerceIn(0, 100),
+            power = readInt("led_switch", 1) != 0,
+        )
+    }
+
+    override suspend fun applyZones(
+        colors: List<RgbColor>,
+        brightness: Int,
+        power: Boolean,
+    ): Boolean = writer.submit(LedState(listOf(colors.firstOrNull() ?: RgbColor(255, 255, 255)), brightness.coerceIn(0, 100), power))
+
+    override suspend fun applySolid(
+        color: RgbColor,
+        brightness: Int,
+        power: Boolean,
+    ): Boolean = applyZones(listOf(color), brightness, power)
+
+    override fun invalidate() = Unit
+
+    private fun writeState(state: LedState): Boolean {
+        val color = state.zoneColors.first()
+        var succeeded = true
+        fun put(
+            name: String,
+            value: Int,
+        ) {
+            if (!access.write(node(name), "$value\n")) succeeded = false
+        }
+        if (state.power) {
+            put("custum_rgb_r", color.red.coerceIn(0, 255))
+            put("custum_rgb_g", color.green.coerceIn(0, 255))
+            put("custum_rgb_b", color.blue.coerceIn(0, 255))
+            put("led_level", state.brightness)
+            put("led_mode", STATIC_MODE)
+            put("led_switch", 1)
+        } else {
+            put("led_switch", 0)
+        }
+        put("led_set", 1)
+        return succeeded
+    }
+
+    private fun readInt(
+        name: String,
+        fallback: Int,
+    ): Int = access.read(node(name))?.trim()?.toIntOrNull() ?: fallback
+
+    private fun node(name: String): String = "${descriptor.basePath}/$name"
+
+    private companion object {
+        const val WRITE_INTERVAL_MS = 80L
+        const val STATIC_MODE = 1
+    }
+}

--- a/android/app/src/main/java/com/hooandee/colores/led/SingleAdcJoypadLedDevice.kt
+++ b/android/app/src/main/java/com/hooandee/colores/led/SingleAdcJoypadLedDevice.kt
@@ -31,7 +31,7 @@ class SingleAdcJoypadLedDevice internal constructor(
     override val supportsPerZone: Boolean = false
 
     override val hardwareEffects: List<HardwareEffect> =
-        EFFECTS.map { HardwareEffect(it.id, it.needsColor, it.defaultSpeed, it.previewColors) }
+        EFFECTS.map { HardwareEffect(it.id, it.colorStops, it.defaultSpeed, it.previewColors) }
 
     override suspend fun readState(): LedState {
         val color =
@@ -52,16 +52,19 @@ class SingleAdcJoypadLedDevice internal constructor(
         brightness: Int,
         power: Boolean,
     ): Boolean =
-        writer.submit(
-            Frame(
-                color = colors.firstOrNull() ?: RgbColor(255, 255, 255),
-                brightness = brightness.coerceIn(0, 100),
-                power = power,
-                ledMode = STATIC_MODE,
-                speed = 0,
-                colored = true,
-            ),
-        )
+        (colors.firstOrNull() ?: RgbColor(255, 255, 255)).let { c ->
+            writer.submit(
+                Frame(
+                    color = c,
+                    secondColor = c,
+                    brightness = brightness.coerceIn(0, 100),
+                    power = power,
+                    ledMode = STATIC_MODE,
+                    speed = 0,
+                    colored = true,
+                ),
+            )
+        }
 
     override suspend fun applySolid(
         color: RgbColor,
@@ -71,20 +74,23 @@ class SingleAdcJoypadLedDevice internal constructor(
 
     override suspend fun applyHardwareEffect(
         effectId: String,
-        color: RgbColor,
+        colors: List<RgbColor>,
         brightness: Int,
         speed: Int,
         power: Boolean,
     ): Boolean {
         val spec = EFFECTS.firstOrNull { it.id == effectId } ?: return false
+        val first = colors.firstOrNull() ?: RgbColor(255, 255, 255)
+        val second = colors.getOrNull(1) ?: first
         return writer.submit(
             Frame(
-                color = color,
+                color = first,
+                secondColor = second,
                 brightness = brightness.coerceIn(0, 100),
                 power = power,
                 ledMode = spec.ledMode,
                 speed = mapSpeed(speed),
-                colored = spec.needsColor,
+                colored = spec.colorStops > 0,
             ),
         )
     }
@@ -108,13 +114,14 @@ class SingleAdcJoypadLedDevice internal constructor(
         put("custum_rgb_r", c.red.coerceIn(0, 255))
         put("custum_rgb_g", c.green.coerceIn(0, 255))
         put("custum_rgb_b", c.blue.coerceIn(0, 255))
-        val zone = if (frame.colored) c else RgbColor(0, 0, 0)
-        put("Led_rgb_r1", zone.red.coerceIn(0, 255))
-        put("Led_rgb_g1", zone.green.coerceIn(0, 255))
-        put("Led_rgb_b1", zone.blue.coerceIn(0, 255))
-        put("Led_rgb_r2", zone.red.coerceIn(0, 255))
-        put("Led_rgb_g2", zone.green.coerceIn(0, 255))
-        put("Led_rgb_b2", zone.blue.coerceIn(0, 255))
+        val zone1 = if (frame.colored) c else RgbColor(0, 0, 0)
+        val zone2 = if (frame.colored) frame.secondColor else RgbColor(0, 0, 0)
+        put("Led_rgb_r1", zone1.red.coerceIn(0, 255))
+        put("Led_rgb_g1", zone1.green.coerceIn(0, 255))
+        put("Led_rgb_b1", zone1.blue.coerceIn(0, 255))
+        put("Led_rgb_r2", zone2.red.coerceIn(0, 255))
+        put("Led_rgb_g2", zone2.green.coerceIn(0, 255))
+        put("Led_rgb_b2", zone2.blue.coerceIn(0, 255))
         put("led_level", frame.brightness)
         put("led_speed", frame.speed)
         put("led_mode", frame.ledMode)
@@ -134,6 +141,7 @@ class SingleAdcJoypadLedDevice internal constructor(
 
     private data class Frame(
         val color: RgbColor,
+        val secondColor: RgbColor,
         val brightness: Int,
         val power: Boolean,
         val ledMode: Int,
@@ -144,7 +152,7 @@ class SingleAdcJoypadLedDevice internal constructor(
     private data class EffectSpec(
         val id: String,
         val ledMode: Int,
-        val needsColor: Boolean,
+        val colorStops: Int,
         val defaultSpeed: Int,
         val previewColors: List<RgbColor>,
     )
@@ -159,11 +167,11 @@ class SingleAdcJoypadLedDevice internal constructor(
 
         val EFFECTS =
             listOf(
-                EffectSpec("breathing", ledMode = 2, needsColor = true, defaultSpeed = 50, previewColors = listOf(RgbColor(93, 81, 255))),
-                EffectSpec("rainbow", ledMode = 3, needsColor = false, defaultSpeed = 50, previewColors = RAINBOW),
-                EffectSpec("marquee", ledMode = 4, needsColor = false, defaultSpeed = 50, previewColors = RAINBOW),
-                EffectSpec("chasing", ledMode = 5, needsColor = true, defaultSpeed = 50, previewColors = listOf(RgbColor(93, 81, 255))),
-                EffectSpec("gaming", ledMode = 6, needsColor = false, defaultSpeed = 50, previewColors = RAINBOW),
+                EffectSpec("breathing", ledMode = 2, colorStops = 2, defaultSpeed = 50, previewColors = listOf(RgbColor(255, 0, 0), RgbColor(0, 0, 255))),
+                EffectSpec("rainbow", ledMode = 3, colorStops = 0, defaultSpeed = 50, previewColors = RAINBOW),
+                EffectSpec("marquee", ledMode = 4, colorStops = 0, defaultSpeed = 50, previewColors = RAINBOW),
+                EffectSpec("chasing", ledMode = 5, colorStops = 2, defaultSpeed = 50, previewColors = listOf(RgbColor(255, 0, 0), RgbColor(0, 0, 255))),
+                EffectSpec("gaming", ledMode = 6, colorStops = 0, defaultSpeed = 50, previewColors = RAINBOW),
             )
     }
 }

--- a/android/app/src/main/java/com/hooandee/colores/led/SingleAdcJoypadLedDevice.kt
+++ b/android/app/src/main/java/com/hooandee/colores/led/SingleAdcJoypadLedDevice.kt
@@ -111,12 +111,11 @@ class SingleAdcJoypadLedDevice internal constructor(
             return succeeded
         }
         val main = frame.color
-        val follow = if (frame.colored) frame.secondColor else main
         put("custum_rgb_r", main.red.coerceIn(0, 255))
         put("custum_rgb_g", main.green.coerceIn(0, 255))
         put("custum_rgb_b", main.blue.coerceIn(0, 255))
         val slotMain = if (frame.colored) main else RgbColor(0, 0, 0)
-        val slotFollow = if (frame.colored) follow else RgbColor(0, 0, 0)
+        val slotFollow = if (frame.colored) frame.secondColor else RgbColor(0, 0, 0)
         put("Led_rgb_r2", slotMain.red.coerceIn(0, 255))
         put("Led_rgb_g2", slotMain.green.coerceIn(0, 255))
         put("Led_rgb_b2", slotMain.blue.coerceIn(0, 255))

--- a/android/app/src/main/java/com/hooandee/colores/led/SysfsRgbDevice.kt
+++ b/android/app/src/main/java/com/hooandee/colores/led/SysfsRgbDevice.kt
@@ -1,0 +1,137 @@
+package com.hooandee.colores.led
+
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import java.io.File
+import kotlin.math.roundToInt
+
+enum class SysfsColorKind {
+    MULTI_INTENSITY_DECIMAL,
+    MULTI_INTENSITY_HEX,
+    RGB_CHANNELS,
+}
+
+data class SysfsRgbDescriptor(
+    val nodePath: String,
+    val zones: Int,
+    val maxBrightness: Int,
+    val kind: SysfsColorKind,
+) : LedDescriptor
+
+interface SysfsAccess {
+    fun read(path: String): String?
+
+    fun exists(path: String): Boolean
+
+    fun canWrite(path: String): Boolean
+
+    fun write(
+        path: String,
+        value: String,
+    ): Boolean
+}
+
+internal object FileSysfsAccess : SysfsAccess {
+    override fun read(path: String): String? = runCatching { File(path).readText().trim() }.getOrNull()
+
+    override fun exists(path: String): Boolean = runCatching { File(path).exists() }.getOrDefault(false)
+
+    override fun canWrite(path: String): Boolean = runCatching { File(path).canWrite() }.getOrDefault(false)
+
+    override fun write(
+        path: String,
+        value: String,
+    ): Boolean = runCatching { File(path).writeText(value); true }.getOrDefault(false)
+}
+
+class SysfsRgbDevice internal constructor(
+    private val descriptor: SysfsRgbDescriptor,
+    private val access: SysfsAccess,
+    scope: CoroutineScope,
+) : LedDevice {
+    constructor(
+        descriptor: SysfsRgbDescriptor,
+        scope: CoroutineScope = CoroutineScope(SupervisorJob() + Dispatchers.IO),
+    ) : this(descriptor, FileSysfsAccess, scope)
+
+    private val brightnessPath = "${descriptor.nodePath}/brightness"
+    private val colorPaths =
+        when (descriptor.kind) {
+            SysfsColorKind.RGB_CHANNELS ->
+                listOf("red", "green", "blue").map { "${descriptor.nodePath}/$it" }
+            else -> listOf("${descriptor.nodePath}/multi_intensity")
+        }
+
+    private val writer = ConflatedLedWriter(scope, WRITE_INTERVAL_MS, write = ::writeState)
+
+    override val available: Boolean
+        get() = descriptor.zones > 0 && colorPaths.all(access::canWrite)
+
+    override val supportsPerZone: Boolean
+        get() = descriptor.zones > 1
+
+    override suspend fun readState(): LedState =
+        LedState(
+            zoneColors = List(descriptor.zones) { RgbColor(0, 0, 0) },
+            brightness = readBrightnessPercent(),
+            power = true,
+        )
+
+    override suspend fun applyZones(
+        colors: List<RgbColor>,
+        brightness: Int,
+        power: Boolean,
+    ): Boolean = writer.submit(LedState(colors.fit(descriptor.zones), brightness.coerceIn(0, 100), power))
+
+    override suspend fun applySolid(
+        color: RgbColor,
+        brightness: Int,
+        power: Boolean,
+    ): Boolean = applyZones(List(descriptor.zones) { color }, brightness, power)
+
+    override fun invalidate() = Unit
+
+    private fun writeState(state: LedState): Boolean {
+        val colors = if (state.power) state.zoneColors else List(descriptor.zones) { RgbColor(0, 0, 0) }
+        val colorWritten =
+            when (descriptor.kind) {
+                SysfsColorKind.RGB_CHANNELS -> writeChannels(colors.first())
+                SysfsColorKind.MULTI_INTENSITY_DECIMAL ->
+                    access.write(colorPaths.first(), colors.flatMap { listOf(it.red, it.green, it.blue) }.joinToString(" "))
+                SysfsColorKind.MULTI_INTENSITY_HEX ->
+                    access.write(colorPaths.first(), colors.joinToString(" ") { "0x%06X".format(packed(it)) })
+            }
+        val brightnessValue = if (state.power) scaleBrightness(state.brightness) else 0
+        val brightnessWritten = access.write(brightnessPath, brightnessValue.toString())
+        return colorWritten && brightnessWritten
+    }
+
+    private fun writeChannels(color: RgbColor): Boolean {
+        val scaled = { channel: Int -> ((channel / 255.0) * descriptor.maxBrightness).roundToInt().coerceIn(0, descriptor.maxBrightness) }
+        return access.write(colorPaths[0], scaled(color.red).toString()) &&
+            access.write(colorPaths[1], scaled(color.green).toString()) &&
+            access.write(colorPaths[2], scaled(color.blue).toString())
+    }
+
+    private fun scaleBrightness(percent: Int): Int =
+        ((percent.coerceIn(0, 100) / 100.0) * descriptor.maxBrightness).roundToInt().coerceIn(0, descriptor.maxBrightness)
+
+    private fun readBrightnessPercent(): Int {
+        val raw = access.read(brightnessPath)?.toIntOrNull() ?: return 100
+        if (descriptor.maxBrightness <= 0) return 100
+        return ((raw.toDouble() / descriptor.maxBrightness) * 100).roundToInt().coerceIn(0, 100)
+    }
+
+    private fun packed(color: RgbColor): Int =
+        (color.red.coerceIn(0, 255) shl 16) or (color.green.coerceIn(0, 255) shl 8) or color.blue.coerceIn(0, 255)
+
+    private fun List<RgbColor>.fit(zones: Int): List<RgbColor> {
+        val fallback = firstOrNull() ?: RgbColor(255, 255, 255)
+        return List(zones.coerceAtLeast(1)) { getOrNull(it) ?: fallback }
+    }
+
+    private companion object {
+        const val WRITE_INTERVAL_MS = 80L
+    }
+}

--- a/android/app/src/main/java/com/hooandee/colores/led/SysfsRgbDevice.kt
+++ b/android/app/src/main/java/com/hooandee/colores/led/SysfsRgbDevice.kt
@@ -82,7 +82,7 @@ class SysfsRgbDevice internal constructor(
         colors: List<RgbColor>,
         brightness: Int,
         power: Boolean,
-    ): Boolean = writer.submit(LedState(colors.fit(descriptor.zones), brightness.coerceIn(0, 100), power))
+    ): Boolean = writer.submit(LedState(colors.fitZones(descriptor.zones), brightness.coerceIn(0, 100), power))
 
     override suspend fun applySolid(
         color: RgbColor,
@@ -125,11 +125,6 @@ class SysfsRgbDevice internal constructor(
 
     private fun packed(color: RgbColor): Int =
         (color.red.coerceIn(0, 255) shl 16) or (color.green.coerceIn(0, 255) shl 8) or color.blue.coerceIn(0, 255)
-
-    private fun List<RgbColor>.fit(zones: Int): List<RgbColor> {
-        val fallback = firstOrNull() ?: RgbColor(255, 255, 255)
-        return List(zones.coerceAtLeast(1)) { getOrNull(it) ?: fallback }
-    }
 
     private companion object {
         const val WRITE_INTERVAL_MS = 80L

--- a/android/app/src/main/java/com/hooandee/colores/ui/ColoresViewModel.kt
+++ b/android/app/src/main/java/com/hooandee/colores/ui/ColoresViewModel.kt
@@ -86,9 +86,17 @@ data class ColoresUiState(
     val currentEffect: EffectPreset?
         get() = effects.firstOrNull { it.id == effectId }
 
+    val gradientEditable: Boolean
+        get() = gradientAvailable || (mode == AppMode.EFFECT && currentEffect?.need == EffectNeed.GRADIENT)
+
+    val editingGradientStops: Boolean
+        get() =
+            (gradient.mode == LightingMode.GRADIENT && gradientAvailable) ||
+                (mode == AppMode.EFFECT && currentEffect?.need == EffectNeed.GRADIENT)
+
     val editingColor: RgbColor
         get() =
-            if (gradient.mode == LightingMode.GRADIENT) {
+            if (editingGradientStops) {
                 gradient.selectedStop ?: ledState.colorForEditing(editTarget)
             } else {
                 ledState.colorForEditing(editTarget)
@@ -198,7 +206,12 @@ class ColoresViewModel(
                         device.hardwareEffects.map {
                             EffectPreset(
                                 id = it.id,
-                                need = if (it.needsColor) EffectNeed.COLOR else EffectNeed.NONE,
+                                need =
+                                    when {
+                                        it.colorStops >= 2 -> EffectNeed.GRADIENT
+                                        it.colorStops == 1 -> EffectNeed.COLOR
+                                        else -> EffectNeed.NONE
+                                    },
                                 defaultSpeed = it.defaultSpeed,
                                 colors = it.colors,
                             )
@@ -222,8 +235,11 @@ class ColoresViewModel(
                         zones = zones,
                         supported = gradientSupported,
                     ).let { gradient ->
-                        if (gradient.stops.isEmpty()) {
-                            gradient.copy(stops = List(zones) { RgbColor(93, 81, 255) })
+                        val minStops = if (device.hardwareEffects.any { it.colorStops >= 2 }) 2 else 1
+                        if (gradient.stops.size < minStops) {
+                            val fallback = gradient.stops.firstOrNull() ?: RgbColor(93, 81, 255)
+                            val padded = List(maxOf(zones, minStops)) { gradient.stops.getOrNull(it) ?: fallback }
+                            gradient.copy(stops = padded)
                         } else {
                             gradient
                         }
@@ -371,7 +387,7 @@ class ColoresViewModel(
 
     fun setEditingColor(color: RgbColor) {
         val current = mutableState.value
-        if (current.gradient.mode == LightingMode.GRADIENT) {
+        if (current.editingGradientStops) {
             updateGradient(current.gradient.replaceSelectedStop(color), apply = true, debounce = true)
         } else {
             updateLedState(debounce = true) { state -> state.withTargetColor(current.editTarget, color) }
@@ -380,7 +396,7 @@ class ColoresViewModel(
 
     fun setSaturation(saturation: Float) {
         val current = mutableState.value
-        if (current.gradient.mode == LightingMode.GRADIENT) {
+        if (current.editingGradientStops) {
             val changed = current.editingColor.toHsvColor().copy(saturation = saturation.coerceIn(0f, 1f)).toRgbColor()
             updateGradient(current.gradient.replaceSelectedStop(changed), apply = true, debounce = true)
         } else {
@@ -390,25 +406,25 @@ class ColoresViewModel(
 
     fun selectGradientStop(index: Int) {
         val current = mutableState.value
-        if (!current.gradientAvailable) return
+        if (!current.gradientEditable) return
         mutableState.update { it.copy(gradient = it.gradient.selectStop(index)) }
     }
 
     fun selectGradientPreset(preset: GradientPreset) {
         val current = mutableState.value
-        val zones = current.detected?.capabilities?.zones ?: return
-        if (!current.gradientAvailable) return
-        updateGradient(current.gradient.selectPreset(preset, zones), apply = true)
+        if (current.detected == null) return
+        if (!current.gradientEditable) return
+        updateGradient(current.gradient.selectPreset(preset, current.gradientStopCount()), apply = true)
     }
 
     fun selectSavedGradient(name: String) {
         val current = mutableState.value
         val saved = current.gradient.savedGradients.firstOrNull { it.name == name } ?: return
-        val zones = current.detected?.capabilities?.zones ?: return
+        if (current.detected == null) return
         updateGradient(
             current.gradient.copy(
                 mode = LightingMode.GRADIENT,
-                stops = GradientInterpolator.interpolate(saved.stops, zones),
+                stops = GradientInterpolator.interpolate(saved.stops, current.gradientStopCount()),
                 selectedStopIndex = 0,
                 selectedPresetId = null,
             ),
@@ -418,8 +434,8 @@ class ColoresViewModel(
 
     fun restoreGradientPreset() {
         val current = mutableState.value
-        val zones = current.detected?.capabilities?.zones ?: return
-        val restored = current.gradient.restorePreset(zones)
+        if (current.detected == null) return
+        val restored = current.gradient.restorePreset(current.gradientStopCount())
         if (restored == current.gradient) return
         updateGradient(restored, apply = true)
     }
@@ -465,7 +481,7 @@ class ColoresViewModel(
     ) {
         val current = mutableState.value
         val zones = current.detected?.capabilities?.zones ?: return
-        if (!current.canWrite || !current.gradientAvailable) return
+        if (!current.canWrite || !current.gradientEditable) return
         val colors = GradientInterpolator.interpolate(gradient.stops, zones)
         mutableState.update { it.copy(gradient = gradient, ledState = it.ledState.copy(zoneColors = colors)) }
         if (apply) {
@@ -538,6 +554,13 @@ private const val COLOR_COMMIT_DEBOUNCE_MS = 120L
 
 private fun AppMode.coerceAvailable(gradientSupported: Boolean): AppMode =
     if (this == AppMode.GRADIENT && !gradientSupported) AppMode.COLOR else this
+
+private fun ColoresUiState.gradientStopCount(): Int =
+    if (mode == AppMode.EFFECT && currentEffect?.need == EffectNeed.GRADIENT) {
+        2
+    } else {
+        detected?.capabilities?.zones ?: 2
+    }
 
 private fun android.content.Context.readAsset(name: String): String =
     assets.open(name).bufferedReader().use { it.readText() }

--- a/android/app/src/main/java/com/hooandee/colores/ui/ColoresViewModel.kt
+++ b/android/app/src/main/java/com/hooandee/colores/ui/ColoresViewModel.kt
@@ -557,7 +557,7 @@ private fun AppMode.coerceAvailable(gradientSupported: Boolean): AppMode =
     if (this == AppMode.GRADIENT && !gradientSupported) AppMode.COLOR else this
 
 private fun ColoresUiState.gradientStopCount(): Int =
-    if (effectNeedsGradient) 2 else (detected?.capabilities?.zones ?: 2)
+    if (effectNeedsGradient && !gradientAvailable) 2 else (detected?.capabilities?.zones ?: 2)
 
 private fun android.content.Context.readAsset(name: String): String =
     assets.open(name).bufferedReader().use { it.readText() }

--- a/android/app/src/main/java/com/hooandee/colores/ui/ColoresViewModel.kt
+++ b/android/app/src/main/java/com/hooandee/colores/ui/ColoresViewModel.kt
@@ -86,13 +86,14 @@ data class ColoresUiState(
     val currentEffect: EffectPreset?
         get() = effects.firstOrNull { it.id == effectId }
 
+    val effectNeedsGradient: Boolean
+        get() = mode == AppMode.EFFECT && currentEffect?.need == EffectNeed.GRADIENT
+
     val gradientEditable: Boolean
-        get() = gradientAvailable || (mode == AppMode.EFFECT && currentEffect?.need == EffectNeed.GRADIENT)
+        get() = gradientAvailable || effectNeedsGradient
 
     val editingGradientStops: Boolean
-        get() =
-            (gradient.mode == LightingMode.GRADIENT && gradientAvailable) ||
-                (mode == AppMode.EFFECT && currentEffect?.need == EffectNeed.GRADIENT)
+        get() = (gradient.mode == LightingMode.GRADIENT && gradientAvailable) || effectNeedsGradient
 
     val editingColor: RgbColor
         get() =
@@ -556,11 +557,7 @@ private fun AppMode.coerceAvailable(gradientSupported: Boolean): AppMode =
     if (this == AppMode.GRADIENT && !gradientSupported) AppMode.COLOR else this
 
 private fun ColoresUiState.gradientStopCount(): Int =
-    if (mode == AppMode.EFFECT && currentEffect?.need == EffectNeed.GRADIENT) {
-        2
-    } else {
-        detected?.capabilities?.zones ?: 2
-    }
+    if (effectNeedsGradient) 2 else (detected?.capabilities?.zones ?: 2)
 
 private fun android.content.Context.readAsset(name: String): String =
     assets.open(name).bufferedReader().use { it.readText() }

--- a/android/app/src/main/java/com/hooandee/colores/ui/ColoresViewModel.kt
+++ b/android/app/src/main/java/com/hooandee/colores/ui/ColoresViewModel.kt
@@ -14,6 +14,7 @@ import com.hooandee.colores.device.AndroidDeviceDetector
 import com.hooandee.colores.device.DetectedAndroidDevice
 import com.hooandee.colores.engine.BandSet
 import com.hooandee.colores.engine.EffectCatalog
+import com.hooandee.colores.engine.EffectNeed
 import com.hooandee.colores.engine.EffectPreset
 import com.hooandee.colores.gradient.DeviceGradientPreferences
 import com.hooandee.colores.gradient.GradientInterpolator
@@ -192,6 +193,19 @@ class ColoresViewModel(
                 }
 
                 val catalog = withContext(Dispatchers.IO) { EffectCatalog.parse(context.readAsset("effects.json")) }
+                val effectPresets =
+                    if (device.hardwareEffects.isNotEmpty()) {
+                        device.hardwareEffects.map {
+                            EffectPreset(
+                                id = it.id,
+                                need = if (it.needsColor) EffectNeed.COLOR else EffectNeed.NONE,
+                                defaultSpeed = it.defaultSpeed,
+                                colors = it.colors,
+                            )
+                        }
+                    } else {
+                        catalog.presets
+                    }
                 val bands = withContext(Dispatchers.IO) { BandSet.parse(context.readAsset("bands.json")) }
                 val zones = detected.capabilities.zones
                 val gradientSupported = detected.capabilities.supportsGradient(device.supportsPerZone)
@@ -238,7 +252,10 @@ class ColoresViewModel(
                             staticColors = zoneColors,
                             solidColor = zoneColors.firstOrNull() ?: RgbColor(93, 81, 255),
                             gradientStops = hydratedGradient.stops,
-                            effectId = catalog.byId(storedLighting.effectId)?.id ?: catalog.defaultEffectId,
+                            effectId =
+                                effectPresets.firstOrNull { it.id == storedLighting.effectId }?.id
+                                    ?: effectPresets.firstOrNull()?.id
+                                    ?: catalog.defaultEffectId,
                             speed = storedLighting.speed,
                             brightness = brightness,
                             power = power,
@@ -253,7 +270,7 @@ class ColoresViewModel(
                         loading = false,
                         detected = detected,
                         controlAccess = controlAccess,
-                        effects = catalog.presets,
+                        effects = effectPresets,
                         ledState = LedState(zoneColors, brightness, power),
                         gradientAvailable = gradientSupported,
                         gradient = hydratedGradient,

--- a/android/app/src/main/java/com/hooandee/colores/ui/ControlAccess.kt
+++ b/android/app/src/main/java/com/hooandee/colores/ui/ControlAccess.kt
@@ -1,6 +1,8 @@
 package com.hooandee.colores.ui
 
+import com.hooandee.colores.led.LedDescriptor
 import com.hooandee.colores.led.SettingsProviderDescriptor
+import com.hooandee.colores.led.SysfsRgbDescriptor
 
 enum class ControlAccess {
     ENABLED,
@@ -10,14 +12,16 @@ enum class ControlAccess {
 
     companion object {
         fun resolve(
-            descriptor: SettingsProviderDescriptor,
+            descriptor: LedDescriptor,
             deviceAvailable: Boolean,
             userPermissionGranted: Boolean,
         ): ControlAccess =
             when {
                 !deviceAvailable -> SERVICE_UNAVAILABLE
-                descriptor.transport == "pserver" -> ENABLED
-                descriptor.requiresPermission == null || userPermissionGranted -> ENABLED
+                descriptor is SysfsRgbDescriptor -> ENABLED
+                descriptor is SettingsProviderDescriptor && descriptor.transport == "pserver" -> ENABLED
+                descriptor is SettingsProviderDescriptor &&
+                    (descriptor.requiresPermission == null || userPermissionGranted) -> ENABLED
                 else -> USER_PERMISSION_REQUIRED
             }
     }

--- a/android/app/src/main/java/com/hooandee/colores/ui/ControlAccess.kt
+++ b/android/app/src/main/java/com/hooandee/colores/ui/ControlAccess.kt
@@ -2,6 +2,7 @@ package com.hooandee.colores.ui
 
 import com.hooandee.colores.led.LedDescriptor
 import com.hooandee.colores.led.SettingsProviderDescriptor
+import com.hooandee.colores.led.SingleAdcJoypadDescriptor
 import com.hooandee.colores.led.SysfsRgbDescriptor
 
 enum class ControlAccess {
@@ -19,6 +20,7 @@ enum class ControlAccess {
             when {
                 !deviceAvailable -> SERVICE_UNAVAILABLE
                 descriptor is SysfsRgbDescriptor -> ENABLED
+                descriptor is SingleAdcJoypadDescriptor -> ENABLED
                 descriptor is SettingsProviderDescriptor && descriptor.transport == "pserver" -> ENABLED
                 descriptor is SettingsProviderDescriptor &&
                     (descriptor.requiresPermission == null || userPermissionGranted) -> ENABLED

--- a/android/app/src/main/java/com/hooandee/colores/ui/ControlAccess.kt
+++ b/android/app/src/main/java/com/hooandee/colores/ui/ControlAccess.kt
@@ -19,8 +19,7 @@ enum class ControlAccess {
         ): ControlAccess =
             when {
                 !deviceAvailable -> SERVICE_UNAVAILABLE
-                descriptor is SysfsRgbDescriptor -> ENABLED
-                descriptor is SingleAdcJoypadDescriptor -> ENABLED
+                descriptor is SysfsRgbDescriptor || descriptor is SingleAdcJoypadDescriptor -> ENABLED
                 descriptor is SettingsProviderDescriptor && descriptor.transport == "pserver" -> ENABLED
                 descriptor is SettingsProviderDescriptor &&
                     (descriptor.requiresPermission == null || userPermissionGranted) -> ENABLED

--- a/android/app/src/main/java/com/hooandee/colores/ui/DeviceScene.kt
+++ b/android/app/src/main/java/com/hooandee/colores/ui/DeviceScene.kt
@@ -8,6 +8,7 @@ import androidx.compose.foundation.background
 import androidx.compose.foundation.border
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.BoxWithConstraints
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
@@ -17,6 +18,7 @@ import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
+import androidx.compose.ui.unit.Dp
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.MaterialTheme
@@ -58,79 +60,89 @@ fun DeviceScene(
         contentColor = MaterialTheme.colorScheme.onSurface,
         shape = RoundedCornerShape(32.dp),
     ) {
-        Column(
-            modifier = Modifier.fillMaxSize().padding(22.dp),
-            horizontalAlignment = Alignment.CenterHorizontally,
-        ) {
-            Row(
-                modifier = Modifier.fillMaxWidth(),
-                horizontalArrangement = Arrangement.spacedBy(12.dp),
-                verticalAlignment = Alignment.CenterVertically,
+        BoxWithConstraints(modifier = Modifier.fillMaxSize()) {
+            val compact = maxHeight < 320.dp
+            val ringSize = if (compact) (maxHeight * 0.34f).coerceIn(52.dp, 112.dp) else 112.dp
+            val scenePadding = if (compact) 14.dp else 22.dp
+            Column(
+                modifier = Modifier.fillMaxSize().padding(scenePadding),
+                horizontalAlignment = Alignment.CenterHorizontally,
             ) {
-                Column(modifier = Modifier.weight(1f)) {
-                    Text(
-                        text = stringResource(R.string.preview_title),
-                        style = MaterialTheme.typography.titleLarge,
-                        fontWeight = FontWeight.SemiBold,
-                    )
-                    Text(
-                        text = stringResource(R.string.preview_hint),
-                        color = MaterialTheme.colorScheme.onSurfaceVariant,
-                        style = MaterialTheme.typography.bodySmall,
-                    )
+                Row(
+                    modifier = Modifier.fillMaxWidth(),
+                    horizontalArrangement = Arrangement.spacedBy(12.dp),
+                    verticalAlignment = Alignment.CenterVertically,
+                ) {
+                    Column(modifier = Modifier.weight(1f)) {
+                        Text(
+                            text = stringResource(R.string.preview_title),
+                            style = if (compact) MaterialTheme.typography.titleMedium else MaterialTheme.typography.titleLarge,
+                            fontWeight = FontWeight.SemiBold,
+                        )
+                        if (!compact) {
+                            Text(
+                                text = stringResource(R.string.preview_hint),
+                                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                                style = MaterialTheme.typography.bodySmall,
+                            )
+                        }
+                    }
+                    if (projection.available) {
+                        Row(
+                            horizontalArrangement = Arrangement.spacedBy(6.dp),
+                            verticalAlignment = Alignment.CenterVertically,
+                        ) {
+                            Text(
+                                text = ledPreviewLabel,
+                                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                                style = MaterialTheme.typography.labelMedium,
+                            )
+                            Switch(
+                                checked = projection.active,
+                                onCheckedChange = onLedPreviewChange,
+                                modifier = Modifier.semantics { contentDescription = ledPreviewLabel },
+                            )
+                        }
+                    }
                 }
-                if (projection.available) {
+                Spacer(Modifier.weight(1f))
+                Surface(
+                    color = Color(0xFF181920),
+                    shape = RoundedCornerShape(999.dp),
+                    border = BorderStroke(1.dp, Color.White.copy(alpha = 0.06f)),
+                ) {
                     Row(
-                        horizontalArrangement = Arrangement.spacedBy(6.dp),
+                        modifier = Modifier.padding(horizontal = 18.dp, vertical = if (compact) 12.dp else 16.dp),
+                        horizontalArrangement = Arrangement.spacedBy(18.dp),
                         verticalAlignment = Alignment.CenterVertically,
                     ) {
-                        Text(
-                            text = ledPreviewLabel,
-                            color = MaterialTheme.colorScheme.onSurfaceVariant,
-                            style = MaterialTheme.typography.labelMedium,
+                        StickTarget(
+                            label = stringResource(R.string.stick_left),
+                            color = leftColor,
+                            selected = selectedTarget == EditTarget.LEFT,
+                            power = power,
+                            enabled = enabled && perZone,
+                            diameter = ringSize,
+                            showLabel = !compact,
+                            projection = projection,
+                            onClick = { onTargetChange(EditTarget.LEFT) },
                         )
-                        Switch(
-                            checked = projection.active,
-                            onCheckedChange = onLedPreviewChange,
-                            modifier = Modifier.semantics { contentDescription = ledPreviewLabel },
+                        StickTarget(
+                            label = stringResource(R.string.stick_right),
+                            color = rightColor,
+                            selected = selectedTarget == EditTarget.RIGHT,
+                            power = power,
+                            enabled = enabled && perZone,
+                            diameter = ringSize,
+                            showLabel = !compact,
+                            projection = projection,
+                            onClick = { onTargetChange(EditTarget.RIGHT) },
                         )
                     }
                 }
-            }
-            Spacer(Modifier.weight(1f))
-            Surface(
-                color = Color(0xFF181920),
-                shape = RoundedCornerShape(999.dp),
-                border = BorderStroke(1.dp, Color.White.copy(alpha = 0.06f)),
-            ) {
-                Row(
-                    modifier = Modifier.padding(horizontal = 18.dp, vertical = 16.dp),
-                    horizontalArrangement = Arrangement.spacedBy(18.dp),
-                    verticalAlignment = Alignment.CenterVertically,
-                ) {
-                    StickTarget(
-                        label = stringResource(R.string.stick_left),
-                        color = leftColor,
-                        selected = selectedTarget == EditTarget.LEFT,
-                        power = power,
-                        enabled = enabled && perZone,
-                        projection = projection,
-                        onClick = { onTargetChange(EditTarget.LEFT) },
-                    )
-                    StickTarget(
-                        label = stringResource(R.string.stick_right),
-                        color = rightColor,
-                        selected = selectedTarget == EditTarget.RIGHT,
-                        power = power,
-                        enabled = enabled && perZone,
-                        projection = projection,
-                        onClick = { onTargetChange(EditTarget.RIGHT) },
-                    )
-                }
-            }
-            if (showBoth) {
-                Spacer(Modifier.height(16.dp))
-                Surface(
+                if (showBoth) {
+                    Spacer(Modifier.height(if (compact) 10.dp else 16.dp))
+                    Surface(
                     onClick = { onTargetChange(EditTarget.BOTH) },
                     enabled = enabled,
                     modifier = Modifier.heightIn(min = 48.dp),
@@ -165,8 +177,9 @@ fun DeviceScene(
                         fontWeight = FontWeight.SemiBold,
                     )
                 }
+                }
+                Spacer(Modifier.weight(1f))
             }
-            Spacer(Modifier.weight(1f))
         }
     }
 }
@@ -178,6 +191,8 @@ private fun StickTarget(
     selected: Boolean,
     power: Boolean,
     enabled: Boolean,
+    diameter: Dp,
+    showLabel: Boolean,
     projection: LedColorProjection,
     onClick: () -> Unit,
 ) {
@@ -195,6 +210,11 @@ private fun StickTarget(
             label = "LED preview glow",
         )
     val powerAlpha = if (power) 1f else 0.18f
+    val glowSize = diameter * (82f / 112f)
+    val glowBorder = diameter * (8f / 112f)
+    val ringSize = diameter * (72f / 112f)
+    val ringBorder = diameter * (11f / 112f)
+    val hubSize = diameter * (28f / 112f)
     Column(
         horizontalAlignment = Alignment.CenterHorizontally,
         verticalArrangement = Arrangement.spacedBy(9.dp),
@@ -204,7 +224,7 @@ private fun StickTarget(
             enabled = enabled,
             modifier =
                 Modifier
-                    .size(112.dp)
+                    .size(diameter)
                     .semantics {
                         contentDescription = label
                         this.selected = selected
@@ -226,9 +246,9 @@ private fun StickTarget(
                 Box(
                     modifier =
                         Modifier
-                            .size(82.dp)
+                            .size(glowSize)
                             .border(
-                                width = 8.dp,
+                                width = glowBorder,
                                 color = displayedColor.copy(alpha = glowAlpha * powerAlpha),
                                 shape = CircleShape,
                             ),
@@ -236,9 +256,9 @@ private fun StickTarget(
                 Box(
                     modifier =
                         Modifier
-                            .size(72.dp)
+                            .size(ringSize)
                             .border(
-                                width = 11.dp,
+                                width = ringBorder,
                                 color = displayedColor.copy(alpha = powerAlpha),
                                 shape = CircleShape,
                             )
@@ -247,17 +267,19 @@ private fun StickTarget(
                 Box(
                     modifier =
                         Modifier
-                            .size(28.dp)
+                            .size(hubSize)
                             .background(Color(0xFF252630), CircleShape),
                 )
             }
         }
-        Text(
-            text = label,
-            color = if (selected) MaterialTheme.colorScheme.onSurface else MaterialTheme.colorScheme.onSurfaceVariant,
-            style = MaterialTheme.typography.labelMedium,
-            fontWeight = if (selected) FontWeight.SemiBold else FontWeight.Normal,
-        )
+        if (showLabel) {
+            Text(
+                text = label,
+                color = if (selected) MaterialTheme.colorScheme.onSurface else MaterialTheme.colorScheme.onSurfaceVariant,
+                style = MaterialTheme.typography.labelMedium,
+                fontWeight = if (selected) FontWeight.SemiBold else FontWeight.Normal,
+            )
+        }
     }
 }
 

--- a/android/app/src/main/java/com/hooandee/colores/ui/DeviceScene.kt
+++ b/android/app/src/main/java/com/hooandee/colores/ui/DeviceScene.kt
@@ -62,7 +62,7 @@ fun DeviceScene(
     ) {
         BoxWithConstraints(modifier = Modifier.fillMaxSize()) {
             val compact = maxHeight < 320.dp
-            val ringSize = if (compact) (maxHeight * 0.34f).coerceIn(52.dp, 112.dp) else 112.dp
+            val ringSize = if (compact) (maxHeight - 150.dp).coerceIn(40.dp, 112.dp) else 112.dp
             val scenePadding = if (compact) 14.dp else 22.dp
             Column(
                 modifier = Modifier.fillMaxSize().padding(scenePadding),
@@ -145,7 +145,7 @@ fun DeviceScene(
                     Surface(
                     onClick = { onTargetChange(EditTarget.BOTH) },
                     enabled = enabled,
-                    modifier = Modifier.heightIn(min = 48.dp),
+                    modifier = Modifier.heightIn(min = if (compact) 36.dp else 48.dp),
                     color =
                         if (selectedTarget == EditTarget.BOTH) {
                             MaterialTheme.colorScheme.primaryContainer
@@ -172,8 +172,8 @@ fun DeviceScene(
                 ) {
                     Text(
                         text = stringResource(R.string.target_both),
-                        modifier = Modifier.padding(horizontal = 24.dp, vertical = 10.dp),
-                        style = MaterialTheme.typography.labelLarge,
+                        modifier = Modifier.padding(horizontal = 24.dp, vertical = if (compact) 6.dp else 10.dp),
+                        style = if (compact) MaterialTheme.typography.labelMedium else MaterialTheme.typography.labelLarge,
                         fontWeight = FontWeight.SemiBold,
                     )
                 }

--- a/android/app/src/main/java/com/hooandee/colores/ui/GradientEditorDialog.kt
+++ b/android/app/src/main/java/com/hooandee/colores/ui/GradientEditorDialog.kt
@@ -137,7 +137,7 @@ private fun GradientZonesPane(
     actions: GradientActions,
     modifier: Modifier,
 ) {
-    val zones = gradientEditorZones(state.detected?.id, state.gradient.stops.size)
+    val zones = gradientEditorZones(state.detected?.gridLayout, state.gradient.stops.size)
     val projection = state.ledColorProjection
     Surface(
         modifier = modifier,
@@ -275,7 +275,7 @@ private fun GradientColorPane(
 ) {
     var saveName by rememberSaveable { mutableStateOf("") }
     val selectedZone =
-        gradientEditorZones(state.detected?.id, state.gradient.stops.size)
+        gradientEditorZones(state.detected?.gridLayout, state.gradient.stops.size)
             .getOrNull(state.gradient.selectedStopIndex)
     val color = state.editingColor
     val saturation = color.toHsvColor().saturation

--- a/android/app/src/main/java/com/hooandee/colores/ui/GradientEditorModel.kt
+++ b/android/app/src/main/java/com/hooandee/colores/ui/GradientEditorModel.kt
@@ -1,5 +1,7 @@
 package com.hooandee.colores.ui
 
+import com.hooandee.colores.device.LedGridCell
+
 internal enum class GradientZonePosition {
     TOP,
     LEFT,
@@ -19,51 +21,25 @@ internal data class GradientEditorZone(
     val position: GradientZonePosition?,
 )
 
-private data class Cell(
-    val row: Int,
-    val col: Int,
-    val position: GradientZonePosition,
-)
-
-private val AYN_THOR_LEFT_CELLS =
-    listOf(
-        Cell(0, 0, GradientZonePosition.TOP_LEFT),
-        Cell(1, 0, GradientZonePosition.BOTTOM_LEFT),
-        Cell(1, 1, GradientZonePosition.BOTTOM_RIGHT),
-        Cell(0, 1, GradientZonePosition.TOP_RIGHT),
-    )
-private val AYN_THOR_RIGHT_CELLS =
-    listOf(
-        Cell(1, 0, GradientZonePosition.BOTTOM_LEFT),
-        Cell(0, 0, GradientZonePosition.TOP_LEFT),
-        Cell(0, 1, GradientZonePosition.TOP_RIGHT),
-        Cell(1, 1, GradientZonePosition.BOTTOM_RIGHT),
-    )
-private val RETROID_POCKET_5_CELLS =
-    listOf(
-        Cell(0, 0, GradientZonePosition.TOP),
-        Cell(0, 1, GradientZonePosition.LEFT),
-        Cell(1, 0, GradientZonePosition.BOTTOM),
-        Cell(1, 1, GradientZonePosition.RIGHT),
-    )
-
 internal fun gradientEditorZones(
-    deviceId: String?,
+    layout: List<LedGridCell>?,
     count: Int,
 ): List<GradientEditorZone> {
-    val cellFor: ((Int) -> Cell)? =
-        when {
-            deviceId == "ayn-thor" && count == 8 -> { index -> if (index < 4) AYN_THOR_LEFT_CELLS[index % 4] else AYN_THOR_RIGHT_CELLS[index % 4] }
-            deviceId == "retroid-pocket-5" && count == 8 -> { index -> RETROID_POCKET_5_CELLS[index % 4] }
-            else -> null
-        }
-    if (cellFor != null) {
-        return List(count) { index ->
-            val cell = cellFor(index)
-            GradientEditorZone(index = index, stick = index / 4, row = cell.row, col = cell.col, position = cell.position)
+    if (layout != null && layout.size == count) {
+        return layout.mapIndexed { index, cell ->
+            GradientEditorZone(
+                index = index,
+                stick = cell.stick,
+                row = cell.row,
+                col = cell.col,
+                position = cell.position?.let(::parsePosition),
+            )
         }
     }
     return List(count) { index ->
         GradientEditorZone(index = index, stick = null, row = index / 4, col = index % 4, position = null)
     }
 }
+
+private fun parsePosition(token: String): GradientZonePosition? =
+    runCatching { GradientZonePosition.valueOf(token.uppercase()) }.getOrNull()

--- a/android/app/src/main/java/com/hooandee/colores/ui/ModePanels.kt
+++ b/android/app/src/main/java/com/hooandee/colores/ui/ModePanels.kt
@@ -208,7 +208,7 @@ private fun EffectsPanel(
     )
     when (state.currentEffect?.need ?: EffectNeed.COLOR) {
         EffectNeed.GRADIENT ->
-            if (state.gradientAvailable) {
+            if (state.gradientEditable) {
                 Text(
                     text = stringResource(R.string.effect_uses_gradient),
                     color = MaterialTheme.colorScheme.onSurfaceVariant,

--- a/android/app/src/main/java/com/hooandee/colores/ui/ModePanels.kt
+++ b/android/app/src/main/java/com/hooandee/colores/ui/ModePanels.kt
@@ -534,5 +534,8 @@ private fun effectLabel(id: String): String =
         "sparkle" -> stringResource(R.string.effect_sparkle)
         "ripple" -> stringResource(R.string.effect_ripple)
         "aurora" -> stringResource(R.string.effect_aurora)
+        "marquee" -> stringResource(R.string.effect_marquee)
+        "chasing" -> stringResource(R.string.effect_chasing)
+        "gaming" -> stringResource(R.string.effect_gaming)
         else -> id
     }

--- a/android/app/src/main/res/values-en/strings.xml
+++ b/android/app/src/main/res/values-en/strings.xml
@@ -91,6 +91,9 @@
     <string name="effect_sparkle">Sparkle</string>
     <string name="effect_ripple">Ripple</string>
     <string name="effect_aurora">Aurora</string>
+    <string name="effect_marquee">Marquee</string>
+    <string name="effect_chasing">Chasing</string>
+    <string name="effect_gaming">Gaming</string>
 
     <string name="sensor_battery">Battery</string>
     <string name="sensor_temperature">Temperature</string>

--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -91,6 +91,9 @@
     <string name="effect_sparkle">Destello</string>
     <string name="effect_ripple">Onda</string>
     <string name="effect_aurora">Aurora</string>
+    <string name="effect_marquee">Marquesina</string>
+    <string name="effect_chasing">Persecución</string>
+    <string name="effect_gaming">Juego</string>
 
     <string name="sensor_battery">Batería</string>
     <string name="sensor_temperature">Temperatura</string>

--- a/android/app/src/test/java/com/hooandee/colores/device/DeviceRegistryTest.kt
+++ b/android/app/src/test/java/com/hooandee/colores/device/DeviceRegistryTest.kt
@@ -1,5 +1,6 @@
 package com.hooandee.colores.device
 
+import com.hooandee.colores.led.SettingsProviderDescriptor
 import java.io.File
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
@@ -109,18 +110,19 @@ class DeviceRegistryTest {
         assertTrue(match.capabilities.brightness)
         assertTrue(match.capabilities.perZone)
         assertEquals(8, match.capabilities.zones)
-        assertEquals("htr3212", match.led.driver)
-        assertEquals("pserver", match.led.transport)
-        assertNull(match.led.requiresPermission)
-        assertEquals("joystick_led_light_picker_color", match.led.colorKey)
-        assertEquals(0.0f, match.led.brightnessRange.start)
-        assertEquals(1.0f, match.led.brightnessRange.endInclusive)
-        requireNotNull(match.led.htr3212)
-        assertEquals(1, match.led.htr3212.leftBus)
-        assertEquals(0, match.led.htr3212.rightBus)
-        assertEquals(60, match.led.htr3212.address)
-        assertEquals(listOf(0, 1, 3, 2), match.led.htr3212.leftOrder)
-        assertEquals(listOf(1, 2, 3, 0), match.led.htr3212.rightOrder)
+        val led = match.led as SettingsProviderDescriptor
+        assertEquals("htr3212", led.driver)
+        assertEquals("pserver", led.transport)
+        assertNull(led.requiresPermission)
+        assertEquals("joystick_led_light_picker_color", led.colorKey)
+        assertEquals(0.0f, led.brightnessRange.start)
+        assertEquals(1.0f, led.brightnessRange.endInclusive)
+        requireNotNull(led.htr3212)
+        assertEquals(1, led.htr3212.leftBus)
+        assertEquals(0, led.htr3212.rightBus)
+        assertEquals(60, led.htr3212.address)
+        assertEquals(listOf(0, 1, 3, 2), led.htr3212.leftOrder)
+        assertEquals(listOf(1, 2, 3, 0), led.htr3212.rightOrder)
     }
 
     @Test
@@ -253,19 +255,20 @@ class DeviceRegistryTest {
 
         requireNotNull(match)
         assertEquals("ayn-thor", match.id)
-        assertEquals("htr3212", match.led.driver)
-        assertEquals("pserver", match.led.transport)
+        val led = match.led as SettingsProviderDescriptor
+        assertEquals("htr3212", led.driver)
+        assertEquals("pserver", led.transport)
         assertEquals(8, match.capabilities.zones)
         assertTrue(match.capabilities.perZone)
-        assertEquals("joystick_led_light_picker_color", match.led.colorKey)
-        assertNull(match.led.requiresPermission)
-        assertEquals(listOf("joystick_light_enabled"), match.led.enableKeys)
-        assertEquals("com.odin.gameassistant", match.led.vendorService)
-        requireNotNull(match.led.htr3212)
-        assertEquals(3, match.led.htr3212.leftBus)
-        assertEquals(6, match.led.htr3212.rightBus)
-        assertEquals(60, match.led.htr3212.address)
-        assertEquals(0x0d, match.led.htr3212.rgbStartRegister)
+        assertEquals("joystick_led_light_picker_color", led.colorKey)
+        assertNull(led.requiresPermission)
+        assertEquals(listOf("joystick_light_enabled"), led.enableKeys)
+        assertEquals("com.odin.gameassistant", led.vendorService)
+        requireNotNull(led.htr3212)
+        assertEquals(3, led.htr3212.leftBus)
+        assertEquals(6, led.htr3212.rightBus)
+        assertEquals(60, led.htr3212.address)
+        assertEquals(0x0d, led.htr3212.rgbStartRegister)
     }
 
     @Test
@@ -277,7 +280,57 @@ class DeviceRegistryTest {
                 previewProfilesJson = shared.resolve("led-preview-profiles.json").readText(),
             )
         val match = registry.match(rp5Identity())
-        assertEquals(0x01, match?.led?.htr3212?.rgbStartRegister)
+        assertEquals(0x01, (match?.led as? SettingsProviderDescriptor)?.htr3212?.rgbStartRegister)
+    }
+
+    @Test
+    fun `production registry parses the RP5 grid layout with one cell per zone`() {
+        val shared = File("../../shared")
+        val registry =
+            DeviceRegistry.parse(
+                devicesJson = shared.resolve("devices.json").readText(),
+                previewProfilesJson = shared.resolve("led-preview-profiles.json").readText(),
+            )
+
+        val layout = registry.match(rp5Identity())?.gridLayout
+        requireNotNull(layout)
+        assertEquals(8, layout.size)
+        assertEquals(listOf(0, 0, 0, 0, 1, 1, 1, 1), layout.map { it.stick })
+        assertEquals("top", layout.first().position)
+    }
+
+    @Test
+    fun `a registry entry without a grid layout leaves it null`() {
+        val match = DeviceRegistry.parse(registryJson, previewProfilesJson).match(rp5Identity())
+        assertNull(match?.gridLayout)
+    }
+
+    @Test
+    fun `a grid layout whose length mismatches the zone count is discarded`() {
+        val injected =
+            registryJson.replaceFirst(
+                "\"device\": [\"kona\"],",
+                "\"device\": [\"kona\"], \"gridLayout\": [ { \"row\": 0, \"col\": 0, \"position\": \"top\" } ],",
+            )
+
+        val match = DeviceRegistry.parse(injected, previewProfilesJson).match(rp5Identity())
+        assertNull(match?.gridLayout)
+    }
+
+    @Test
+    fun `a grid layout with an invalid position token is discarded`() {
+        val injected =
+            registryJson.replaceFirst(
+                "\"device\": [\"shared-led-test\"],",
+                "\"device\": [\"shared-led-test\"], \"gridLayout\": [ " +
+                    "{ \"row\": 0, \"col\": 0, \"position\": \"nowhere\" }, { \"row\": 0, \"col\": 1, \"position\": \"left\" } ],",
+            )
+
+        val match =
+            DeviceRegistry.parse(injected, previewProfilesJson).match(
+                AndroidDeviceIdentity("Shared LED Test Device", "shared-led-test", "Test", emptyMap()),
+            )
+        assertNull(match?.gridLayout)
     }
 
     @Test

--- a/android/app/src/test/java/com/hooandee/colores/device/GenericLedResolverTest.kt
+++ b/android/app/src/test/java/com/hooandee/colores/device/GenericLedResolverTest.kt
@@ -31,6 +31,7 @@ class GenericLedResolverTest {
         assertEquals("pserver", led.transport)
         assertNull(led.requiresPermission)
         assertEquals("joystick_led_light_picker_color", led.colorKey)
+        assertTrue(led.enableKeys.containsAll(listOf("left_handle_light_enabled", "right_handle_light_enabled")))
     }
 
     @Test

--- a/android/app/src/test/java/com/hooandee/colores/device/GenericLedResolverTest.kt
+++ b/android/app/src/test/java/com/hooandee/colores/device/GenericLedResolverTest.kt
@@ -1,6 +1,7 @@
 package com.hooandee.colores.device
 
 import com.hooandee.colores.led.SettingsProviderDescriptor
+import com.hooandee.colores.led.SingleAdcJoypadDescriptor
 import com.hooandee.colores.led.SysfsColorKind
 import com.hooandee.colores.led.SysfsRgbDescriptor
 import org.junit.Assert.assertEquals
@@ -65,5 +66,21 @@ class GenericLedResolverTest {
     @Test
     fun `null sysfs descriptor yields no device`() {
         assertNull(GenericLedResolver.sysfs(identity, null))
+    }
+
+    @Test
+    fun `joypad route builds a single zone device`() {
+        val detected = requireNotNull(GenericLedResolver.joypad(identity, SingleAdcJoypadDescriptor("/n")))
+
+        assertEquals("generic-joypad", detected.id)
+        assertEquals(1, detected.capabilities.zones)
+        assertEquals(false, detected.capabilities.perZone)
+        assertTrue(detected.capabilities.color)
+        assertTrue(detected.led is SingleAdcJoypadDescriptor)
+    }
+
+    @Test
+    fun `null joypad descriptor yields no device`() {
+        assertNull(GenericLedResolver.joypad(identity, null))
     }
 }

--- a/android/app/src/test/java/com/hooandee/colores/device/GenericLedResolverTest.kt
+++ b/android/app/src/test/java/com/hooandee/colores/device/GenericLedResolverTest.kt
@@ -1,0 +1,68 @@
+package com.hooandee.colores.device
+
+import com.hooandee.colores.led.SettingsProviderDescriptor
+import com.hooandee.colores.led.SysfsColorKind
+import com.hooandee.colores.led.SysfsRgbDescriptor
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class GenericLedResolverTest {
+    private val identity = AndroidDeviceIdentity("ODIN2 Portal", "kalama", "AYN", emptyMap())
+
+    @Test
+    fun `vendor route needs both the service and the color key`() {
+        assertNull(GenericLedResolver.vendor(identity, pserverAvailable = false, colorKeyValue = "#FF00FF00"))
+        assertNull(GenericLedResolver.vendor(identity, pserverAvailable = true, colorKeyValue = null))
+        assertNull(GenericLedResolver.vendor(identity, pserverAvailable = true, colorKeyValue = "  "))
+    }
+
+    @Test
+    fun `vendor route builds a two zone pserver descriptor from the product name`() {
+        val detected = requireNotNull(GenericLedResolver.vendor(identity, pserverAvailable = true, colorKeyValue = "#FF112233"))
+
+        assertEquals("generic-vendor", detected.id)
+        assertEquals("ODIN2 Portal", detected.friendlyName)
+        assertEquals(2, detected.capabilities.zones)
+        assertTrue(detected.capabilities.perZone)
+        val led = detected.led as SettingsProviderDescriptor
+        assertEquals("settings_provider", led.driver)
+        assertEquals("pserver", led.transport)
+        assertNull(led.requiresPermission)
+        assertEquals("joystick_led_light_picker_color", led.colorKey)
+    }
+
+    @Test
+    fun `sysfs route mirrors the discovered descriptor and zone count`() {
+        val descriptor = SysfsRgbDescriptor("/n", zones = 4, maxBrightness = 255, kind = SysfsColorKind.MULTI_INTENSITY_HEX)
+
+        val detected = requireNotNull(GenericLedResolver.sysfs(identity, descriptor))
+
+        assertEquals("generic-sysfs", detected.id)
+        assertEquals(4, detected.capabilities.zones)
+        assertTrue(detected.capabilities.perZone)
+        assertEquals(descriptor, detected.led)
+    }
+
+    @Test
+    fun `sysfs route reports a single zone without per zone control`() {
+        val descriptor = SysfsRgbDescriptor("/n", zones = 1, maxBrightness = 255, kind = SysfsColorKind.RGB_CHANNELS)
+
+        val detected = requireNotNull(GenericLedResolver.sysfs(identity, descriptor))
+
+        assertEquals(false, detected.capabilities.perZone)
+    }
+
+    @Test
+    fun `falls back to manufacturer then device for the friendly name`() {
+        val blankModel = AndroidDeviceIdentity(model = "", device = "kalama", manufacturer = "AYN", productProperties = emptyMap())
+        val detected = requireNotNull(GenericLedResolver.vendor(blankModel, pserverAvailable = true, colorKeyValue = "#FFFFFFFF"))
+        assertEquals("AYN", detected.friendlyName)
+    }
+
+    @Test
+    fun `null sysfs descriptor yields no device`() {
+        assertNull(GenericLedResolver.sysfs(identity, null))
+    }
+}

--- a/android/app/src/test/java/com/hooandee/colores/device/PlatformSupportContractTest.kt
+++ b/android/app/src/test/java/com/hooandee/colores/device/PlatformSupportContractTest.kt
@@ -12,6 +12,7 @@ class PlatformSupportContractTest {
     private val requiredFeatures =
         setOf(
             "device_detection",
+            "generic_led_discovery",
             "solid_color",
             "per_zone_color",
             "brightness",

--- a/android/app/src/test/java/com/hooandee/colores/device/SingleAdcJoypadDiscoveryTest.kt
+++ b/android/app/src/test/java/com/hooandee/colores/device/SingleAdcJoypadDiscoveryTest.kt
@@ -1,6 +1,6 @@
 package com.hooandee.colores.device
 
-import com.hooandee.colores.led.SysfsAccess
+import com.hooandee.colores.led.FakeSysfsAccess
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNull
 import org.junit.Test
@@ -10,7 +10,7 @@ class SingleAdcJoypadDiscoveryTest {
 
     @Test
     fun `detects the joypad when the color node and latch are writable`() {
-        val access = fakeAccess(setOf("$base/custum_rgb_r", "$base/led_set"))
+        val access = FakeSysfsAccess(setOf("$base/custum_rgb_r", "$base/led_set"))
 
         val descriptor = SingleAdcJoypadDiscovery.scan(base, access)
 
@@ -19,39 +19,17 @@ class SingleAdcJoypadDiscoveryTest {
 
     @Test
     fun `absent when the color node is missing`() {
-        val access = fakeAccess(setOf("$base/led_set"))
+        val access = FakeSysfsAccess(setOf("$base/led_set"))
         assertNull(SingleAdcJoypadDiscovery.scan(base, access))
     }
 
     @Test
     fun `absent when the nodes are read only`() {
         val access =
-            object : SysfsAccess {
-                override fun read(path: String): String? = null
-
-                override fun exists(path: String): Boolean = true
-
-                override fun canWrite(path: String): Boolean = false
-
-                override fun write(
-                    path: String,
-                    value: String,
-                ): Boolean = false
-            }
+            FakeSysfsAccess(
+                writable = emptySet(),
+                values = mutableMapOf("$base/custum_rgb_r" to "0", "$base/led_set" to "0"),
+            )
         assertNull(SingleAdcJoypadDiscovery.scan(base, access))
     }
-
-    private fun fakeAccess(writable: Set<String>): SysfsAccess =
-        object : SysfsAccess {
-            override fun read(path: String): String? = null
-
-            override fun exists(path: String): Boolean = path in writable
-
-            override fun canWrite(path: String): Boolean = path in writable
-
-            override fun write(
-                path: String,
-                value: String,
-            ): Boolean = path in writable
-        }
 }

--- a/android/app/src/test/java/com/hooandee/colores/device/SingleAdcJoypadDiscoveryTest.kt
+++ b/android/app/src/test/java/com/hooandee/colores/device/SingleAdcJoypadDiscoveryTest.kt
@@ -1,0 +1,57 @@
+package com.hooandee.colores.device
+
+import com.hooandee.colores.led.SysfsAccess
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+
+class SingleAdcJoypadDiscoveryTest {
+    private val base = "/sys/bus/platform/devices/singleadc-joypad"
+
+    @Test
+    fun `detects the joypad when the color node and latch are writable`() {
+        val access = fakeAccess(setOf("$base/custum_rgb_r", "$base/led_set"))
+
+        val descriptor = SingleAdcJoypadDiscovery.scan(base, access)
+
+        assertEquals(base, descriptor?.basePath)
+    }
+
+    @Test
+    fun `absent when the color node is missing`() {
+        val access = fakeAccess(setOf("$base/led_set"))
+        assertNull(SingleAdcJoypadDiscovery.scan(base, access))
+    }
+
+    @Test
+    fun `absent when the nodes are read only`() {
+        val access =
+            object : SysfsAccess {
+                override fun read(path: String): String? = null
+
+                override fun exists(path: String): Boolean = true
+
+                override fun canWrite(path: String): Boolean = false
+
+                override fun write(
+                    path: String,
+                    value: String,
+                ): Boolean = false
+            }
+        assertNull(SingleAdcJoypadDiscovery.scan(base, access))
+    }
+
+    private fun fakeAccess(writable: Set<String>): SysfsAccess =
+        object : SysfsAccess {
+            override fun read(path: String): String? = null
+
+            override fun exists(path: String): Boolean = path in writable
+
+            override fun canWrite(path: String): Boolean = path in writable
+
+            override fun write(
+                path: String,
+                value: String,
+            ): Boolean = path in writable
+        }
+}

--- a/android/app/src/test/java/com/hooandee/colores/device/SysfsRgbDiscoveryTest.kt
+++ b/android/app/src/test/java/com/hooandee/colores/device/SysfsRgbDiscoveryTest.kt
@@ -1,0 +1,116 @@
+package com.hooandee.colores.device
+
+import com.hooandee.colores.led.SysfsAccess
+import com.hooandee.colores.led.SysfsColorKind
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+
+class SysfsRgbDiscoveryTest {
+    @Test
+    fun `packed multi intensity node reports one zone per index token`() {
+        val access =
+            fakeAccess(
+                files = mapOf("/sys/leds/rings/multi_index" to "rgb rgb rgb rgb", "/sys/leds/rings/max_brightness" to "255"),
+                writable = setOf("/sys/leds/rings/multi_intensity"),
+            )
+
+        val descriptor = SysfsRgbDiscovery.discover(listOf(node("ally:rgb:joystick_rings", "/sys/leds/rings")), access)
+
+        requireNotNull(descriptor)
+        assertEquals(4, descriptor.zones)
+        assertEquals(SysfsColorKind.MULTI_INTENSITY_HEX, descriptor.kind)
+        assertEquals(255, descriptor.maxBrightness)
+    }
+
+    @Test
+    fun `channel named multi intensity collapses three tokens into one zone`() {
+        val access =
+            fakeAccess(
+                files = mapOf("/sys/leds/rgb/multi_index" to "red green blue"),
+                writable = setOf("/sys/leds/rgb/multi_intensity"),
+            )
+
+        val descriptor = SysfsRgbDiscovery.discover(listOf(node("rgb", "/sys/leds/rgb")), access)
+
+        requireNotNull(descriptor)
+        assertEquals(1, descriptor.zones)
+        assertEquals(SysfsColorKind.MULTI_INTENSITY_DECIMAL, descriptor.kind)
+    }
+
+    @Test
+    fun `separate red green blue channels resolve to a single zone`() {
+        val paths = listOf("red", "green", "blue").map { "/sys/leds/gamepad/$it" }
+        val access = fakeAccess(files = paths.associateWith { "0" }, writable = paths.toSet())
+
+        val descriptor = SysfsRgbDiscovery.discover(listOf(node("gamepad-rgb", "/sys/leds/gamepad")), access)
+
+        requireNotNull(descriptor)
+        assertEquals(1, descriptor.zones)
+        assertEquals(SysfsColorKind.RGB_CHANNELS, descriptor.kind)
+    }
+
+    @Test
+    fun `a clearly named status LED is excluded even when writable`() {
+        val paths = listOf("red", "green", "blue").map { "/sys/leds/notif/$it" }
+        val access = fakeAccess(files = paths.associateWith { "0" }, writable = paths.toSet())
+
+        val descriptor =
+            SysfsRgbDiscovery.discover(listOf(node("rgb:notification", "/sys/leds/notif")), access)
+
+        assertNull(descriptor)
+    }
+
+    @Test
+    fun `prefers an rgb named node over an unnamed one`() {
+        val access =
+            fakeAccess(
+                files =
+                    mapOf(
+                        "/sys/leds/led1/multi_index" to "rgb",
+                        "/sys/leds/rings/multi_index" to "rgb rgb",
+                    ),
+                writable = setOf("/sys/leds/led1/multi_intensity", "/sys/leds/rings/multi_intensity"),
+            )
+
+        val descriptor =
+            SysfsRgbDiscovery.discover(
+                listOf(node("led1", "/sys/leds/led1"), node("rgb:rings", "/sys/leds/rings")),
+                access,
+            )
+
+        assertEquals("/sys/leds/rings", descriptor?.nodePath)
+        assertEquals(2, descriptor?.zones)
+    }
+
+    @Test
+    fun `skips a non writable node and reports no controllable surface`() {
+        val access = fakeAccess(files = mapOf("/sys/leds/rings/multi_index" to "rgb"), writable = emptySet())
+
+        val descriptor = SysfsRgbDiscovery.discover(listOf(node("rgb:rings", "/sys/leds/rings")), access)
+
+        assertNull(descriptor)
+    }
+
+    private fun node(
+        name: String,
+        path: String,
+    ) = SysfsLedNode(name, path)
+
+    private fun fakeAccess(
+        files: Map<String, String>,
+        writable: Set<String>,
+    ): SysfsAccess =
+        object : SysfsAccess {
+            override fun read(path: String): String? = files[path]
+
+            override fun exists(path: String): Boolean = path in files || path in writable
+
+            override fun canWrite(path: String): Boolean = path in writable
+
+            override fun write(
+                path: String,
+                value: String,
+            ): Boolean = path in writable
+        }
+}

--- a/android/app/src/test/java/com/hooandee/colores/device/SysfsRgbDiscoveryTest.kt
+++ b/android/app/src/test/java/com/hooandee/colores/device/SysfsRgbDiscoveryTest.kt
@@ -1,5 +1,6 @@
 package com.hooandee.colores.device
 
+import com.hooandee.colores.led.FakeSysfsAccess
 import com.hooandee.colores.led.SysfsAccess
 import com.hooandee.colores.led.SysfsColorKind
 import org.junit.Assert.assertEquals
@@ -100,17 +101,5 @@ class SysfsRgbDiscoveryTest {
     private fun fakeAccess(
         files: Map<String, String>,
         writable: Set<String>,
-    ): SysfsAccess =
-        object : SysfsAccess {
-            override fun read(path: String): String? = files[path]
-
-            override fun exists(path: String): Boolean = path in files || path in writable
-
-            override fun canWrite(path: String): Boolean = path in writable
-
-            override fun write(
-                path: String,
-                value: String,
-            ): Boolean = path in writable
-        }
+    ): SysfsAccess = FakeSysfsAccess(writable, files.toMutableMap())
 }

--- a/android/app/src/test/java/com/hooandee/colores/led/FakeSysfsAccess.kt
+++ b/android/app/src/test/java/com/hooandee/colores/led/FakeSysfsAccess.kt
@@ -1,0 +1,21 @@
+package com.hooandee.colores.led
+
+internal class FakeSysfsAccess(
+    private val writable: Set<String>,
+    val values: MutableMap<String, String> = mutableMapOf(),
+) : SysfsAccess {
+    override fun read(path: String): String? = values[path]
+
+    override fun exists(path: String): Boolean = path in writable || path in values
+
+    override fun canWrite(path: String): Boolean = path in writable
+
+    override fun write(
+        path: String,
+        value: String,
+    ): Boolean {
+        if (path !in writable) return false
+        values[path] = value.trim()
+        return true
+    }
+}

--- a/android/app/src/test/java/com/hooandee/colores/led/SettingsProviderCodecTest.kt
+++ b/android/app/src/test/java/com/hooandee/colores/led/SettingsProviderCodecTest.kt
@@ -33,6 +33,15 @@ class SettingsProviderCodecTest {
     }
 
     @Test
+    fun `encodePower emits one value per key, master first then scalars`() {
+        assertEquals(listOf("1,1"), SettingsProviderCodec.encodePower(true, 2, keyCount = 1))
+        assertEquals(
+            listOf("1,1", "1", "1", "1", "1"),
+            SettingsProviderCodec.encodePower(true, 2, keyCount = 5),
+        )
+    }
+
+    @Test
     fun `decodes current RP5 settings`() {
         val state =
             SettingsProviderCodec.decode(

--- a/android/app/src/test/java/com/hooandee/colores/led/SettingsProviderLedDeviceTest.kt
+++ b/android/app/src/test/java/com/hooandee/colores/led/SettingsProviderLedDeviceTest.kt
@@ -55,6 +55,25 @@ class SettingsProviderLedDeviceTest {
 
     @OptIn(ExperimentalCoroutinesApi::class)
     @Test
+    fun `asserts every enable key on the first write after reading a heterogeneous state`() =
+        runTest {
+            val store = FakeSettingsStore()
+            store.values["enabled"] = "1"
+            store.values["left"] = "1"
+            store.values["right"] = "0"
+            val device = SettingsProviderLedDevice(descriptor, store, backgroundScope)
+
+            device.readState()
+            device.applyZones(listOf(RgbColor(1, 2, 3), RgbColor(4, 5, 6)), brightness = 80, power = true)
+            runCurrent()
+
+            assertEquals("1,1", store.values["enabled"])
+            assertEquals("1", store.values["left"])
+            assertEquals("1", store.values["right"])
+        }
+
+    @OptIn(ExperimentalCoroutinesApi::class)
+    @Test
     fun `is unavailable when its settings transport is unavailable`() =
         runTest {
             val device = SettingsProviderLedDevice(descriptor, FakeSettingsStore(available = false), backgroundScope)

--- a/android/app/src/test/java/com/hooandee/colores/led/SingleAdcJoypadLedDeviceTest.kt
+++ b/android/app/src/test/java/com/hooandee/colores/led/SingleAdcJoypadLedDeviceTest.kt
@@ -50,6 +50,57 @@ class SingleAdcJoypadLedDeviceTest {
         }
 
     @Test
+    fun `colored hardware effect writes its led mode, speed and color`() =
+        runTest {
+            val access = FakeJoypadAccess(nodes + setOf("$base/led_speed", "$base/Led_rgb_r1", "$base/Led_rgb_g1", "$base/Led_rgb_b1", "$base/Led_rgb_r2", "$base/Led_rgb_g2", "$base/Led_rgb_b2"))
+            val device = SingleAdcJoypadLedDevice(SingleAdcJoypadDescriptor(base), access, backgroundScope)
+
+            assertTrue(device.applyHardwareEffect("breathing", RgbColor(10, 20, 30), brightness = 100, speed = 100, power = true))
+            runCurrent()
+
+            assertEquals("2", access.values["$base/led_mode"])
+            assertEquals("8", access.values["$base/led_speed"])
+            assertEquals("10", access.values["$base/custum_rgb_r"])
+            assertEquals("10", access.values["$base/Led_rgb_r1"])
+            assertEquals("30", access.values["$base/Led_rgb_b2"])
+            assertEquals("1", access.values["$base/led_set"])
+        }
+
+    @Test
+    fun `fixed hardware effect zeroes the zone colors`() =
+        runTest {
+            val access = FakeJoypadAccess(nodes + setOf("$base/led_speed", "$base/Led_rgb_r1", "$base/Led_rgb_g1", "$base/Led_rgb_b1", "$base/Led_rgb_r2", "$base/Led_rgb_g2", "$base/Led_rgb_b2"))
+            val device = SingleAdcJoypadLedDevice(SingleAdcJoypadDescriptor(base), access, backgroundScope)
+
+            device.applyHardwareEffect("marquee", RgbColor(255, 0, 0), brightness = 100, speed = 50, power = true)
+            runCurrent()
+
+            assertEquals("4", access.values["$base/led_mode"])
+            assertEquals("0", access.values["$base/Led_rgb_r1"])
+        }
+
+    @Test
+    fun `unknown hardware effect is rejected`() =
+        runTest {
+            val access = FakeJoypadAccess(nodes)
+            val device = SingleAdcJoypadLedDevice(SingleAdcJoypadDescriptor(base), access, backgroundScope)
+            assertFalse(device.applyHardwareEffect("nope", RgbColor(1, 2, 3), 100, 50, true))
+        }
+
+    @Test
+    fun `exposes anbernic hardware effects`() {
+        val device =
+            SingleAdcJoypadLedDevice(
+                SingleAdcJoypadDescriptor(base),
+                FakeJoypadAccess(nodes),
+                kotlinx.coroutines.CoroutineScope(kotlinx.coroutines.Dispatchers.Unconfined),
+            )
+        assertEquals(listOf("breathing", "rainbow", "marquee", "chasing", "gaming"), device.hardwareEffects.map { it.id })
+        assertTrue(device.hardwareEffects.first { it.id == "breathing" }.needsColor)
+        assertFalse(device.hardwareEffects.first { it.id == "marquee" }.needsColor)
+    }
+
+    @Test
     fun `reports a single zone and no per zone`() {
         val device =
             SingleAdcJoypadLedDevice(

--- a/android/app/src/test/java/com/hooandee/colores/led/SingleAdcJoypadLedDeviceTest.kt
+++ b/android/app/src/test/java/com/hooandee/colores/led/SingleAdcJoypadLedDeviceTest.kt
@@ -1,0 +1,94 @@
+package com.hooandee.colores.led
+
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.runCurrent
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class SingleAdcJoypadLedDeviceTest {
+    private val base = "/sys/bus/platform/devices/singleadc-joypad"
+    private val nodes =
+        listOf("custum_rgb_r", "custum_rgb_g", "custum_rgb_b", "led_level", "led_mode", "led_switch", "led_set")
+            .map { "$base/$it" }
+            .toSet()
+
+    @Test
+    fun `static color writes custum rgb, level, mode and latches led_set`() =
+        runTest {
+            val access = FakeJoypadAccess(nodes)
+            val device = SingleAdcJoypadLedDevice(SingleAdcJoypadDescriptor(base), access, backgroundScope)
+
+            device.applySolid(RgbColor(255, 128, 0), brightness = 80, power = true)
+            runCurrent()
+
+            assertEquals("255", access.values["$base/custum_rgb_r"])
+            assertEquals("128", access.values["$base/custum_rgb_g"])
+            assertEquals("0", access.values["$base/custum_rgb_b"])
+            assertEquals("80", access.values["$base/led_level"])
+            assertEquals("1", access.values["$base/led_mode"])
+            assertEquals("1", access.values["$base/led_switch"])
+            assertEquals("1", access.values["$base/led_set"])
+        }
+
+    @Test
+    fun `power off drops the switch and still latches`() =
+        runTest {
+            val access = FakeJoypadAccess(nodes)
+            val device = SingleAdcJoypadLedDevice(SingleAdcJoypadDescriptor(base), access, backgroundScope)
+
+            device.applySolid(RgbColor(255, 0, 0), brightness = 100, power = false)
+            runCurrent()
+
+            assertEquals("0", access.values["$base/led_switch"])
+            assertEquals("1", access.values["$base/led_set"])
+            assertNull(access.values["$base/custum_rgb_r"])
+        }
+
+    @Test
+    fun `reports a single zone and no per zone`() {
+        val device =
+            SingleAdcJoypadLedDevice(
+                SingleAdcJoypadDescriptor(base),
+                FakeJoypadAccess(nodes),
+                kotlinx.coroutines.CoroutineScope(kotlinx.coroutines.Dispatchers.Unconfined),
+            )
+        assertFalse(device.supportsPerZone)
+        assertTrue(device.available)
+    }
+
+    @Test
+    fun `is unavailable when the nodes are not writable`() {
+        val device =
+            SingleAdcJoypadLedDevice(
+                SingleAdcJoypadDescriptor(base),
+                FakeJoypadAccess(emptySet()),
+                kotlinx.coroutines.CoroutineScope(kotlinx.coroutines.Dispatchers.Unconfined),
+            )
+        assertFalse(device.available)
+    }
+}
+
+private class FakeJoypadAccess(
+    private val writable: Set<String>,
+    val values: MutableMap<String, String> = mutableMapOf(),
+) : SysfsAccess {
+    override fun read(path: String): String? = values[path]
+
+    override fun exists(path: String): Boolean = path in writable || path in values
+
+    override fun canWrite(path: String): Boolean = path in writable
+
+    override fun write(
+        path: String,
+        value: String,
+    ): Boolean {
+        if (path !in writable) return false
+        values[path] = value.trim()
+        return true
+    }
+}

--- a/android/app/src/test/java/com/hooandee/colores/led/SingleAdcJoypadLedDeviceTest.kt
+++ b/android/app/src/test/java/com/hooandee/colores/led/SingleAdcJoypadLedDeviceTest.kt
@@ -20,7 +20,7 @@ class SingleAdcJoypadLedDeviceTest {
     @Test
     fun `static color writes custum rgb, level, mode and latches led_set`() =
         runTest {
-            val access = FakeJoypadAccess(nodes)
+            val access = FakeSysfsAccess(nodes)
             val device = SingleAdcJoypadLedDevice(SingleAdcJoypadDescriptor(base), access, backgroundScope)
 
             device.applySolid(RgbColor(255, 128, 0), brightness = 80, power = true)
@@ -38,7 +38,7 @@ class SingleAdcJoypadLedDeviceTest {
     @Test
     fun `power off drops the switch and still latches`() =
         runTest {
-            val access = FakeJoypadAccess(nodes)
+            val access = FakeSysfsAccess(nodes)
             val device = SingleAdcJoypadLedDevice(SingleAdcJoypadDescriptor(base), access, backgroundScope)
 
             device.applySolid(RgbColor(255, 0, 0), brightness = 100, power = false)
@@ -55,7 +55,7 @@ class SingleAdcJoypadLedDeviceTest {
     @Test
     fun `two color hardware effect writes a distinct colour per zone slot`() =
         runTest {
-            val access = FakeJoypadAccess(allNodes)
+            val access = FakeSysfsAccess(allNodes)
             val device = SingleAdcJoypadLedDevice(SingleAdcJoypadDescriptor(base), access, backgroundScope)
 
             assertTrue(
@@ -82,7 +82,7 @@ class SingleAdcJoypadLedDeviceTest {
     @Test
     fun `single colour list mirrors the colour to both zone slots`() =
         runTest {
-            val access = FakeJoypadAccess(allNodes)
+            val access = FakeSysfsAccess(allNodes)
             val device = SingleAdcJoypadLedDevice(SingleAdcJoypadDescriptor(base), access, backgroundScope)
 
             device.applyHardwareEffect("chasing", listOf(RgbColor(9, 8, 7)), brightness = 100, speed = 0, power = true)
@@ -95,7 +95,7 @@ class SingleAdcJoypadLedDeviceTest {
     @Test
     fun `fixed hardware effect zeroes the zone colors`() =
         runTest {
-            val access = FakeJoypadAccess(allNodes)
+            val access = FakeSysfsAccess(allNodes)
             val device = SingleAdcJoypadLedDevice(SingleAdcJoypadDescriptor(base), access, backgroundScope)
 
             device.applyHardwareEffect("marquee", listOf(RgbColor(255, 0, 0)), brightness = 100, speed = 50, power = true)
@@ -108,7 +108,7 @@ class SingleAdcJoypadLedDeviceTest {
     @Test
     fun `unknown hardware effect is rejected`() =
         runTest {
-            val access = FakeJoypadAccess(nodes)
+            val access = FakeSysfsAccess(nodes)
             val device = SingleAdcJoypadLedDevice(SingleAdcJoypadDescriptor(base), access, backgroundScope)
             assertFalse(device.applyHardwareEffect("nope", listOf(RgbColor(1, 2, 3)), 100, 50, true))
         }
@@ -118,7 +118,7 @@ class SingleAdcJoypadLedDeviceTest {
         val device =
             SingleAdcJoypadLedDevice(
                 SingleAdcJoypadDescriptor(base),
-                FakeJoypadAccess(nodes),
+                FakeSysfsAccess(nodes),
                 kotlinx.coroutines.CoroutineScope(kotlinx.coroutines.Dispatchers.Unconfined),
             )
         assertEquals(listOf("breathing", "rainbow", "marquee", "chasing", "gaming"), device.hardwareEffects.map { it.id })
@@ -132,7 +132,7 @@ class SingleAdcJoypadLedDeviceTest {
         val device =
             SingleAdcJoypadLedDevice(
                 SingleAdcJoypadDescriptor(base),
-                FakeJoypadAccess(nodes),
+                FakeSysfsAccess(nodes),
                 kotlinx.coroutines.CoroutineScope(kotlinx.coroutines.Dispatchers.Unconfined),
             )
         assertFalse(device.supportsPerZone)
@@ -144,29 +144,9 @@ class SingleAdcJoypadLedDeviceTest {
         val device =
             SingleAdcJoypadLedDevice(
                 SingleAdcJoypadDescriptor(base),
-                FakeJoypadAccess(emptySet()),
+                FakeSysfsAccess(emptySet()),
                 kotlinx.coroutines.CoroutineScope(kotlinx.coroutines.Dispatchers.Unconfined),
             )
         assertFalse(device.available)
-    }
-}
-
-private class FakeJoypadAccess(
-    private val writable: Set<String>,
-    val values: MutableMap<String, String> = mutableMapOf(),
-) : SysfsAccess {
-    override fun read(path: String): String? = values[path]
-
-    override fun exists(path: String): Boolean = path in writable || path in values
-
-    override fun canWrite(path: String): Boolean = path in writable
-
-    override fun write(
-        path: String,
-        value: String,
-    ): Boolean {
-        if (path !in writable) return false
-        values[path] = value.trim()
-        return true
     }
 }

--- a/android/app/src/test/java/com/hooandee/colores/led/SingleAdcJoypadLedDeviceTest.kt
+++ b/android/app/src/test/java/com/hooandee/colores/led/SingleAdcJoypadLedDeviceTest.kt
@@ -49,30 +49,55 @@ class SingleAdcJoypadLedDeviceTest {
             assertNull(access.values["$base/custum_rgb_r"])
         }
 
+    private val allNodes =
+        nodes + setOf("$base/led_speed", "$base/Led_rgb_r1", "$base/Led_rgb_g1", "$base/Led_rgb_b1", "$base/Led_rgb_r2", "$base/Led_rgb_g2", "$base/Led_rgb_b2")
+
     @Test
-    fun `colored hardware effect writes its led mode, speed and color`() =
+    fun `two color hardware effect writes a distinct colour per zone slot`() =
         runTest {
-            val access = FakeJoypadAccess(nodes + setOf("$base/led_speed", "$base/Led_rgb_r1", "$base/Led_rgb_g1", "$base/Led_rgb_b1", "$base/Led_rgb_r2", "$base/Led_rgb_g2", "$base/Led_rgb_b2"))
+            val access = FakeJoypadAccess(allNodes)
             val device = SingleAdcJoypadLedDevice(SingleAdcJoypadDescriptor(base), access, backgroundScope)
 
-            assertTrue(device.applyHardwareEffect("breathing", RgbColor(10, 20, 30), brightness = 100, speed = 100, power = true))
+            assertTrue(
+                device.applyHardwareEffect(
+                    "breathing",
+                    listOf(RgbColor(10, 20, 30), RgbColor(40, 50, 60)),
+                    brightness = 100,
+                    speed = 100,
+                    power = true,
+                ),
+            )
             runCurrent()
 
             assertEquals("2", access.values["$base/led_mode"])
             assertEquals("8", access.values["$base/led_speed"])
-            assertEquals("10", access.values["$base/custum_rgb_r"])
             assertEquals("10", access.values["$base/Led_rgb_r1"])
-            assertEquals("30", access.values["$base/Led_rgb_b2"])
+            assertEquals("20", access.values["$base/Led_rgb_g1"])
+            assertEquals("40", access.values["$base/Led_rgb_r2"])
+            assertEquals("60", access.values["$base/Led_rgb_b2"])
             assertEquals("1", access.values["$base/led_set"])
+        }
+
+    @Test
+    fun `single colour list mirrors the colour to both zone slots`() =
+        runTest {
+            val access = FakeJoypadAccess(allNodes)
+            val device = SingleAdcJoypadLedDevice(SingleAdcJoypadDescriptor(base), access, backgroundScope)
+
+            device.applyHardwareEffect("chasing", listOf(RgbColor(9, 8, 7)), brightness = 100, speed = 0, power = true)
+            runCurrent()
+
+            assertEquals("9", access.values["$base/Led_rgb_r1"])
+            assertEquals("9", access.values["$base/Led_rgb_r2"])
         }
 
     @Test
     fun `fixed hardware effect zeroes the zone colors`() =
         runTest {
-            val access = FakeJoypadAccess(nodes + setOf("$base/led_speed", "$base/Led_rgb_r1", "$base/Led_rgb_g1", "$base/Led_rgb_b1", "$base/Led_rgb_r2", "$base/Led_rgb_g2", "$base/Led_rgb_b2"))
+            val access = FakeJoypadAccess(allNodes)
             val device = SingleAdcJoypadLedDevice(SingleAdcJoypadDescriptor(base), access, backgroundScope)
 
-            device.applyHardwareEffect("marquee", RgbColor(255, 0, 0), brightness = 100, speed = 50, power = true)
+            device.applyHardwareEffect("marquee", listOf(RgbColor(255, 0, 0)), brightness = 100, speed = 50, power = true)
             runCurrent()
 
             assertEquals("4", access.values["$base/led_mode"])
@@ -84,11 +109,11 @@ class SingleAdcJoypadLedDeviceTest {
         runTest {
             val access = FakeJoypadAccess(nodes)
             val device = SingleAdcJoypadLedDevice(SingleAdcJoypadDescriptor(base), access, backgroundScope)
-            assertFalse(device.applyHardwareEffect("nope", RgbColor(1, 2, 3), 100, 50, true))
+            assertFalse(device.applyHardwareEffect("nope", listOf(RgbColor(1, 2, 3)), 100, 50, true))
         }
 
     @Test
-    fun `exposes anbernic hardware effects`() {
+    fun `exposes anbernic hardware effects with two colour stops for the coloured ones`() {
         val device =
             SingleAdcJoypadLedDevice(
                 SingleAdcJoypadDescriptor(base),
@@ -96,8 +121,9 @@ class SingleAdcJoypadLedDeviceTest {
                 kotlinx.coroutines.CoroutineScope(kotlinx.coroutines.Dispatchers.Unconfined),
             )
         assertEquals(listOf("breathing", "rainbow", "marquee", "chasing", "gaming"), device.hardwareEffects.map { it.id })
-        assertTrue(device.hardwareEffects.first { it.id == "breathing" }.needsColor)
-        assertFalse(device.hardwareEffects.first { it.id == "marquee" }.needsColor)
+        assertEquals(2, device.hardwareEffects.first { it.id == "breathing" }.colorStops)
+        assertEquals(2, device.hardwareEffects.first { it.id == "chasing" }.colorStops)
+        assertEquals(0, device.hardwareEffects.first { it.id == "marquee" }.colorStops)
     }
 
     @Test

--- a/android/app/src/test/java/com/hooandee/colores/led/SingleAdcJoypadLedDeviceTest.kt
+++ b/android/app/src/test/java/com/hooandee/colores/led/SingleAdcJoypadLedDeviceTest.kt
@@ -71,10 +71,11 @@ class SingleAdcJoypadLedDeviceTest {
 
             assertEquals("2", access.values["$base/led_mode"])
             assertEquals("8", access.values["$base/led_speed"])
-            assertEquals("10", access.values["$base/Led_rgb_r1"])
-            assertEquals("20", access.values["$base/Led_rgb_g1"])
-            assertEquals("40", access.values["$base/Led_rgb_r2"])
-            assertEquals("60", access.values["$base/Led_rgb_b2"])
+            assertEquals("10", access.values["$base/custum_rgb_r"])
+            assertEquals("10", access.values["$base/Led_rgb_r2"])
+            assertEquals("30", access.values["$base/Led_rgb_b2"])
+            assertEquals("40", access.values["$base/Led_rgb_r1"])
+            assertEquals("60", access.values["$base/Led_rgb_b1"])
             assertEquals("1", access.values["$base/led_set"])
         }
 

--- a/android/app/src/test/java/com/hooandee/colores/led/SysfsRgbDeviceTest.kt
+++ b/android/app/src/test/java/com/hooandee/colores/led/SysfsRgbDeviceTest.kt
@@ -1,0 +1,119 @@
+package com.hooandee.colores.led
+
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.runCurrent
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class SysfsRgbDeviceTest {
+    @Test
+    fun `hex multi intensity writes packed colors per zone and scaled brightness`() =
+        runTest {
+            val access = FakeSysfsAccess(writable = setOf("/n/multi_intensity", "/n/brightness"))
+            val device =
+                SysfsRgbDevice(
+                    SysfsRgbDescriptor("/n", zones = 2, maxBrightness = 255, kind = SysfsColorKind.MULTI_INTENSITY_HEX),
+                    access,
+                    backgroundScope,
+                )
+
+            assertTrue(device.applyZones(listOf(RgbColor(255, 0, 0), RgbColor(0, 255, 0)), brightness = 100, power = true))
+            runCurrent()
+
+            assertEquals("0xFF0000 0x00FF00", access.values["/n/multi_intensity"])
+            assertEquals("255", access.values["/n/brightness"])
+        }
+
+    @Test
+    fun `decimal multi intensity writes per channel values`() =
+        runTest {
+            val access = FakeSysfsAccess(writable = setOf("/n/multi_intensity", "/n/brightness"))
+            val device =
+                SysfsRgbDevice(
+                    SysfsRgbDescriptor("/n", zones = 2, maxBrightness = 255, kind = SysfsColorKind.MULTI_INTENSITY_DECIMAL),
+                    access,
+                    backgroundScope,
+                )
+
+            device.applyZones(listOf(RgbColor(10, 20, 30), RgbColor(40, 50, 60)), brightness = 50, power = true)
+            runCurrent()
+
+            assertEquals("10 20 30 40 50 60", access.values["/n/multi_intensity"])
+            assertEquals("128", access.values["/n/brightness"])
+        }
+
+    @Test
+    fun `rgb channels scale to max brightness`() =
+        runTest {
+            val access = FakeSysfsAccess(writable = setOf("/n/red", "/n/green", "/n/blue", "/n/brightness"))
+            val device =
+                SysfsRgbDevice(
+                    SysfsRgbDescriptor("/n", zones = 1, maxBrightness = 100, kind = SysfsColorKind.RGB_CHANNELS),
+                    access,
+                    backgroundScope,
+                )
+
+            device.applySolid(RgbColor(255, 0, 0), brightness = 100, power = true)
+            runCurrent()
+
+            assertEquals("100", access.values["/n/red"])
+            assertEquals("0", access.values["/n/green"])
+            assertEquals("0", access.values["/n/blue"])
+            assertEquals("100", access.values["/n/brightness"])
+        }
+
+    @Test
+    fun `power off clears the channels and brightness`() =
+        runTest {
+            val access = FakeSysfsAccess(writable = setOf("/n/red", "/n/green", "/n/blue", "/n/brightness"))
+            val device =
+                SysfsRgbDevice(
+                    SysfsRgbDescriptor("/n", zones = 1, maxBrightness = 100, kind = SysfsColorKind.RGB_CHANNELS),
+                    access,
+                    backgroundScope,
+                )
+
+            device.applySolid(RgbColor(255, 0, 0), brightness = 100, power = false)
+            runCurrent()
+
+            assertEquals("0", access.values["/n/red"])
+            assertEquals("0", access.values["/n/brightness"])
+        }
+
+    @Test
+    fun `is unavailable when the color node is not writable`() {
+        val access = FakeSysfsAccess(writable = emptySet())
+        val device =
+            SysfsRgbDevice(
+                SysfsRgbDescriptor("/n", zones = 1, maxBrightness = 255, kind = SysfsColorKind.MULTI_INTENSITY_HEX),
+                access,
+                kotlinx.coroutines.CoroutineScope(kotlinx.coroutines.Dispatchers.Unconfined),
+            )
+
+        assertFalse(device.available)
+    }
+}
+
+private class FakeSysfsAccess(
+    private val writable: Set<String>,
+    val values: MutableMap<String, String> = mutableMapOf(),
+) : SysfsAccess {
+    override fun read(path: String): String? = values[path]
+
+    override fun exists(path: String): Boolean = path in writable || path in values
+
+    override fun canWrite(path: String): Boolean = path in writable
+
+    override fun write(
+        path: String,
+        value: String,
+    ): Boolean {
+        if (path !in writable) return false
+        values[path] = value
+        return true
+    }
+}

--- a/android/app/src/test/java/com/hooandee/colores/led/SysfsRgbDeviceTest.kt
+++ b/android/app/src/test/java/com/hooandee/colores/led/SysfsRgbDeviceTest.kt
@@ -97,23 +97,3 @@ class SysfsRgbDeviceTest {
         assertFalse(device.available)
     }
 }
-
-private class FakeSysfsAccess(
-    private val writable: Set<String>,
-    val values: MutableMap<String, String> = mutableMapOf(),
-) : SysfsAccess {
-    override fun read(path: String): String? = values[path]
-
-    override fun exists(path: String): Boolean = path in writable || path in values
-
-    override fun canWrite(path: String): Boolean = path in writable
-
-    override fun write(
-        path: String,
-        value: String,
-    ): Boolean {
-        if (path !in writable) return false
-        values[path] = value
-        return true
-    }
-}

--- a/android/app/src/test/java/com/hooandee/colores/ui/ControlAccessTest.kt
+++ b/android/app/src/test/java/com/hooandee/colores/ui/ControlAccessTest.kt
@@ -1,10 +1,36 @@
 package com.hooandee.colores.ui
 
 import com.hooandee.colores.led.SettingsProviderDescriptor
+import com.hooandee.colores.led.SysfsColorKind
+import com.hooandee.colores.led.SysfsRgbDescriptor
 import org.junit.Assert.assertEquals
 import org.junit.Test
 
 class ControlAccessTest {
+    @Test
+    fun `writable sysfs node enables controls without a permission`() {
+        assertEquals(
+            ControlAccess.ENABLED,
+            ControlAccess.resolve(
+                SysfsRgbDescriptor("/n", zones = 1, maxBrightness = 255, kind = SysfsColorKind.RGB_CHANNELS),
+                deviceAvailable = true,
+                userPermissionGranted = false,
+            ),
+        )
+    }
+
+    @Test
+    fun `non writable sysfs node is unavailable`() {
+        assertEquals(
+            ControlAccess.SERVICE_UNAVAILABLE,
+            ControlAccess.resolve(
+                SysfsRgbDescriptor("/n", zones = 1, maxBrightness = 255, kind = SysfsColorKind.RGB_CHANNELS),
+                deviceAvailable = false,
+                userPermissionGranted = true,
+            ),
+        )
+    }
+
     @Test
     fun `PServer enables controls without a user permission`() {
         assertEquals(

--- a/android/app/src/test/java/com/hooandee/colores/ui/ControlAccessTest.kt
+++ b/android/app/src/test/java/com/hooandee/colores/ui/ControlAccessTest.kt
@@ -1,12 +1,21 @@
 package com.hooandee.colores.ui
 
 import com.hooandee.colores.led.SettingsProviderDescriptor
+import com.hooandee.colores.led.SingleAdcJoypadDescriptor
 import com.hooandee.colores.led.SysfsColorKind
 import com.hooandee.colores.led.SysfsRgbDescriptor
 import org.junit.Assert.assertEquals
 import org.junit.Test
 
 class ControlAccessTest {
+    @Test
+    fun `writable joypad enables controls without a permission`() {
+        assertEquals(
+            ControlAccess.ENABLED,
+            ControlAccess.resolve(SingleAdcJoypadDescriptor("/n"), deviceAvailable = true, userPermissionGranted = false),
+        )
+    }
+
     @Test
     fun `writable sysfs node enables controls without a permission`() {
         assertEquals(

--- a/android/app/src/test/java/com/hooandee/colores/ui/GradientEditorModelTest.kt
+++ b/android/app/src/test/java/com/hooandee/colores/ui/GradientEditorModelTest.kt
@@ -1,14 +1,39 @@
 package com.hooandee.colores.ui
 
+import com.hooandee.colores.device.LedGridCell
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
 import org.junit.Test
 
 class GradientEditorModelTest {
+    private val rp5Layout =
+        listOf(
+            LedGridCell(0, 0, 0, "top"),
+            LedGridCell(0, 0, 1, "left"),
+            LedGridCell(0, 1, 0, "bottom"),
+            LedGridCell(0, 1, 1, "right"),
+            LedGridCell(1, 0, 0, "top"),
+            LedGridCell(1, 0, 1, "left"),
+            LedGridCell(1, 1, 0, "bottom"),
+            LedGridCell(1, 1, 1, "right"),
+        )
+
+    private val thorLayout =
+        listOf(
+            LedGridCell(0, 0, 0, "top_left"),
+            LedGridCell(0, 1, 0, "bottom_left"),
+            LedGridCell(0, 1, 1, "bottom_right"),
+            LedGridCell(0, 0, 1, "top_right"),
+            LedGridCell(1, 1, 0, "bottom_left"),
+            LedGridCell(1, 0, 0, "top_left"),
+            LedGridCell(1, 0, 1, "top_right"),
+            LedGridCell(1, 1, 1, "bottom_right"),
+        )
+
     @Test
-    fun `RP5 zones are grouped into two sticks with cardinal positions`() {
-        val zones = gradientEditorZones("retroid-pocket-5", 8)
+    fun `data layout groups zones into two sticks with cardinal positions`() {
+        val zones = gradientEditorZones(rp5Layout, 8)
 
         assertEquals((0..7).toList(), zones.map { it.index })
         assertEquals(List(4) { 0 } + List(4) { 1 }, zones.map { it.stick })
@@ -24,8 +49,8 @@ class GradientEditorModelTest {
     }
 
     @Test
-    fun `AYN Thor zones map to a calibrated two by two grid, mirrored between sticks`() {
-        val zones = gradientEditorZones("ayn-thor", 8)
+    fun `data layout maps a calibrated two by two grid, mirrored between sticks`() {
+        val zones = gradientEditorZones(thorLayout, 8)
 
         assertEquals(List(4) { 0 } + List(4) { 1 }, zones.map { it.stick })
         val left = zones.take(4)
@@ -43,8 +68,8 @@ class GradientEditorModelTest {
     }
 
     @Test
-    fun `unknown layouts fall back to a numbered grid of up to four columns`() {
-        val zones = gradientEditorZones("unknown", 6)
+    fun `null layout falls back to a numbered grid of up to four columns`() {
+        val zones = gradientEditorZones(null, 6)
 
         assertEquals(listOf(0, 1, 2, 3, 4, 5), zones.map { it.index })
         zones.forEach {
@@ -55,5 +80,13 @@ class GradientEditorModelTest {
         assertEquals(0 to 3, zones[3].row to zones[3].col)
         assertEquals(1 to 0, zones[4].row to zones[4].col)
         assertTrue(zones.all { it.col in 0..3 })
+    }
+
+    @Test
+    fun `layout of the wrong length falls back to a numbered grid`() {
+        val zones = gradientEditorZones(rp5Layout, 6)
+
+        zones.forEach { assertNull(it.stick) }
+        assertEquals(0 to 0, zones[0].row to zones[0].col)
     }
 }

--- a/android/app/src/test/java/com/hooandee/colores/ui/GridLayoutContractTest.kt
+++ b/android/app/src/test/java/com/hooandee/colores/ui/GridLayoutContractTest.kt
@@ -1,0 +1,55 @@
+package com.hooandee.colores.ui
+
+import com.hooandee.colores.device.AndroidDeviceIdentity
+import com.hooandee.colores.device.DeviceRegistry
+import java.io.File
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Test
+
+class GridLayoutContractTest {
+    private val registry =
+        DeviceRegistry.parse(
+            devicesJson = File("../../shared/devices.json").readText(),
+            previewProfilesJson = File("../../shared/led-preview-profiles.json").readText(),
+        )
+
+    @Test
+    fun `RP5 shared grid layout reproduces the calibrated cardinal grid`() {
+        val match =
+            requireNotNull(
+                registry.match(AndroidDeviceIdentity("Retroid Pocket 5", "kona", "Moorechip", emptyMap())),
+            )
+        assertNotNull(match.gridLayout)
+
+        val zones = gradientEditorZones(match.gridLayout, match.capabilities.zones)
+
+        assertEquals(List(4) { 0 } + List(4) { 1 }, zones.map { it.stick })
+        assertEquals(
+            listOf(
+                GradientZonePosition.TOP,
+                GradientZonePosition.LEFT,
+                GradientZonePosition.BOTTOM,
+                GradientZonePosition.RIGHT,
+            ).let { it + it },
+            zones.map { it.position },
+        )
+    }
+
+    @Test
+    fun `AYN Thor shared grid layout reproduces the calibrated mirrored grid`() {
+        val match =
+            requireNotNull(
+                registry.match(AndroidDeviceIdentity("AYN Thor", "kalama", "AYN", emptyMap())),
+            )
+        assertNotNull(match.gridLayout)
+
+        val zones = gradientEditorZones(match.gridLayout, match.capabilities.zones)
+
+        assertEquals(List(4) { 0 } + List(4) { 1 }, zones.map { it.stick })
+        assertEquals(GradientZonePosition.TOP_LEFT, zones[0].position)
+        assertEquals(GradientZonePosition.BOTTOM_LEFT, zones[1].position)
+        assertEquals(GradientZonePosition.BOTTOM_LEFT, zones[4].position)
+        assertEquals(GradientZonePosition.TOP_LEFT, zones[5].position)
+    }
+}

--- a/shared/README.md
+++ b/shared/README.md
@@ -25,7 +25,11 @@ El bloque `android` puede declarar listas `model`, `device` y un objeto `led`. P
 
 El driver `htr3212` conserva esos campos para el estado oficial de brillo, encendido y color de respaldo, y añade un bloque `htr3212` con `leftBus`, `rightBus`, `address`, `leftOrder` y `rightOrder`. Las listas de orden traducen cada zona lógica del joystick, en orden arriba/izquierda/abajo/derecha, al grupo físico `0..3` del controlador. Deben ser permutaciones completas y calibradas en el dispositivo real.
 
+El bloque `android` puede declarar `gridLayout`, la disposición física de las zonas para el editor de gradiente. Es una lista de celdas con exactamente una entrada por zona, en el orden lógico del dispositivo. Cada celda tiene `stick` (entero de agrupación por joystick, o `null` si no se agrupa), `row`, `col` y `position`. `position` es `null` o uno de `top`, `left`, `bottom`, `right`, `top_left`, `top_right`, `bottom_left`, `bottom_right`. Si `gridLayout` falta, su longitud no coincide con el número de zonas o alguna celda es inválida, la plataforma cae a una rejilla numerada por defecto. Es dato de calibración: añadir una máquina es dato, no código.
+
 Una entrada puede declarar `previewProfile` para aproximar en la interfaz la apariencia de sus LEDs físicos. Si la referencia falta o no se resuelve, la plataforma muestra el RGB exacto y no ofrece la vista calibrada.
+
+Cuando ninguna entrada casa por `model`/`device`, cada plataforma intenta descubrir la superficie de control de forma genérica (en Android: servicio vendor tipo PServer con las claves estándar, luego un nodo sysfs escribible), sin entrada por-modelo. El registro se reserva para lo que necesita calibración fina (mapas de registro, orden de zonas, buses, `gridLayout`).
 
 ## `led-preview-profiles.json`
 

--- a/shared/devices.json
+++ b/shared/devices.json
@@ -23,7 +23,17 @@
           "leftOrder": [0, 1, 3, 2],
           "rightOrder": [1, 2, 3, 0]
         }
-      }
+      },
+      "gridLayout": [
+        { "stick": 0, "row": 0, "col": 0, "position": "top" },
+        { "stick": 0, "row": 0, "col": 1, "position": "left" },
+        { "stick": 0, "row": 1, "col": 0, "position": "bottom" },
+        { "stick": 0, "row": 1, "col": 1, "position": "right" },
+        { "stick": 1, "row": 0, "col": 0, "position": "top" },
+        { "stick": 1, "row": 0, "col": 1, "position": "left" },
+        { "stick": 1, "row": 1, "col": 0, "position": "bottom" },
+        { "stick": 1, "row": 1, "col": 1, "position": "right" }
+      ]
     },
     "linux": null,
     "capabilities": { "color": true, "brightness": true, "perZone": true },
@@ -54,7 +64,17 @@
           "rightOrder": [0, 1, 2, 3],
           "rgbStartRegister": 13
         }
-      }
+      },
+      "gridLayout": [
+        { "stick": 0, "row": 0, "col": 0, "position": "top_left" },
+        { "stick": 0, "row": 1, "col": 0, "position": "bottom_left" },
+        { "stick": 0, "row": 1, "col": 1, "position": "bottom_right" },
+        { "stick": 0, "row": 0, "col": 1, "position": "top_right" },
+        { "stick": 1, "row": 1, "col": 0, "position": "bottom_left" },
+        { "stick": 1, "row": 0, "col": 0, "position": "top_left" },
+        { "stick": 1, "row": 0, "col": 1, "position": "top_right" },
+        { "stick": 1, "row": 1, "col": 1, "position": "bottom_right" }
+      ]
     },
     "linux": null,
     "capabilities": { "color": true, "brightness": true, "perZone": true },

--- a/shared/platform-support.json
+++ b/shared/platform-support.json
@@ -8,6 +8,11 @@
       "platforms": { "decky": "validated", "android": "validated", "windows": "deferred" }
     },
     {
+      "id": "generic_led_discovery",
+      "contracts": ["devices.json"],
+      "platforms": { "decky": "validated", "android": "implemented", "windows": "deferred" }
+    },
+    {
       "id": "solid_color",
       "contracts": ["devices.json"],
       "platforms": { "decky": "validated", "android": "validated", "windows": "deferred" }

--- a/shared/platform-support.json
+++ b/shared/platform-support.json
@@ -85,7 +85,7 @@
     {
       "id": "hardware_effects",
       "contracts": ["devices.json"],
-      "platforms": { "decky": "validated", "android": "planned", "windows": "deferred" }
+      "platforms": { "decky": "validated", "android": "implemented", "windows": "deferred" }
     }
   ]
 }


### PR DESCRIPTION
Brings the Android app in line with the project's core principle — adapt to any handheld with no per-model config — and adds Anbernic support end to end. All hardware claims below were verified on real devices (AYN ODIN 2 Portal, Anbernic RG Cube).

## Generic LED discovery (behind the existing `LedDevice` seam)
When no `shared/devices.json` entry matches by model, `AndroidDeviceDetector` now falls through a resolution chain instead of reporting "no LEDs":

1. **Model match** (calibrated, existing)
2. **Vendor / PServer** — `PServerBinder` present + the standard joystick colour key readable → a `settings_provider`/`pserver` descriptor (covers RP/AYN clones). Verified on the ODIN 2 Portal (detects + per-stick colour); also fixed the AYN handle-light enables so the route actually lights up.
3. **Anbernic `singleadc-joypad`** — reverse-engineered on an RG Cube: `custum_rgb` (main) + `Led_rgb_1/2` (follow) + `led_mode/level/speed/switch` latched by `led_set`; world-writable, no root. Solid colour + 6 hardware effects (breathing/rainbow/marquee/chasing/gaming), with two-colour input for the colour-aware ones, matching the reference controllers (GammaRGB, MustardOS).
4. **Generic sysfs** — a writable `multi_intensity` or `red/green/blue` node under `/sys/class/leds`, excluding clearly-named status LEDs.
5. **"No controllable LEDs"** — clean graceful degradation (verified on the RG Cube before the joypad driver, and it correctly does not hijack the PMIC notification LED).

## Layout as data
The per-device gradient grid (previously hardcoded in `GradientEditorModel` for the Thor/RP5) now lives in `shared/devices.json` under `android.gridLayout` and is parsed into `DetectedAndroidDevice` — adding a machine's layout is data, not Kotlin. Documented in `shared/README.md`.

## Hardware effects
`LedDevice` gains an optional `hardwareEffects` list + `applyHardwareEffect`; `LightingController` routes `EFFECT` mode to the device (no software render loop) when the effect is a hardware effect. The Effects tab shows the device's hardware effects; colour-aware ones reuse the gradient editor for a two-colour input.

## UI fixes (pre-existing, surfaced on the ODIN's wide/short screen)
- Stick rings rendered as stretched pills on short landscape scenes — `DeviceScene` is now height-aware (rings stay circular; tall/portrait layouts unchanged).
- The "both sticks" button label was clipped in compact mode.

## Multi-point gradient — researched
The RG Cube physically has 16 addressable LEDs via an MCU UART (muOS drives them over `/dev/ttyS5`), but on stock Android that node is root/system-only, so the non-root driver interface caps at two colours. A true multi-point gradient needs root (open the MCU UART) or a device whose driver exposes per-LED — tracked as follow-up, not in this PR.

## Shared contracts
`platform-support.json`: `generic_led_discovery` and `hardware_effects` android → `implemented` (code done, gate green; not `validated` — only the vendor/PServer and joypad routes have on-device evidence, the sysfs-write route does not yet).

## Verification
- `assembleDebug` + `testDebugUnitTest` + `lintDebug` green (no lint suppressions).
- On-device: ODIN 2 Portal (vendor route) and RG Cube (joypad route: solid colour, effects `led_mode` 2/4/5, two-colour breathing via the Sunset preset).
- `/simplify` (4 angles) and `/review` (high effort) applied; the review caught and fixed a real regression (per-zone gradient effects were capped to two stops on multi-zone devices).

## Scope
Only `android/**` and `shared/**` changed; the Decky runtime is untouched. The frame engine stays golden-locked to `py_modules/effects.py`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)