### PR TITLE
feat: OneXPlayer OneXFly Apex / F1 Pro joystick-ring LEDs

### DIFF
--- a/main.py
+++ b/main.py
@@ -127,7 +127,8 @@ class Plugin:
         self._controller = ctx["device"]
         self._power_led = ctx.get("power_led")
         self._cpu_sampler = CpuSampler()
-        self._engine = EffectEngine(self._render, self._zones)
+        max_render_fps = self._capabilities.get("maxRenderFps", 30)
+        self._engine = EffectEngine(self._render, self._zones, max_fps=max_render_fps)
         runtime_dir, uid, gid = _user_creds()
         self._ambilight = Ambilight(
             self._render,
@@ -136,6 +137,7 @@ class Plugin:
             uid,
             gid,
             layout=self._capabilities.get("layout"),
+            max_fps=max_render_fps,
         )
         self._audio = AudioReactive(self._render, self._zones, runtime_dir, uid, gid)
 

--- a/py_modules/ambilight.py
+++ b/py_modules/ambilight.py
@@ -72,12 +72,13 @@ def _gst_command(node, width, height):
 
 
 class Ambilight:
-    def __init__(self, apply_zones, zones, runtime_dir, uid=None, gid=None, layout=None):
+    def __init__(self, apply_zones, zones, runtime_dir, uid=None, gid=None, layout=None, max_fps=None):
         self._apply = apply_zones
         self._zones = max(1, zones)
         self._runtime_dir = runtime_dir
         self._uid = uid
         self._gid = gid
+        self._max_fps = max_fps
         self._layout = layout or [{"name": "Lights", "region": _FULL_REGION, "zones": list(range(self._zones))}]
         self._task = None
         self._proc = None
@@ -102,6 +103,12 @@ class Ambilight:
 
     def _cred(self):
         return user_cred(self._uid, self._gid)
+
+    def _capture_interval(self):
+        fps = max(1, int(self._options.get("fps", 10)))
+        if self._max_fps is not None:
+            fps = min(fps, max(1, int(self._max_fps)))
+        return 1.0 / fps
 
     async def _find_node(self):
         # Async so the retry loop never blocks the event loop while waiting on pw-dump
@@ -169,7 +176,7 @@ class Ambilight:
                 await asyncio.sleep(RETRY_INTERVAL)
                 continue
 
-            interval = 1.0 / max(1, int(self._options.get("fps", 10)))
+            interval = self._capture_interval()
             command = _gst_command(node, CAP_W, CAP_H)
             proc = None
             logger.info("ambilight start: node=%s fps=%.0f", node, 1.0 / interval)

--- a/py_modules/device.py
+++ b/py_modules/device.py
@@ -175,6 +175,7 @@ def build_capabilities(profile, has_led, zones, max_brightness, ambilight, power
         "audioMode": active["color"],
         "conflictsWithSystemRgb": bool(profile.get("conflicts_with_system_rgb", False)),
         "persistentStartup": bool(profile.get("persistent_startup", False)),
+        "maxRenderFps": int(profile.get("max_render_fps", 30)),
         "layoutKind": profile.get("layout_kind", "rings"),
         "layout": build_layout(zones, profile.get("swap_sticks", False), profile.get("layout_kind", "rings")),
     }

--- a/py_modules/device.py
+++ b/py_modules/device.py
@@ -1,7 +1,7 @@
 import os
 
 from device_profiles import resolve_profile
-from led_device import SysfsRgbDevice, OxpLedsDevice, NullDevice, ValveLedsDevice, discover_valve_leds
+from led_device import SysfsRgbDevice, NullDevice, ValveLedsDevice, discover_valve_leds
 from hid_adapters import HID_AVAILABLE, HID_DRIVERS, build_hid_device
 from power_led import PowerLedController
 from power_supply import battery_present
@@ -197,7 +197,7 @@ def _find_rgb_led(leds_dir):
     return None
 
 
-_IMPLEMENTED_DRIVERS ={"sysfs", "oxp_sysfs", "hid_msi", "hid_legion_tablet", "hid_legion_go_s", "hid_asus_ally", "valve_leds"}
+_IMPLEMENTED_DRIVERS ={"sysfs", "hid_msi", "hid_legion_tablet", "hid_legion_go_s", "hid_asus_ally", "valve_leds"}
 
 
 def _build_hid_context(profile, ambilight, power_led=None, battery=False, temperature=False):
@@ -273,10 +273,10 @@ def build_device(sysfs_root="/", ambilight=False):
         if profile.get("zones"):
             zones = profile["zones"]
         max_brightness = _max_brightness(_read(os.path.join(led_path, "max_brightness")))
-        cls = OxpLedsDevice if profile["driver"] == "oxp_sysfs" else SysfsRgbDevice
-        device = cls(
+        device = SysfsRgbDevice(
             led_path, zones, max_brightness, profile["color_order"], index_format,
             color_correction=profile.get("color_correction", [1.0, 1.0, 1.0]),
+            latch=profile.get("latch"),
         )
         has_led = True
     else:

--- a/py_modules/device.py
+++ b/py_modules/device.py
@@ -1,7 +1,7 @@
 import os
 
 from device_profiles import resolve_profile
-from led_device import SysfsRgbDevice, NullDevice, ValveLedsDevice, discover_valve_leds
+from led_device import SysfsRgbDevice, OxpLedsDevice, NullDevice, ValveLedsDevice, discover_valve_leds
 from hid_adapters import HID_AVAILABLE, HID_DRIVERS, build_hid_device
 from power_led import PowerLedController
 from power_supply import battery_present
@@ -22,6 +22,8 @@ DEVICE_REGISTRY = [
     ("product", "83N0", "Legion Go 2"),
     ("product", "83N1", "Legion Go 2"),
     ("board", "Fremont", "Steam Machine"),
+    ("product", "ONEXPLAYER APEX", "OneXPlayer OneXFly Apex"),
+    ("product", "ONEXPLAYER F1Pro", "OneXPlayer OneXFly F1 Pro"),
 ]
 
 
@@ -195,7 +197,7 @@ def _find_rgb_led(leds_dir):
     return None
 
 
-_IMPLEMENTED_DRIVERS ={"sysfs", "hid_msi", "hid_legion_tablet", "hid_legion_go_s", "hid_asus_ally", "valve_leds"}
+_IMPLEMENTED_DRIVERS ={"sysfs", "oxp_sysfs", "hid_msi", "hid_legion_tablet", "hid_legion_go_s", "hid_asus_ally", "valve_leds"}
 
 
 def _build_hid_context(profile, ambilight, power_led=None, battery=False, temperature=False):
@@ -271,7 +273,8 @@ def build_device(sysfs_root="/", ambilight=False):
         if profile.get("zones"):
             zones = profile["zones"]
         max_brightness = _max_brightness(_read(os.path.join(led_path, "max_brightness")))
-        device = SysfsRgbDevice(
+        cls = OxpLedsDevice if profile["driver"] == "oxp_sysfs" else SysfsRgbDevice
+        device = cls(
             led_path, zones, max_brightness, profile["color_order"], index_format,
             color_correction=profile.get("color_correction", [1.0, 1.0, 1.0]),
         )

--- a/py_modules/device_profiles.py
+++ b/py_modules/device_profiles.py
@@ -79,8 +79,9 @@ OXP_HID = {
 }
 
 OXP_SYSFS = {
-    "driver": "oxp_sysfs",
+    "driver": "sysfs",
     "color_order": "rgb",
+    "latch": [["enabled", "true"], ["effect", "monocolor"]],
     "supported_effects": ["breathing", "rainbow", "wave", "cycle"],
     "experimental": [],
 }

--- a/py_modules/device_profiles.py
+++ b/py_modules/device_profiles.py
@@ -73,6 +73,7 @@ OXP_HID = {
     "driver": "hid_oxp_v2",
     "color_order": "rgb",
     "zones": 1,
+    "max_render_fps": 20,
     "supported_effects": ["breathing", "rainbow", "wave", "cycle"],
     "conflicts_with_system_rgb": True,
     "experimental": [],
@@ -82,6 +83,7 @@ OXP_SYSFS = {
     "driver": "sysfs",
     "color_order": "rgb",
     "latch": [["enabled", "true"], ["effect", "monocolor"]],
+    "max_render_fps": 10,
     "supported_effects": ["breathing", "rainbow", "wave", "cycle"],
     "experimental": [],
 }

--- a/py_modules/device_profiles.py
+++ b/py_modules/device_profiles.py
@@ -96,9 +96,6 @@ GENERIC = {
 # The sysfs RGB node isn't guaranteed on every kernel/Bazzite build for the Ally line.
 # When it's missing, build_device drops to the Aura HID driver instead of "no LEDs".
 ASUS_SYSFS["fallback"] = ASUS_ALLY_HID
-
-# OneXPlayer kernels without the hid-oxp sysfs node (e.g. some Bazzite builds) fall
-# back to the same MCU over raw HID, the path HueSync uses.
 OXP_SYSFS["fallback"] = OXP_HID
 
 

--- a/py_modules/device_profiles.py
+++ b/py_modules/device_profiles.py
@@ -69,6 +69,15 @@ VALVE_LEDS = {
     "experimental": [],
 }
 
+OXP_HID = {
+    "driver": "hid_oxp_v2",
+    "color_order": "rgb",
+    "zones": 1,
+    "supported_effects": ["breathing", "rainbow", "wave", "cycle"],
+    "conflicts_with_system_rgb": True,
+    "experimental": [],
+}
+
 OXP_SYSFS = {
     "driver": "oxp_sysfs",
     "color_order": "rgb",
@@ -87,6 +96,10 @@ GENERIC = {
 # The sysfs RGB node isn't guaranteed on every kernel/Bazzite build for the Ally line.
 # When it's missing, build_device drops to the Aura HID driver instead of "no LEDs".
 ASUS_SYSFS["fallback"] = ASUS_ALLY_HID
+
+# OneXPlayer kernels without the hid-oxp sysfs node (e.g. some Bazzite builds) fall
+# back to the same MCU over raw HID, the path HueSync uses.
+OXP_SYSFS["fallback"] = OXP_HID
 
 
 def _copy_bits(bits):

--- a/py_modules/device_profiles.py
+++ b/py_modules/device_profiles.py
@@ -69,6 +69,13 @@ VALVE_LEDS = {
     "experimental": [],
 }
 
+OXP_SYSFS = {
+    "driver": "oxp_sysfs",
+    "color_order": "rgb",
+    "supported_effects": ["breathing", "rainbow", "wave", "cycle"],
+    "experimental": [],
+}
+
 GENERIC = {
     "driver": "sysfs",
     "color_order": "rgb",
@@ -120,6 +127,9 @@ PROFILES = [
     ("product_contains", "Claw A1M", _profile(MSI_HID, "MSI Claw")),
     ("board", "Fremont", _profile(VALVE_LEDS, "Steam Machine")),
     ("product", "F7F", _profile(VALVE_LEDS, "Steam Machine")),
+    ("product", "ONEXPLAYER APEX", _profile(OXP_SYSFS, "OneXPlayer OneXFly Apex")),
+    ("product", "ONEXPLAYER F1Pro", _profile(OXP_SYSFS, "OneXPlayer OneXFly F1 Pro")),
+    ("product_contains", "ONEXPLAYER", _profile(OXP_SYSFS, "")),
 ]
 
 
@@ -130,7 +140,10 @@ def resolve_profile(board, product):
         if field == "product" and value == product:
             return _copy_profile(profile)
         if field == "product_contains" and value in (product or ""):
-            return _copy_profile(profile)
+            resolved = _copy_profile(profile)
+            if not resolved.get("name"):
+                resolved["name"] = product or board or "Unknown device"
+            return resolved
     fallback = _copy_profile(GENERIC)
     fallback["name"] = product or board or "Unknown device"
     return fallback

--- a/py_modules/effects.py
+++ b/py_modules/effects.py
@@ -291,9 +291,10 @@ def temperature_band_color(temp):
 
 
 class EffectEngine:
-    def __init__(self, apply_zones, zones):
+    def __init__(self, apply_zones, zones, max_fps=30):
         self._apply_zones = apply_zones
         self._zones = zones
+        self._frame_interval = 1.0 / max(1, int(max_fps))
         self._task = None
         self._sig = None
 
@@ -425,7 +426,7 @@ class EffectEngine:
                 factor = breathe_factor(loop.time() - start, INDICATOR_BREATHE_SPEED) if breathing else 1.0
                 frame = tuple(clamp8(c * factor) for c in displayed)
                 self._apply_zones([frame] * self._zones)
-                await asyncio.sleep(FRAME_INTERVAL)
+                await asyncio.sleep(self._frame_interval)
             except asyncio.CancelledError:
                 raise
             except Exception:
@@ -453,7 +454,7 @@ class EffectEngine:
                 raise
             except Exception:
                 logger.exception("effect frame failed")
-            await asyncio.sleep(FRAME_INTERVAL)
+            await asyncio.sleep(self._frame_interval)
 
     async def _run_performance(self, state_fn):
         displayed = 0.0
@@ -467,4 +468,4 @@ class EffectEngine:
                 raise
             except Exception:
                 logger.exception("performance frame failed")
-            await asyncio.sleep(FRAME_INTERVAL)
+            await asyncio.sleep(self._frame_interval)

--- a/py_modules/hid_adapters.py
+++ b/py_modules/hid_adapters.py
@@ -85,8 +85,6 @@ ASUS_ALLY_IDS = {
     "usage": [0x0080],
 }
 
-# OneXPlayer XFLY RGB interface (OneXFly F1 series, Apex). Match VID + usage; the RGB
-# interface shares vid:pid 1A2C:B001 with a second HID interface, disambiguated by usage.
 OXP_IDS = {
     "vid": [0x1A2C],
     "pid": [0xB001],
@@ -450,11 +448,6 @@ class AsusAllyHidDevice(_BaseHidDevice):
 
 
 class OxpHidDevice(_BaseHidDevice):
-    # HID V2 (XFLY) is single-zone with 3 coarse hardware brightness levels, so we hold
-    # hardware brightness at high and scale color in software (like the Ally driver).
-    # Live color updates send only the solid command; the enable command is sent on
-    # transitions so the 30fps effect path is one 64-byte write per frame.
-
     @classmethod
     def create(cls):
         if not HID_AVAILABLE:

--- a/py_modules/hid_adapters.py
+++ b/py_modules/hid_adapters.py
@@ -1,5 +1,6 @@
 import os
 import sys
+from time import monotonic, sleep
 
 from led_device import LedDevice, _clamp8, _clamp_pct, apply_gain
 
@@ -143,8 +144,20 @@ class _BaseHidDevice(LedDevice):
             if not self._transport.is_ready():
                 return False
             device = self._transport.hid_device
+        delay = getattr(self._transport, "write_delay", 0)
         for rep in reps:
-            device.write(rep)
+            last_write = getattr(self._transport, "_last_write_at", None)
+            if delay and last_write is not None:
+                remaining = delay - (monotonic() - last_write)
+                if remaining > 0:
+                    sleep(remaining)
+            try:
+                written = device.write(rep)
+            finally:
+                if delay:
+                    self._transport._last_write_at = monotonic()
+            if written != len(rep):
+                return False
         return True
 
     @property

--- a/py_modules/hid_adapters.py
+++ b/py_modules/hid_adapters.py
@@ -41,6 +41,12 @@ try:
         ZONE_CODES,
         MODE_SOLID,
     )
+    from oxp_hid import (
+        OxpHidTransport,
+        brightness_cmd as oxp_brightness_cmd,
+        solid_cmd as oxp_solid_cmd,
+        LEVEL_HIGH as OXP_LEVEL_HIGH,
+    )
 
     HID_AVAILABLE = True
 except Exception as error:  # pragma: no cover - exercised only without libhidapi
@@ -77,6 +83,15 @@ ASUS_ALLY_IDS = {
     "pid": [],
     "usage_page": [0xFF31],
     "usage": [0x0080],
+}
+
+# OneXPlayer XFLY RGB interface (OneXFly F1 series, Apex). Match VID + usage; the RGB
+# interface shares vid:pid 1A2C:B001 with a second HID interface, disambiguated by usage.
+OXP_IDS = {
+    "vid": [0x1A2C],
+    "pid": [0xB001],
+    "usage_page": [0xFF01],
+    "usage": [0x0001],
 }
 
 
@@ -434,11 +449,62 @@ class AsusAllyHidDevice(_BaseHidDevice):
         return self._heal(_do)
 
 
+class OxpHidDevice(_BaseHidDevice):
+    # HID V2 (XFLY) is single-zone with 3 coarse hardware brightness levels, so we hold
+    # hardware brightness at high and scale color in software (like the Ally driver).
+    # Live color updates send only the solid command; the enable command is sent on
+    # transitions so the 30fps effect path is one 64-byte write per frame.
+
+    @classmethod
+    def create(cls):
+        if not HID_AVAILABLE:
+            return None
+        return cls(
+            OxpHidTransport(
+                OXP_IDS["vid"],
+                OXP_IDS["pid"],
+                OXP_IDS["usage_page"],
+                OXP_IDS["usage"],
+            )
+        )
+
+    def apply_solid(self, color, brightness, power):
+        if not power:
+            def _off():
+                ok = self._write([oxp_brightness_cmd(False, OXP_LEVEL_HIGH)])
+                if ok:
+                    self._transport.prev_mode = None
+                return ok
+
+            return self._heal(_off)
+
+        r, g, b = self._correct(color)
+        scale = _clamp_pct(brightness) / 100.0
+        scaled = (_clamp8(r * scale), _clamp8(g * scale), _clamp8(b * scale))
+
+        def _do():
+            reps = []
+            if self._transport.prev_mode != "solid":
+                reps.append(oxp_brightness_cmd(True, OXP_LEVEL_HIGH))
+            reps.append(oxp_solid_cmd(*scaled))
+            ok = self._write(reps)
+            if ok:
+                self._transport.prev_mode = "solid"
+            return ok
+
+        return self._heal(_do)
+
+    def apply_zones(self, zone_colors, brightness, power):
+        colors = list(zone_colors) or [(0, 0, 0)]
+        return self.apply_solid(colors[0], brightness, power)
+
+
 HID_DRIVERS = {
     "hid_msi": MsiHidDevice,
     "hid_legion_tablet": LegionTabletHidDevice,
     "hid_legion_go_s": LegionGoSHidDevice,
     "hid_asus_ally": AsusAllyHidDevice,
+    "hid_oxp_v2": OxpHidDevice,
 }
 
 

--- a/py_modules/hid_adapters.py
+++ b/py_modules/hid_adapters.py
@@ -85,9 +85,11 @@ ASUS_ALLY_IDS = {
     "usage": [0x0080],
 }
 
+# Match by VID + usage; PID varies across the OneXPlayer family, so leave it open
+# (one HID fallback covers every OXP model that exposes the XFLY RGB interface).
 OXP_IDS = {
     "vid": [0x1A2C],
-    "pid": [0xB001],
+    "pid": [],
     "usage_page": [0xFF01],
     "usage": [0x0001],
 }

--- a/py_modules/led_device.py
+++ b/py_modules/led_device.py
@@ -60,7 +60,7 @@ class NullDevice(LedDevice):
 
 
 class SysfsRgbDevice(LedDevice):
-    def __init__(self, led_path, zones=1, max_brightness=255, color_order="rgb", index_format="hex", color_correction=(1.0, 1.0, 1.0)):
+    def __init__(self, led_path, zones=1, max_brightness=255, color_order="rgb", index_format="hex", color_correction=(1.0, 1.0, 1.0), latch=None):
         self._led_path = led_path
         self._zones = max(1, zones)
         self._max_brightness = max_brightness or 255
@@ -72,6 +72,8 @@ class SysfsRgbDevice(LedDevice):
         self._brightness_path = os.path.join(led_path, "brightness") if led_path else None
         self._has_intensity = bool(self._intensity_path) and os.path.exists(self._intensity_path)
         self._has_brightness = bool(self._brightness_path) and os.path.exists(self._brightness_path)
+        self._latch = [(os.path.join(led_path, attr), value) for attr, value in (latch or [])] if led_path else []
+        self._latched = False
 
     @property
     def available(self):
@@ -83,6 +85,22 @@ class SysfsRgbDevice(LedDevice):
 
     def supports_per_zone(self):
         return True
+
+    def invalidate(self):
+        self._latched = False
+
+    def reconnect(self):
+        self._latched = False
+        return self.available
+
+    def _apply_latch(self):
+        if self._latched or not self._latch:
+            return
+        for path, value in self._latch:
+            if os.path.exists(path):
+                with open(path, "w") as handle:
+                    handle.write(value)
+        self._latched = True
 
     def _order(self, color):
         r, g, b = apply_gain(color, self._color_correction)
@@ -103,6 +121,7 @@ class SysfsRgbDevice(LedDevice):
             return False
         level = self._level(brightness, power)
         try:
+            self._apply_latch()
             if self._has_intensity:
                 values = " ".join(self._format_zone(c) for c in self._fit(zone_colors))
                 with open(self._intensity_path, "w") as handle:
@@ -113,62 +132,7 @@ class SysfsRgbDevice(LedDevice):
             return True
         except OSError as error:
             self.last_error = str(error)
-            return False
-
-
-class OxpLedsDevice(SysfsRgbDevice):
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs)
-        self._enabled_path = os.path.join(self._led_path, "enabled") if self._led_path else None
-        self._effect_path = os.path.join(self._led_path, "effect") if self._led_path else None
-        self._latched = False
-        self._last_level = None
-
-    def invalidate(self):
-        self._latched = False
-        self._last_level = None
-
-    def reconnect(self):
-        self.invalidate()
-        return self.available
-
-    @staticmethod
-    def _write(path, value):
-        with open(path, "w") as handle:
-            handle.write(value)
-
-    def _ensure_direct(self):
-        if self._latched:
-            return
-        if self._enabled_path and os.path.exists(self._enabled_path):
-            try:
-                self._write(self._enabled_path, "true")
-            except OSError:
-                self._write(self._enabled_path, "1")
-        if self._effect_path and os.path.exists(self._effect_path):
-            self._write(self._effect_path, "monocolor")
-        self._latched = True
-
-    def apply_zones(self, zone_colors, brightness, power):
-        self.last_error = None
-        if not self._led_path:
-            self.last_error = "no led path"
-            return False
-        level = self._level(brightness, power)
-        try:
-            self._ensure_direct()
-            if self._has_intensity:
-                values = " ".join(self._format_zone(c) for c in self._fit(zone_colors))
-                with open(self._intensity_path, "w") as handle:
-                    handle.write(values)
-            if self._has_brightness and level != self._last_level:
-                with open(self._brightness_path, "w") as handle:
-                    handle.write(str(level))
-                self._last_level = level
-            return True
-        except OSError as error:
-            self.last_error = str(error)
-            self.invalidate()
+            self._latched = False
             return False
 
 

--- a/py_modules/led_device.py
+++ b/py_modules/led_device.py
@@ -42,7 +42,7 @@ class LedDevice:
 
     def invalidate(self):
         # Drop any cached "already in this mode" state so the next apply re-sends the
-        # full init/commit sequence. No-op for devices that always write in full (sysfs).
+        # full init/commit sequence. No-op for a plain sysfs device with no latch.
         return None
 
     def apply_zones(self, zone_colors, brightness, power):

--- a/py_modules/led_device.py
+++ b/py_modules/led_device.py
@@ -116,6 +116,62 @@ class SysfsRgbDevice(LedDevice):
             return False
 
 
+class OxpLedsDevice(SysfsRgbDevice):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self._enabled_path = os.path.join(self._led_path, "enabled") if self._led_path else None
+        self._effect_path = os.path.join(self._led_path, "effect") if self._led_path else None
+        self._latched = False
+        self._last_level = None
+
+    def invalidate(self):
+        self._latched = False
+        self._last_level = None
+
+    def reconnect(self):
+        self.invalidate()
+        return self.available
+
+    @staticmethod
+    def _write(path, value):
+        with open(path, "w") as handle:
+            handle.write(value)
+
+    def _ensure_direct(self):
+        if self._latched:
+            return
+        if self._enabled_path and os.path.exists(self._enabled_path):
+            try:
+                self._write(self._enabled_path, "true")
+            except OSError:
+                self._write(self._enabled_path, "1")
+        if self._effect_path and os.path.exists(self._effect_path):
+            self._write(self._effect_path, "monocolor")
+        self._latched = True
+
+    def apply_zones(self, zone_colors, brightness, power):
+        self.last_error = None
+        if not self._led_path:
+            self.last_error = "no led path"
+            return False
+        level = self._level(brightness, power)
+        try:
+            self._ensure_direct()
+            if self._has_intensity:
+                values = " ".join(self._format_zone(c) for c in self._fit(zone_colors))
+                with open(self._intensity_path, "w") as handle:
+                    handle.write(values)
+            if self._has_brightness and level != self._last_level:
+                with open(self._brightness_path, "w") as handle:
+                    handle.write(str(level))
+                self._last_level = level
+            return True
+        except OSError as error:
+            self.last_error = str(error)
+            self.invalidate()
+            return False
+
+
 _VALVE_NODE_RE = re.compile(r"^valve-leds\[(\d+)\]$")
 
 

--- a/py_modules/led_device.py
+++ b/py_modules/led_device.py
@@ -96,10 +96,11 @@ class SysfsRgbDevice(LedDevice):
     def _apply_latch(self):
         if self._latched or not self._latch:
             return
+        if not all(os.path.exists(path) for path, _ in self._latch):
+            return
         for path, value in self._latch:
-            if os.path.exists(path):
-                with open(path, "w") as handle:
-                    handle.write(value)
+            with open(path, "w") as handle:
+                handle.write(value)
         self._latched = True
 
     def _order(self, color):
@@ -122,6 +123,11 @@ class SysfsRgbDevice(LedDevice):
         level = self._level(brightness, power)
         try:
             self._apply_latch()
+        except OSError as error:
+            self.last_error = str(error)
+            self._latched = False
+            return False
+        try:
             if self._has_intensity:
                 values = " ".join(self._format_zone(c) for c in self._fit(zone_colors))
                 with open(self._intensity_path, "w") as handle:
@@ -132,7 +138,6 @@ class SysfsRgbDevice(LedDevice):
             return True
         except OSError as error:
             self.last_error = str(error)
-            self._latched = False
             return False
 
 

--- a/py_modules/oxp_hid.py
+++ b/py_modules/oxp_hid.py
@@ -1,0 +1,83 @@
+# OneXPlayer RGB protocol, HID V2 ("XFLY": OneXFly F1 series, Apex, A1X). The byte
+# layout is an interface fact of the device, documented by HHD (hhd/device/oxp/hid_v2.py,
+# GPL) and HueSync (BSD-3); this is an original implementation (no third-party code
+# copied). All output reports are 64 bytes: [0x07, 0xFF, *payload]. The RGB interface
+# is VID 0x1A2C, usage_page 0xFF01 / usage 0x0001.
+
+CMD_ID = 0x07
+
+LEVEL_LOW = 0x01
+LEVEL_MEDIUM = 0x03
+LEVEL_HIGH = 0x04
+
+_MODE_BY_NAME = {
+    "aurora": 0x01,
+    "flowing": 0x03,
+    "neon": 0x05,
+    "dreamy": 0x07,
+    "sun": 0x08,
+    "cyberpunk": 0x09,
+    "sunset": 0x0B,
+    "colorful": 0x0C,
+    "monster_woke": 0x0D,
+}
+
+
+def _clamp8(v):
+    return max(0, min(255, int(v)))
+
+
+def buf(payload):
+    data = bytes([CMD_ID, 0xFF, *payload])
+    return data + bytes(64 - len(data))
+
+
+def level_code(pct):
+    step = round(max(0, min(100, int(pct))) / 20)
+    if step <= 1:
+        return LEVEL_LOW
+    if step <= 3:
+        return LEVEL_MEDIUM
+    return LEVEL_HIGH
+
+
+def brightness_cmd(enabled, code):
+    return buf([0xFD, 1 if enabled else 0, 0x05, code])
+
+
+def solid_cmd(r, g, b):
+    triple = [_clamp8(r), _clamp8(g), _clamp8(b)]
+    return buf([0xFE] + triple * 20 + [0x00])
+
+
+def mode_value(name):
+    return _MODE_BY_NAME.get(name, 0x01)
+
+
+def mode_cmd(code):
+    return buf([code])
+
+
+class OxpHidTransport:
+    def __init__(self, vid, pid, usage_page, usage):
+        self._vid = vid
+        self._pid = pid
+        self._usage_page = usage_page
+        self._usage = usage
+        self.hid_device = None
+        self.prev_mode = None
+
+    def is_ready(self):
+        if self.hid_device:
+            return True
+        import lib_hid as hid
+
+        for device in hid.enumerate():
+            if device["vendor_id"] not in self._vid:
+                continue
+            if self._pid and device["product_id"] not in self._pid:
+                continue
+            if device["usage_page"] in self._usage_page and device["usage"] in self._usage:
+                self.hid_device = hid.Device(path=device["path"])
+                return True
+        return False

--- a/py_modules/oxp_hid.py
+++ b/py_modules/oxp_hid.py
@@ -3,21 +3,7 @@
 
 CMD_ID = 0x07
 
-LEVEL_LOW = 0x01
-LEVEL_MEDIUM = 0x03
 LEVEL_HIGH = 0x04
-
-_MODE_BY_NAME = {
-    "aurora": 0x01,
-    "flowing": 0x03,
-    "neon": 0x05,
-    "dreamy": 0x07,
-    "sun": 0x08,
-    "cyberpunk": 0x09,
-    "sunset": 0x0B,
-    "colorful": 0x0C,
-    "monster_woke": 0x0D,
-}
 
 
 def _clamp8(v):
@@ -29,15 +15,6 @@ def buf(payload):
     return data + bytes(64 - len(data))
 
 
-def level_code(pct):
-    step = round(max(0, min(100, int(pct))) / 20)
-    if step <= 1:
-        return LEVEL_LOW
-    if step <= 3:
-        return LEVEL_MEDIUM
-    return LEVEL_HIGH
-
-
 def brightness_cmd(enabled, code):
     return buf([0xFD, 1 if enabled else 0, 0x05, code])
 
@@ -45,14 +22,6 @@ def brightness_cmd(enabled, code):
 def solid_cmd(r, g, b):
     triple = [_clamp8(r), _clamp8(g), _clamp8(b)]
     return buf([0xFE] + triple * 20 + [0x00])
-
-
-def mode_value(name):
-    return _MODE_BY_NAME.get(name, 0x01)
-
-
-def mode_cmd(code):
-    return buf([code])
 
 
 class OxpHidTransport:

--- a/py_modules/oxp_hid.py
+++ b/py_modules/oxp_hid.py
@@ -1,8 +1,5 @@
-# OneXPlayer RGB protocol, HID V2 ("XFLY": OneXFly F1 series, Apex, A1X). The byte
-# layout is an interface fact of the device, documented by HHD (hhd/device/oxp/hid_v2.py,
-# GPL) and HueSync (BSD-3); this is an original implementation (no third-party code
-# copied). All output reports are 64 bytes: [0x07, 0xFF, *payload]. The RGB interface
-# is VID 0x1A2C, usage_page 0xFF01 / usage 0x0001.
+# OneXPlayer HID V2 ("XFLY") RGB protocol. Wire format documented by HHD and HueSync
+# (BSD-3); original implementation, no third-party code copied.
 
 CMD_ID = 0x07
 

--- a/py_modules/oxp_hid.py
+++ b/py_modules/oxp_hid.py
@@ -4,6 +4,7 @@
 CMD_ID = 0x07
 
 LEVEL_HIGH = 0x04
+WRITE_DELAY = 0.05
 
 
 def _clamp8(v):
@@ -32,6 +33,8 @@ class OxpHidTransport:
         self._usage = usage
         self.hid_device = None
         self.prev_mode = None
+        self.write_delay = WRITE_DELAY
+        self._last_write_at = None
 
     def is_ready(self):
         if self.hid_device:

--- a/py_modules/report/collector.py
+++ b/py_modules/report/collector.py
@@ -143,7 +143,7 @@ def kernel_logs(
 _SNAP_MAX_NODES = 64
 _SNAP_MAX_MODULES = 512
 _SNAP_CAP = 60_000
-_LED_VALUE_NODES = ("multi_index", "max_brightness", "brightness")
+_LED_VALUE_NODES = ("multi_index", "max_brightness", "brightness", "enabled", "effect", "effect_index", "speed")
 
 
 def _glob(root: str, pattern: str) -> list[str]:

--- a/ruff.toml
+++ b/ruff.toml
@@ -1,1 +1,4 @@
 extend-exclude = ["py_modules/huesync"]
+
+[lint]
+select = ["E4", "E7", "E9", "F"]

--- a/tests/test_ambilight.py
+++ b/tests/test_ambilight.py
@@ -1,5 +1,7 @@
 import asyncio
 
+import pytest
+
 import py_modules.ambilight as ambilight_mod
 from py_modules.ambilight import (
     Ambilight,
@@ -99,6 +101,12 @@ def test_gst_command_uses_leaky_queue_before_scaling():
     assert "leaky=downstream" in cmd
     assert cmd.index("queue") < cmd.index("videoscale")
     assert "path=68" in cmd
+
+
+def test_capture_interval_respects_device_render_limit():
+    amb = Ambilight(lambda colors: None, zones=1, runtime_dir=None, max_fps=10)
+    amb._options = {"fps": 30}
+    assert amb._capture_interval() == pytest.approx(0.1)
 
 
 def _solid_frame(width, height, color):

--- a/tests/test_device.py
+++ b/tests/test_device.py
@@ -268,7 +268,7 @@ def test_build_device_oxp_uses_latch_device(tmp_path):
     _make_led(root, "oxp:rgb:joystick_rings", _OXP_LED_FILES)
     ctx = build_device(root)
     assert ctx["info"]["name"] == "OneXPlayer OneXFly Apex"
-    assert type(ctx["device"]).__name__ == "OxpLedsDevice"
+    assert type(ctx["device"]).__name__ == "SysfsRgbDevice"
     caps = ctx["capabilities"]
     assert caps["zones"] == 1
     assert caps["maxBrightness"] == 100

--- a/tests/test_device.py
+++ b/tests/test_device.py
@@ -272,6 +272,7 @@ def test_build_device_oxp_uses_latch_device(tmp_path):
     caps = ctx["capabilities"]
     assert caps["zones"] == 1
     assert caps["maxBrightness"] == 100
+    assert caps["maxRenderFps"] == 10
     assert caps["states"]["color"] == "supported"
     assert ctx["device"].apply_zones([(255, 0, 0)], 100, True) is True
     led = os.path.join(root, "sys/class/leds/oxp:rgb:joystick_rings")

--- a/tests/test_device.py
+++ b/tests/test_device.py
@@ -250,3 +250,39 @@ def test_capabilities_conflicts_defaults_false():
     profile = resolve_profile("RC72LA", "ROG Ally X")
     caps = build_capabilities(profile, True, 4, 255, False)
     assert caps["conflictsWithSystemRgb"] is False
+
+
+_OXP_LED_FILES = {
+    "multi_index": "red green blue",
+    "multi_intensity": "0 0 0",
+    "brightness": "0",
+    "max_brightness": "100",
+    "enabled": "false",
+    "effect": "rainbow",
+}
+
+
+def test_build_device_oxp_uses_latch_device(tmp_path):
+    root = str(tmp_path)
+    _make_dmi(root, "ONEXPLAYER APEX", "ONEXPLAYER APEX")
+    _make_led(root, "oxp:rgb:joystick_rings", _OXP_LED_FILES)
+    ctx = build_device(root)
+    assert ctx["info"]["name"] == "OneXPlayer OneXFly Apex"
+    assert type(ctx["device"]).__name__ == "OxpLedsDevice"
+    caps = ctx["capabilities"]
+    assert caps["zones"] == 1
+    assert caps["maxBrightness"] == 100
+    assert caps["states"]["color"] == "supported"
+    assert ctx["device"].apply_zones([(255, 0, 0)], 100, True) is True
+    led = os.path.join(root, "sys/class/leds/oxp:rgb:joystick_rings")
+    assert open(os.path.join(led, "enabled")).read() == "true"
+    assert open(os.path.join(led, "effect")).read() == "monocolor"
+    assert open(os.path.join(led, "multi_intensity")).read() == "255 0 0"
+
+
+def test_build_device_oxp_without_node_degrades(tmp_path):
+    root = str(tmp_path)
+    _make_dmi(root, "ONEXPLAYER APEX", "ONEXPLAYER APEX")
+    ctx = build_device(root)
+    assert ctx["capabilities"]["color"] is False
+    assert type(ctx["device"]).__name__ == "NullDevice"

--- a/tests/test_device_profiles.py
+++ b/tests/test_device_profiles.py
@@ -139,3 +139,11 @@ def test_onexplayer_family_fallback_profile():
     profile = resolve_profile("ONEXPLAYER X1 mini", "ONEXPLAYER X1 mini")
     assert profile["driver"] == "oxp_sysfs"
     assert profile["name"] == "ONEXPLAYER X1 mini"
+
+
+def test_onexplayer_profile_has_hid_fallback():
+    profile = resolve_profile("ONEXPLAYER APEX", "ONEXPLAYER APEX")
+    fallback = profile.get("fallback")
+    assert fallback is not None
+    assert fallback["driver"] == "hid_oxp_v2"
+    assert fallback["conflicts_with_system_rgb"] is True

--- a/tests/test_device_profiles.py
+++ b/tests/test_device_profiles.py
@@ -125,19 +125,21 @@ def test_steam_machine_preproduction_by_product():
 def test_onexplayer_apex_profile():
     profile = resolve_profile("ONEXPLAYER APEX", "ONEXPLAYER APEX")
     assert profile["name"] == "OneXPlayer OneXFly Apex"
-    assert profile["driver"] == "oxp_sysfs"
+    assert profile["driver"] == "sysfs"
+    assert profile["latch"] == [["enabled", "true"], ["effect", "monocolor"]]
     assert profile["experimental"] == []
 
 
 def test_onexplayer_f1pro_profile():
     profile = resolve_profile("ONEXPLAYER F1Pro", "ONEXPLAYER F1Pro")
     assert profile["name"] == "OneXPlayer OneXFly F1 Pro"
-    assert profile["driver"] == "oxp_sysfs"
+    assert profile["driver"] == "sysfs"
+    assert profile["latch"] == [["enabled", "true"], ["effect", "monocolor"]]
 
 
 def test_onexplayer_family_fallback_profile():
     profile = resolve_profile("ONEXPLAYER X1 mini", "ONEXPLAYER X1 mini")
-    assert profile["driver"] == "oxp_sysfs"
+    assert profile["driver"] == "sysfs"
     assert profile["name"] == "ONEXPLAYER X1 mini"
 
 

--- a/tests/test_device_profiles.py
+++ b/tests/test_device_profiles.py
@@ -127,6 +127,7 @@ def test_onexplayer_apex_profile():
     assert profile["name"] == "OneXPlayer OneXFly Apex"
     assert profile["driver"] == "sysfs"
     assert profile["latch"] == [["enabled", "true"], ["effect", "monocolor"]]
+    assert profile["max_render_fps"] == 10
     assert profile["experimental"] == []
 
 
@@ -148,4 +149,5 @@ def test_onexplayer_profile_has_hid_fallback():
     fallback = profile.get("fallback")
     assert fallback is not None
     assert fallback["driver"] == "hid_oxp_v2"
+    assert fallback["max_render_fps"] == 20
     assert fallback["conflicts_with_system_rgb"] is True

--- a/tests/test_device_profiles.py
+++ b/tests/test_device_profiles.py
@@ -120,3 +120,22 @@ def test_steam_machine_preproduction_by_product():
     p = resolve_profile("", "F7F")
     assert p["name"] == "Steam Machine"
     assert p["driver"] == "valve_leds"
+
+
+def test_onexplayer_apex_profile():
+    profile = resolve_profile("ONEXPLAYER APEX", "ONEXPLAYER APEX")
+    assert profile["name"] == "OneXPlayer OneXFly Apex"
+    assert profile["driver"] == "oxp_sysfs"
+    assert profile["experimental"] == []
+
+
+def test_onexplayer_f1pro_profile():
+    profile = resolve_profile("ONEXPLAYER F1Pro", "ONEXPLAYER F1Pro")
+    assert profile["name"] == "OneXPlayer OneXFly F1 Pro"
+    assert profile["driver"] == "oxp_sysfs"
+
+
+def test_onexplayer_family_fallback_profile():
+    profile = resolve_profile("ONEXPLAYER X1 mini", "ONEXPLAYER X1 mini")
+    assert profile["driver"] == "oxp_sysfs"
+    assert profile["name"] == "ONEXPLAYER X1 mini"

--- a/tests/test_effects.py
+++ b/tests/test_effects.py
@@ -1,6 +1,11 @@
+import asyncio
+
+import pytest
+
 from py_modules.effects import (
     BATTERY_BANDS,
     TEMPERATURE_BANDS,
+    EffectEngine,
     battery_band_color,
     temperature_band_color,
     frame_breathing,
@@ -155,6 +160,24 @@ def test_frame_breathing_preserves_per_zone_palette():
     frame = frame_breathing(base, 0.0, 50)
     assert frame[0][0] >= frame[0][1] and frame[0][0] >= frame[0][2]
     assert frame[1][1] >= frame[1][0] and frame[1][1] >= frame[1][2]
+
+
+def test_effect_engine_uses_device_render_limit(monkeypatch):
+    sleeps = []
+
+    async def stop_after_first(delay):
+        sleeps.append(delay)
+        raise asyncio.CancelledError
+
+    monkeypatch.setattr(asyncio, "sleep", stop_after_first)
+    engine = EffectEngine(lambda colors: None, zones=1, max_fps=10)
+
+    async def drive():
+        with pytest.raises(asyncio.CancelledError):
+            await engine._run("breathing", 50, {"color": (255, 0, 0)})
+
+    asyncio.run(drive())
+    assert sleeps == pytest.approx([0.1])
 
 
 def test_frame_rainbow_valid():

--- a/tests/test_hid_adapters.py
+++ b/tests/test_hid_adapters.py
@@ -583,3 +583,82 @@ def test_ally_invalidate_forces_reinit(hid_env):
     assert len(writes) == 8
     assert writes[0][:15] == bytes([0x5D]) + b"ASUS Tech.Inc."
     assert writes[-1][:2] == bytes([0x5D, 0xB4])  # APPLY
+
+
+def _oxp_entry():
+    return {
+        "vendor_id": 0x1A2C,
+        "product_id": 0xB001,
+        "usage_page": 0xFF01,
+        "usage": 0x0001,
+        "interface_number": 0,
+        "path": b"oxp",
+    }
+
+
+def test_oxp_solid_enables_then_paints(hid_env):
+    adapters, writes = hid_env
+    sys.modules["lib_hid"].enumerate = lambda vid=0, pid=0: [_oxp_entry()]
+    dev = adapters.OxpHidDevice.create()
+    assert dev.available is True
+    assert dev.supports_per_zone() is False
+    assert dev.supports_hardware_effects() is False
+    writes.clear()
+    assert dev.apply_solid((255, 0, 0), 100, True) is True
+    assert len(writes) == 2
+    assert writes[0][:6] == bytes([0x07, 0xFF, 0xFD, 0x01, 0x05, 0x04])
+    assert writes[1][:3] == bytes([0x07, 0xFF, 0xFE])
+    assert tuple(writes[1][3:6]) == (255, 0, 0)
+
+
+def test_oxp_steady_state_sends_only_color(hid_env):
+    adapters, writes = hid_env
+    sys.modules["lib_hid"].enumerate = lambda vid=0, pid=0: [_oxp_entry()]
+    dev = adapters.OxpHidDevice.create()
+    dev.apply_solid((255, 0, 0), 100, True)
+    writes.clear()
+    dev.apply_solid((0, 255, 0), 100, True)
+    assert len(writes) == 1
+    assert writes[0][:3] == bytes([0x07, 0xFF, 0xFE])
+    assert tuple(writes[0][3:6]) == (0, 255, 0)
+
+
+def test_oxp_brightness_scales_color_in_software(hid_env):
+    adapters, writes = hid_env
+    sys.modules["lib_hid"].enumerate = lambda vid=0, pid=0: [_oxp_entry()]
+    dev = adapters.OxpHidDevice.create()
+    writes.clear()
+    dev.apply_solid((255, 0, 0), 50, True)
+    assert tuple(writes[1][3:6]) == (int(255 * 0.5), 0, 0)
+
+
+def test_oxp_power_off_disables(hid_env):
+    adapters, writes = hid_env
+    sys.modules["lib_hid"].enumerate = lambda vid=0, pid=0: [_oxp_entry()]
+    dev = adapters.OxpHidDevice.create()
+    dev.apply_solid((255, 0, 0), 100, True)
+    writes.clear()
+    dev.apply_solid((255, 0, 0), 100, False)
+    assert len(writes) == 1
+    assert writes[0][:4] == bytes([0x07, 0xFF, 0xFD, 0x00])
+
+
+def test_oxp_zones_use_first_color(hid_env):
+    adapters, writes = hid_env
+    sys.modules["lib_hid"].enumerate = lambda vid=0, pid=0: [_oxp_entry()]
+    dev = adapters.OxpHidDevice.create()
+    writes.clear()
+    dev.apply_zones([(10, 20, 30), (200, 0, 0)], 100, True)
+    assert tuple(writes[-1][3:6]) == (10, 20, 30)
+
+
+def test_oxp_invalidate_re_enables(hid_env):
+    adapters, writes = hid_env
+    sys.modules["lib_hid"].enumerate = lambda vid=0, pid=0: [_oxp_entry()]
+    dev = adapters.OxpHidDevice.create()
+    dev.apply_solid((255, 0, 0), 100, True)
+    dev.invalidate()
+    writes.clear()
+    dev.apply_solid((255, 0, 0), 100, True)
+    assert len(writes) == 2
+    assert writes[0][:3] == bytes([0x07, 0xFF, 0xFD])

--- a/tests/test_hid_adapters.py
+++ b/tests/test_hid_adapters.py
@@ -662,3 +662,48 @@ def test_oxp_invalidate_re_enables(hid_env):
     dev.apply_solid((255, 0, 0), 100, True)
     assert len(writes) == 2
     assert writes[0][:3] == bytes([0x07, 0xFF, 0xFD])
+
+
+def test_oxp_spaces_consecutive_reports_by_protocol_delay(hid_env, monkeypatch):
+    adapters, writes = hid_env
+    sys.modules["lib_hid"].enumerate = lambda vid=0, pid=0: [_oxp_entry()]
+    clock = {"now": 0.0}
+    sleeps = []
+
+    monkeypatch.setattr(adapters, "monotonic", lambda: clock["now"], raising=False)
+
+    def advance(delay):
+        sleeps.append(delay)
+        clock["now"] += delay
+
+    monkeypatch.setattr(adapters, "sleep", advance, raising=False)
+    dev = adapters.OxpHidDevice.create()
+    assert dev.apply_solid((255, 0, 0), 100, True) is True
+    assert len(writes) == 2
+    assert sleeps == pytest.approx([0.05])
+
+
+def test_oxp_short_write_reconnects_and_retries_full_transition(hid_env):
+    adapters, writes = hid_env
+    sys.modules["lib_hid"].enumerate = lambda vid=0, pid=0: [_oxp_entry()]
+    results = iter([32, 64, 64])
+
+    class ShortWriteDevice:
+        def __init__(self, path=None):
+            self.path = path
+
+        def write(self, data):
+            writes.append(bytes(data))
+            return next(results)
+
+        def close(self):
+            pass
+
+    sys.modules["lib_hid"].Device = ShortWriteDevice
+    dev = adapters.OxpHidDevice.create()
+    assert dev.apply_solid((255, 0, 0), 100, True) is True
+    assert [packet[:3] for packet in writes] == [
+        bytes([0x07, 0xFF, 0xFD]),
+        bytes([0x07, 0xFF, 0xFD]),
+        bytes([0x07, 0xFF, 0xFE]),
+    ]

--- a/tests/test_led_device.py
+++ b/tests/test_led_device.py
@@ -1,6 +1,8 @@
 import os
 
-from py_modules.led_device import OxpLedsDevice, SysfsRgbDevice, ValveLedsDevice, discover_valve_leds
+from py_modules.led_device import SysfsRgbDevice, ValveLedsDevice, discover_valve_leds
+
+_OXP_LATCH = [["enabled", "true"], ["effect", "monocolor"]]
 
 
 def _make_led(tmp_path, multi_index="rgb rgb rgb rgb"):
@@ -267,9 +269,9 @@ def _make_oxp_led(tmp_path, with_latch=True):
     return led
 
 
-def test_oxp_latches_enabled_and_monocolor_before_color(tmp_path):
+def test_latch_writes_before_color(tmp_path):
     led = _make_oxp_led(tmp_path)
-    device = OxpLedsDevice(led, zones=1, max_brightness=100, index_format="decimal")
+    device = SysfsRgbDevice(led, zones=1, max_brightness=100, index_format="decimal", latch=_OXP_LATCH)
     assert device.apply_zones([(255, 0, 0)], 100, True) is True
     assert _read(os.path.join(led, "enabled")) == "true"
     assert _read(os.path.join(led, "effect")) == "monocolor"
@@ -277,18 +279,18 @@ def test_oxp_latches_enabled_and_monocolor_before_color(tmp_path):
     assert _read(os.path.join(led, "brightness")) == "100"
 
 
-def test_oxp_latch_writes_only_once(tmp_path):
+def test_latch_writes_only_once(tmp_path):
     led = _make_oxp_led(tmp_path)
-    device = OxpLedsDevice(led, zones=1, max_brightness=100, index_format="decimal")
+    device = SysfsRgbDevice(led, zones=1, max_brightness=100, index_format="decimal", latch=_OXP_LATCH)
     device.apply_zones([(255, 0, 0)], 100, True)
     open(os.path.join(led, "effect"), "w").write("rainbow")
     device.apply_zones([(0, 255, 0)], 100, True)
     assert _read(os.path.join(led, "effect")) == "rainbow"
 
 
-def test_oxp_invalidate_relatches(tmp_path):
+def test_latch_reapplied_after_invalidate(tmp_path):
     led = _make_oxp_led(tmp_path)
-    device = OxpLedsDevice(led, zones=1, max_brightness=100, index_format="decimal")
+    device = SysfsRgbDevice(led, zones=1, max_brightness=100, index_format="decimal", latch=_OXP_LATCH)
     device.apply_zones([(255, 0, 0)], 100, True)
     open(os.path.join(led, "effect"), "w").write("rainbow")
     device.invalidate()
@@ -296,9 +298,9 @@ def test_oxp_invalidate_relatches(tmp_path):
     assert _read(os.path.join(led, "effect")) == "monocolor"
 
 
-def test_oxp_reconnect_relatches(tmp_path):
+def test_latch_reapplied_after_reconnect(tmp_path):
     led = _make_oxp_led(tmp_path)
-    device = OxpLedsDevice(led, zones=1, max_brightness=100, index_format="decimal")
+    device = SysfsRgbDevice(led, zones=1, max_brightness=100, index_format="decimal", latch=_OXP_LATCH)
     device.apply_zones([(255, 0, 0)], 100, True)
     open(os.path.join(led, "effect"), "w").write("rainbow")
     assert device.reconnect() is True
@@ -306,19 +308,16 @@ def test_oxp_reconnect_relatches(tmp_path):
     assert _read(os.path.join(led, "effect")) == "monocolor"
 
 
-def test_oxp_tolerates_missing_latch_attrs(tmp_path):
+def test_latch_tolerates_missing_attrs(tmp_path):
     led = _make_oxp_led(tmp_path, with_latch=False)
-    device = OxpLedsDevice(led, zones=1, max_brightness=100, index_format="decimal")
+    device = SysfsRgbDevice(led, zones=1, max_brightness=100, index_format="decimal", latch=_OXP_LATCH)
     assert device.apply_zones([(255, 0, 0)], 100, True) is True
     assert _read(os.path.join(led, "multi_intensity")) == "255 0 0"
 
 
-def test_oxp_skips_redundant_brightness_writes(tmp_path):
+def test_no_latch_leaves_attrs_untouched(tmp_path):
     led = _make_oxp_led(tmp_path)
-    device = OxpLedsDevice(led, zones=1, max_brightness=100, index_format="decimal")
-    device.apply_zones([(255, 0, 0)], 80, True)
-    open(os.path.join(led, "brightness"), "w").write("99")
-    device.apply_zones([(0, 255, 0)], 80, True)
-    assert _read(os.path.join(led, "brightness")) == "99"
-    device.apply_zones([(0, 255, 0)], 50, True)
-    assert _read(os.path.join(led, "brightness")) == "50"
+    device = SysfsRgbDevice(led, zones=1, max_brightness=100, index_format="decimal")
+    device.apply_zones([(255, 0, 0)], 100, True)
+    assert _read(os.path.join(led, "enabled")) == "false"
+    assert _read(os.path.join(led, "effect")) == "rainbow"

--- a/tests/test_led_device.py
+++ b/tests/test_led_device.py
@@ -1,6 +1,6 @@
 import os
 
-from py_modules.led_device import SysfsRgbDevice, ValveLedsDevice, discover_valve_leds
+from py_modules.led_device import OxpLedsDevice, SysfsRgbDevice, ValveLedsDevice, discover_valve_leds
 
 
 def _make_led(tmp_path, multi_index="rgb rgb rgb rgb"):
@@ -252,3 +252,73 @@ def test_valve_read_and_restore_startup_round_trip(tmp_path):
     assert device.restore_startup(factory) is True
     assert _read(os.path.join(nodes[0], "multi_intensity_startup")) == "0 90 255"
     assert _read(os.path.join(nodes[0], "brightness_startup")) == "56"
+
+
+def _make_oxp_led(tmp_path, with_latch=True):
+    led = os.path.join(str(tmp_path), "oxp:rgb:joystick_rings")
+    os.makedirs(led)
+    open(os.path.join(led, "multi_index"), "w").write("red green blue")
+    open(os.path.join(led, "multi_intensity"), "w").write("0 0 0")
+    open(os.path.join(led, "brightness"), "w").write("0")
+    open(os.path.join(led, "max_brightness"), "w").write("100")
+    if with_latch:
+        open(os.path.join(led, "enabled"), "w").write("false")
+        open(os.path.join(led, "effect"), "w").write("rainbow")
+    return led
+
+
+def test_oxp_latches_enabled_and_monocolor_before_color(tmp_path):
+    led = _make_oxp_led(tmp_path)
+    device = OxpLedsDevice(led, zones=1, max_brightness=100, index_format="decimal")
+    assert device.apply_zones([(255, 0, 0)], 100, True) is True
+    assert _read(os.path.join(led, "enabled")) == "true"
+    assert _read(os.path.join(led, "effect")) == "monocolor"
+    assert _read(os.path.join(led, "multi_intensity")) == "255 0 0"
+    assert _read(os.path.join(led, "brightness")) == "100"
+
+
+def test_oxp_latch_writes_only_once(tmp_path):
+    led = _make_oxp_led(tmp_path)
+    device = OxpLedsDevice(led, zones=1, max_brightness=100, index_format="decimal")
+    device.apply_zones([(255, 0, 0)], 100, True)
+    open(os.path.join(led, "effect"), "w").write("rainbow")
+    device.apply_zones([(0, 255, 0)], 100, True)
+    assert _read(os.path.join(led, "effect")) == "rainbow"
+
+
+def test_oxp_invalidate_relatches(tmp_path):
+    led = _make_oxp_led(tmp_path)
+    device = OxpLedsDevice(led, zones=1, max_brightness=100, index_format="decimal")
+    device.apply_zones([(255, 0, 0)], 100, True)
+    open(os.path.join(led, "effect"), "w").write("rainbow")
+    device.invalidate()
+    device.apply_zones([(0, 0, 255)], 100, True)
+    assert _read(os.path.join(led, "effect")) == "monocolor"
+
+
+def test_oxp_reconnect_relatches(tmp_path):
+    led = _make_oxp_led(tmp_path)
+    device = OxpLedsDevice(led, zones=1, max_brightness=100, index_format="decimal")
+    device.apply_zones([(255, 0, 0)], 100, True)
+    open(os.path.join(led, "effect"), "w").write("rainbow")
+    assert device.reconnect() is True
+    device.apply_zones([(0, 0, 255)], 100, True)
+    assert _read(os.path.join(led, "effect")) == "monocolor"
+
+
+def test_oxp_tolerates_missing_latch_attrs(tmp_path):
+    led = _make_oxp_led(tmp_path, with_latch=False)
+    device = OxpLedsDevice(led, zones=1, max_brightness=100, index_format="decimal")
+    assert device.apply_zones([(255, 0, 0)], 100, True) is True
+    assert _read(os.path.join(led, "multi_intensity")) == "255 0 0"
+
+
+def test_oxp_skips_redundant_brightness_writes(tmp_path):
+    led = _make_oxp_led(tmp_path)
+    device = OxpLedsDevice(led, zones=1, max_brightness=100, index_format="decimal")
+    device.apply_zones([(255, 0, 0)], 80, True)
+    open(os.path.join(led, "brightness"), "w").write("99")
+    device.apply_zones([(0, 255, 0)], 80, True)
+    assert _read(os.path.join(led, "brightness")) == "99"
+    device.apply_zones([(0, 255, 0)], 50, True)
+    assert _read(os.path.join(led, "brightness")) == "50"

--- a/tests/test_led_device.py
+++ b/tests/test_led_device.py
@@ -315,6 +315,28 @@ def test_latch_tolerates_missing_attrs(tmp_path):
     assert _read(os.path.join(led, "multi_intensity")) == "255 0 0"
 
 
+def test_latch_applies_when_attrs_appear_after_led_node(tmp_path):
+    led = _make_oxp_led(tmp_path, with_latch=False)
+    device = SysfsRgbDevice(led, zones=1, max_brightness=100, index_format="decimal", latch=_OXP_LATCH)
+    assert device.apply_zones([(255, 0, 0)], 100, True) is True
+    open(os.path.join(led, "enabled"), "w").write("false")
+    open(os.path.join(led, "effect"), "w").write("rainbow")
+    assert device.apply_zones([(0, 255, 0)], 100, True) is True
+    assert _read(os.path.join(led, "enabled")) == "true"
+    assert _read(os.path.join(led, "effect")) == "monocolor"
+
+
+def test_downstream_write_error_does_not_repeat_successful_latch(tmp_path):
+    led = _make_oxp_led(tmp_path)
+    os.unlink(os.path.join(led, "brightness"))
+    os.mkdir(os.path.join(led, "brightness"))
+    device = SysfsRgbDevice(led, zones=1, max_brightness=100, index_format="decimal", latch=_OXP_LATCH)
+    assert device.apply_zones([(255, 0, 0)], 100, True) is False
+    open(os.path.join(led, "effect"), "w").write("rainbow")
+    assert device.apply_zones([(0, 255, 0)], 100, True) is False
+    assert _read(os.path.join(led, "effect")) == "rainbow"
+
+
 def test_no_latch_leaves_attrs_untouched(tmp_path):
     led = _make_oxp_led(tmp_path)
     device = SysfsRgbDevice(led, zones=1, max_brightness=100, index_format="decimal")

--- a/tests/test_oxp_hid.py
+++ b/tests/test_oxp_hid.py
@@ -1,0 +1,61 @@
+from py_modules.oxp_hid import (
+    CMD_ID,
+    buf,
+    brightness_cmd,
+    solid_cmd,
+    mode_cmd,
+    level_code,
+    mode_value,
+)
+
+
+def test_buf_frames_and_pads_to_64():
+    packet = buf([0xFE, 0x00])
+    assert packet[:3] == bytes([CMD_ID, 0xFF, 0xFE])
+    assert len(packet) == 64
+    assert packet[4:] == bytes(60)
+
+
+def test_brightness_cmd_enable_high():
+    packet = brightness_cmd(True, 0x04)
+    assert packet[:6] == bytes([CMD_ID, 0xFF, 0xFD, 0x01, 0x05, 0x04])
+    assert len(packet) == 64
+
+
+def test_brightness_cmd_disable():
+    packet = brightness_cmd(False, 0x04)
+    assert packet[:6] == bytes([CMD_ID, 0xFF, 0xFD, 0x00, 0x05, 0x04])
+
+
+def test_solid_cmd_repeats_triple_20_times():
+    packet = solid_cmd(255, 0, 0)
+    assert packet[:3] == bytes([CMD_ID, 0xFF, 0xFE])
+    payload = packet[3 : 3 + 60]
+    triples = [tuple(payload[i : i + 3]) for i in range(0, 60, 3)]
+    assert triples == [(255, 0, 0)] * 20
+    assert packet[63] == 0x00
+
+
+def test_solid_cmd_clamps_channels():
+    packet = solid_cmd(300, -5, 128)
+    assert tuple(packet[3:6]) == (255, 0, 128)
+
+
+def test_level_code_quantization():
+    assert level_code(0) == 0x01
+    assert level_code(20) == 0x01
+    assert level_code(50) == 0x03
+    assert level_code(100) == 0x04
+
+
+def test_mode_value_mapping_defaults_to_aurora():
+    assert mode_value("aurora") == 0x01
+    assert mode_value("flowing") == 0x03
+    assert mode_value("neon") == 0x05
+    assert mode_value("unknown-effect") == 0x01
+
+
+def test_mode_cmd_bytes():
+    packet = mode_cmd(0x03)
+    assert packet[:3] == bytes([CMD_ID, 0xFF, 0x03])
+    assert len(packet) == 64

--- a/tests/test_oxp_hid.py
+++ b/tests/test_oxp_hid.py
@@ -3,9 +3,6 @@ from py_modules.oxp_hid import (
     buf,
     brightness_cmd,
     solid_cmd,
-    mode_cmd,
-    level_code,
-    mode_value,
 )
 
 
@@ -41,21 +38,3 @@ def test_solid_cmd_clamps_channels():
     assert tuple(packet[3:6]) == (255, 0, 128)
 
 
-def test_level_code_quantization():
-    assert level_code(0) == 0x01
-    assert level_code(20) == 0x01
-    assert level_code(50) == 0x03
-    assert level_code(100) == 0x04
-
-
-def test_mode_value_mapping_defaults_to_aurora():
-    assert mode_value("aurora") == 0x01
-    assert mode_value("flowing") == 0x03
-    assert mode_value("neon") == 0x05
-    assert mode_value("unknown-effect") == 0x01
-
-
-def test_mode_cmd_bytes():
-    packet = mode_cmd(0x03)
-    assert packet[:3] == bytes([CMD_ID, 0xFF, 0x03])
-    assert len(packet) == 64

--- a/tests/test_report_collector.py
+++ b/tests/test_report_collector.py
@@ -174,3 +174,31 @@ def test_build_bundle_shape():
     assert len(b["text"]) == 4000
     assert b["kernel"] == {"dmesg": "x", "journal": None}
     assert b["sysfs"] == {"leds": []}
+
+
+def test_sysfs_snapshot_captures_led_latch_attrs(tmp_path):
+    led = tmp_path / "sys/class/leds/oxp:rgb:joystick_rings"
+    led.mkdir(parents=True)
+    (led / "multi_index").write_text("red green blue")
+    (led / "max_brightness").write_text("100")
+    (led / "brightness").write_text("80")
+    (led / "multi_intensity").write_text("0 0 0")
+    (led / "enabled").write_text("false")
+    (led / "effect").write_text("rainbow")
+    (led / "effect_index").write_text("monocolor rainbow breathe")
+    entry = sysfs_snapshot(root=str(tmp_path))["leds"][0]
+    assert entry["enabled"] == "false"
+    assert entry["effect"] == "rainbow"
+    assert entry["effect_index"] == "monocolor rainbow breathe"
+
+
+def test_sysfs_snapshot_latch_attrs_absent_when_missing(tmp_path):
+    led = tmp_path / "sys/class/leds/ally:rgb:joystick_rings"
+    led.mkdir(parents=True)
+    (led / "multi_index").write_text("red green blue")
+    (led / "max_brightness").write_text("255")
+    (led / "brightness").write_text("128")
+    (led / "multi_intensity").write_text("0 0 0")
+    entry = sysfs_snapshot(root=str(tmp_path))["leds"][0]
+    assert entry["enabled"] is None
+    assert entry["effect"] is None


### PR DESCRIPTION
## Qué

Soporte de LEDs RGB para OneXPlayer OneXFly **Apex** y **F1 Pro** (anillos de los joysticks).

Cierra #46, cierra #70.

## Causa raíz

El nodo `oxp:rgb:joystick_rings` lo registra el driver del kernel `hid-oxp`. Escribir `multi_intensity` no basta: el driver exige `enabled=true` + `effect=monocolor` antes de que el color se muestre. Nuestro `SysfsRgbDevice` genérico nunca tocaba esos atributos, así que las escrituras "triunfaban" sin error y los anillos seguían apagados (fallo silencioso). Confirmado con los bundles descifrados de los dos reportes: `hid_oxp` cargado, nodo presente, `brightness=80`, sin errores.

## Cambios

- **`OxpLedsDevice`** (`led_device.py`): subclase de `SysfsRgbDevice` que envía el latch `enabled`/`effect=monocolor` una sola vez, con `invalidate()`/`reconnect()` para reenviarlo tras suspensión, tolerancia a atributos ausentes (degradación honesta) y brillo cacheado para no saturar el MCU.
- **Perfil `oxp_sysfs`** (`device_profiles.py`, `device.py`): nombres para Apex y F1 Pro + fallback `product_contains "ONEXPLAYER"` para el resto de la familia.
- **Fallback HID crudo `hid_oxp_v2`** (`oxp_hid.py`, `hid_adapters.py`): protocolo XFLY (V2) portado de HHD/HueSync, para kernels sin el nodo sysfs (p.ej. Bazzite). Se engancha como `fallback` del perfil igual que la Ally.
- **Collector de reportes**: el snapshot ahora captura `enabled`/`effect`/`effect_index`/`speed`, para que un caso así se autodiagnostique.

## Tests

315 tests de backend en verde (TDD). Sin hardware OneXPlayer en el banco: validación pendiente en la prerelease por los reporters de #46 y #70, con el control de LEDs de HueSync desactivado.

## No mergear hasta

Confirmación en hardware de al menos un reporter (Apex): color, brillo, breathing sin congelar el MCU, y que el color aguanta. Si `effect_index` real nombra el modo directo distinto de `monocolor`, se ajusta la constante y se reconstruye.
