### PR TITLE
fix: improve tab navigation and audio VU

### DIFF
--- a/py_modules/audio.py
+++ b/py_modules/audio.py
@@ -13,6 +13,7 @@ _spawn = asyncio.create_subprocess_exec
 RATE = 16000
 CHUNK = 1024  # samples per frame (~64ms at 16kHz)
 FULL_SCALE = 8000.0  # RMS mapped to level 1.0
+DYNAMIC_RANGE_DB = 40.0
 RETRY_INTERVAL = 3.0
 
 
@@ -22,7 +23,10 @@ def _level_from_pcm(data):
     if not samples:
         return 0.0
     rms = math.sqrt(sum(s * s for s in samples) / len(samples))
-    return min(1.0, rms / FULL_SCALE)
+    if rms <= 0:
+        return 0.0
+    level = 1.0 + 20.0 * math.log10(rms / FULL_SCALE) / DYNAMIC_RANGE_DB
+    return max(0.0, min(1.0, level))
 
 
 class AudioReactive:

--- a/py_modules/effects.py
+++ b/py_modules/effects.py
@@ -272,8 +272,14 @@ def frame_vu(level, zones):
     if zones <= 0:
         return []
     center = (zones - 1) / 2.0
+    center_fill = 0.5 if zones % 2 == 0 else 0.0
+    radius = center - center_fill
     reach = max(0.0, min(1.0, level)) * (zones / 2.0)
-    return _fill_bar(zones, lambda i: reach - abs(i - center), lambda i: abs(i - center) / center if center else 0.0)
+    return _fill_bar(
+        zones,
+        lambda i: reach + center_fill - abs(i - center),
+        lambda i: max(0.0, abs(i - center) - center_fill) / radius if radius else 0.0,
+    )
 
 
 def battery_band_color(level):

--- a/src/components/TabBar.tsx
+++ b/src/components/TabBar.tsx
@@ -2,6 +2,7 @@ import { FC, ReactNode, useEffect, useRef } from "react";
 import { Focusable } from "@decky/ui";
 import { segmentGroupStyle, segmentItemStyle } from "./segmented";
 import { MarqueeText } from "./MarqueeText";
+import { COLORES_TABSTRIP, focusAfterNavigation } from "../focus";
 
 export interface TabItem {
   id: string;
@@ -16,41 +17,122 @@ interface TabBarProps {
   onSelect: (id: string) => void;
 }
 
+const ACTIVE_LABEL_MAX = 150;
+const FADE_W = 22;
+const TAB_RADIUS = 12;
+const TAB_SURFACE = "rgba(255,255,255,0.04)";
+const FADE_BASE = {
+  position: "absolute" as const,
+  top: 0,
+  bottom: 0,
+  width: FADE_W,
+  pointerEvents: "none" as const,
+  opacity: 0,
+  transition: "opacity 140ms ease",
+  zIndex: 2,
+};
+
 export const TabBar: FC<TabBarProps> = ({ tabs, activeId, onSelect }) => {
+  const stripRef = useRef<HTMLDivElement>(null);
   const activeTabRef = useRef<HTMLDivElement>(null);
+  const leftFadeRef = useRef<HTMLDivElement>(null);
+  const rightFadeRef = useRef<HTMLDivElement>(null);
   const mounted = useRef(false);
+
+  const reconcile = () => {
+    const strip = stripRef.current;
+    if (!strip) return;
+    const overflow = strip.scrollWidth - strip.clientWidth;
+    strip.style.justifyContent = overflow > 1 ? "flex-start" : "center";
+    const left = strip.scrollLeft;
+    if (leftFadeRef.current) leftFadeRef.current.style.opacity = left > 1 ? "1" : "0";
+    if (rightFadeRef.current)
+      rightFadeRef.current.style.opacity = left < overflow - 1 ? "1" : "0";
+  };
+
   useEffect(() => {
-    if (!mounted.current) {
-      mounted.current = true;
-      return;
-    }
-    const el = activeTabRef.current;
-    if (el?.isConnected && el.ownerDocument.hasFocus()) el.focus();
+    const activeTab = activeTabRef.current;
+    activeTab?.scrollIntoView({
+      inline: "center",
+      block: "nearest",
+      behavior: mounted.current ? "smooth" : "auto",
+    });
+    let cancelFocus: (() => void) | undefined;
+    if (mounted.current && activeTab) cancelFocus = focusAfterNavigation(activeTab);
+    else mounted.current = true;
+    return cancelFocus;
   }, [activeId]);
 
+  useEffect(reconcile);
+
+  useEffect(() => {
+    const strip = stripRef.current;
+    if (!strip) return;
+    strip.addEventListener("scroll", reconcile, { passive: true });
+    const ro =
+      typeof ResizeObserver !== "undefined" ? new ResizeObserver(reconcile) : null;
+    ro?.observe(strip);
+    return () => {
+      strip.removeEventListener("scroll", reconcile);
+      ro?.disconnect();
+    };
+  }, [tabs.length]);
+
   return (
-    <Focusable style={segmentGroupStyle}>
-      {tabs.map((tab) => {
-        const active = tab.id === activeId;
-        return (
-          <Focusable
-            key={tab.id}
-            ref={active ? activeTabRef : undefined}
-            style={{
-              ...segmentItemStyle(active),
-              flex: active ? 1 : "0 0 auto",
-              padding: active ? "6px 10px" : "6px 9px",
-            }}
-            aria-label={tab.label}
-            onActivate={() => onSelect(tab.id)}
-            onClick={() => onSelect(tab.id)}
-          >
-            {tab.icon}
-            {active && <MarqueeText text={tab.label} />}
-            {tab.badge}
-          </Focusable>
-        );
-      })}
-    </Focusable>
+    <div style={{ position: "relative" }}>
+      <Focusable
+        ref={stripRef}
+        className={COLORES_TABSTRIP}
+        style={{
+          ...segmentGroupStyle,
+          padding: "8px 10px",
+          overflowX: "auto",
+          overflowY: "hidden",
+        }}
+      >
+        {tabs.map((tab) => {
+          const active = tab.id === activeId;
+          return (
+            <Focusable
+              key={tab.id}
+              ref={active ? activeTabRef : undefined}
+              style={{
+                ...segmentItemStyle(active),
+                flex: "0 0 auto",
+                maxWidth: active ? ACTIVE_LABEL_MAX : undefined,
+                padding: active ? "6px 10px" : "6px 9px",
+              }}
+              aria-label={tab.label}
+              onActivate={() => onSelect(tab.id)}
+              onClick={() => onSelect(tab.id)}
+            >
+              {tab.icon}
+              {active && <MarqueeText text={tab.label} />}
+              {tab.badge}
+            </Focusable>
+          );
+        })}
+      </Focusable>
+      <div
+        ref={leftFadeRef}
+        style={{
+          ...FADE_BASE,
+          left: 0,
+          borderTopLeftRadius: TAB_RADIUS,
+          borderBottomLeftRadius: TAB_RADIUS,
+          background: `linear-gradient(to right, ${TAB_SURFACE}, transparent)`,
+        }}
+      />
+      <div
+        ref={rightFadeRef}
+        style={{
+          ...FADE_BASE,
+          right: 0,
+          borderTopRightRadius: TAB_RADIUS,
+          borderBottomRightRadius: TAB_RADIUS,
+          background: `linear-gradient(to left, ${TAB_SURFACE}, transparent)`,
+        }}
+      />
+    </div>
   );
 };

--- a/src/focus.test.ts
+++ b/src/focus.test.ts
@@ -1,5 +1,12 @@
 import { describe, it, expect } from "vitest";
-import { buildFocusCss, ensureFocusStyles, FOCUS_STYLE_ID, COLORES_ROOT } from "./focus";
+import {
+  buildFocusCss,
+  ensureFocusStyles,
+  FOCUS_STYLE_ID,
+  COLORES_ROOT,
+  COLORES_TABSTRIP,
+  focusAfterNavigation,
+} from "./focus";
 
 describe("buildFocusCss", () => {
   const css = buildFocusCss();
@@ -20,6 +27,11 @@ describe("buildFocusCss", () => {
 
   it("uses !important so it wins over the elements' inline box-shadow", () => {
     expect(css).toContain("!important");
+  });
+
+  it("hides the native scrollbar on the horizontal tab strip", () => {
+    expect(css).toContain(`.${COLORES_TABSTRIP} { scrollbar-width: none;`);
+    expect(css).toContain(`.${COLORES_TABSTRIP}::-webkit-scrollbar`);
   });
 });
 
@@ -65,5 +77,56 @@ describe("ensureFocusStyles", () => {
 
   it("never throws when the document surface is unusable", () => {
     expect(() => ensureFocusStyles({} as unknown as Document)).not.toThrow();
+  });
+});
+
+describe("focusAfterNavigation", () => {
+  it("reasserts the active focus after Steam restores the previous controller focus", () => {
+    let focused = "previous";
+    let scheduled: FrameRequestCallback | undefined;
+    const element = {
+      isConnected: true,
+      ownerDocument: { hasFocus: () => true },
+      focus: () => {
+        focused = "active";
+      },
+    } as unknown as HTMLElement;
+
+    focusAfterNavigation(
+      element,
+      (callback) => {
+        scheduled = callback;
+        return 1;
+      },
+      () => undefined,
+    );
+    focused = "previous";
+    scheduled?.(0);
+
+    expect(focused).toBe("active");
+  });
+
+  it("does not steal focus when the QAM document is inactive", () => {
+    let focusCalls = 0;
+    let scheduled: FrameRequestCallback | undefined;
+    const element = {
+      isConnected: true,
+      ownerDocument: { hasFocus: () => false },
+      focus: () => {
+        focusCalls += 1;
+      },
+    } as unknown as HTMLElement;
+
+    focusAfterNavigation(
+      element,
+      (callback) => {
+        scheduled = callback;
+        return 1;
+      },
+      () => undefined,
+    );
+    scheduled?.(0);
+
+    expect(focusCalls).toBe(0);
   });
 });

--- a/src/focus.ts
+++ b/src/focus.ts
@@ -2,6 +2,20 @@ import { FALLBACK_ACCENT_RGB } from "./accent";
 
 export const COLORES_ROOT = "colores-root";
 export const FOCUS_STYLE_ID = "colores-focus-styles";
+export const COLORES_TABSTRIP = "colores-tabstrip";
+
+export function focusAfterNavigation(
+  element: HTMLElement,
+  scheduleFrame: (callback: FrameRequestCallback) => number = requestAnimationFrame,
+  cancelFrame: (handle: number) => void = cancelAnimationFrame,
+): () => void {
+  const canFocus = () => element.isConnected && element.ownerDocument.hasFocus();
+  if (canFocus()) element.focus();
+  const handle = scheduleFrame(() => {
+    if (canFocus()) element.focus();
+  });
+  return () => cancelFrame(handle);
+}
 
 export function buildFocusCss(): string {
   const ring = `rgb(var(--colores-accent-rgb, ${FALLBACK_ACCENT_RGB}))`;
@@ -16,7 +30,9 @@ export function buildFocusCss(): string {
   transition: box-shadow 120ms ease, filter 120ms ease;
   position: relative;
   z-index: 1;
-}`.trim();
+}
+.${COLORES_TABSTRIP} { scrollbar-width: none; -ms-overflow-style: none; }
+.${COLORES_TABSTRIP}::-webkit-scrollbar { display: none; width: 0; height: 0; }`.trim();
 }
 
 export function ensureFocusStyles(doc: Document = document): void {

--- a/src/palette.test.ts
+++ b/src/palette.test.ts
@@ -1,0 +1,16 @@
+import { describe, expect, it } from "vitest";
+import { audioVuColors } from "./palette";
+
+describe("audioVuColors", () => {
+  it("renders a two-zone center pair as visible green", () => {
+    const colors = audioVuColors(0.6, 2);
+
+    expect(colors[0]).toEqual(colors[1]);
+    expect(colors[0].g).toBeGreaterThan(colors[0].r);
+    expect(colors[0].r + colors[0].g + colors[0].b).toBeGreaterThan(100);
+  });
+
+  it("returns no colors when the device has no zones", () => {
+    expect(audioVuColors(0.6, 0)).toEqual([]);
+  });
+});

--- a/src/palette.ts
+++ b/src/palette.ts
@@ -288,10 +288,17 @@ export function performanceMeterColors(loadPct: number, zones: number): RGB[] {
 }
 
 export function audioVuColors(level: number, zones: number): RGB[] {
-  const n = Math.max(1, zones);
+  if (zones <= 0) return [];
+  const n = zones;
   const center = (n - 1) / 2;
+  const centerFill = n % 2 === 0 ? 0.5 : 0;
+  const radius = center - centerFill;
   const reach = Math.max(0, Math.min(1, level)) * (n / 2);
-  return fillBar(zones, (i) => reach - Math.abs(i - center), (i) => (center ? Math.abs(i - center) / center : 0));
+  return fillBar(
+    zones,
+    (i) => reach + centerFill - Math.abs(i - center),
+    (i) => (radius ? Math.max(0, Math.abs(i - center) - centerFill) / radius : 0),
+  );
 }
 
 export function temperatureBandColor(temp: number): RGB {

--- a/tests/test_audio.py
+++ b/tests/test_audio.py
@@ -11,9 +11,9 @@ def test_level_zero_on_silence():
     assert _level_from_pcm(_pcm(0)) == 0.0
 
 
-def test_level_scales_with_amplitude():
-    # RMS of a constant signal is its amplitude; FULL_SCALE is 8000.
-    assert _level_from_pcm(_pcm(4000)) == 0.5
+def test_level_uses_decibel_range_for_quiet_audio():
+    assert _level_from_pcm(_pcm(80)) == 0.0
+    assert _level_from_pcm(_pcm(800)) == 0.5
     assert _level_from_pcm(_pcm(8000)) == 1.0
 
 

--- a/tests/test_effects.py
+++ b/tests/test_effects.py
@@ -18,6 +18,7 @@ from py_modules.effects import (
     frame_ripple,
     frame_aurora,
     frame_meter,
+    frame_vu,
     clock_color,
     hsv_to_rgb,
     interpolate_gradient,
@@ -36,7 +37,6 @@ def test_clock_color_wraps_around_midnight():
 
 
 def test_vu_silence_is_dark_and_loud_fills_from_center():
-    from py_modules.effects import frame_vu
     assert all(c == (0, 0, 0) for c in frame_vu(0.0, 17))
     loud = frame_vu(1.0, 17)
     assert len(loud) == 17
@@ -44,6 +44,13 @@ def test_vu_silence_is_dark_and_loud_fills_from_center():
     quiet = frame_vu(0.25, 17)
     assert sum(quiet[8]) > 0 and quiet[0] == (0, 0, 0)  # center lit, edges dark
     assert frame_vu(0.5, 0) == []
+
+
+def test_vu_two_zone_device_reacts_below_half_scale():
+    quiet = frame_vu(0.1, 2)
+    assert quiet[0] == quiet[1]
+    assert sum(quiet[0]) > 0
+    assert quiet[0][1] > quiet[0][0]
 
 
 def test_meter_fills_proportionally():


### PR DESCRIPTION
## Qué cambia / What changes

- Replica en Colores la estructura desplazable de pestañas de Panel de Control: elementos sin colapsar, pestaña activa centrada y degradados laterales.
- Mantiene el foco del mando sincronizado con la pestaña activa tras navegar con L1/R1, sin reclamarlo cuando la superficie de Steam está inactiva.
- Ajusta el nivel de audio a una escala de 40 dB para que el VU reaccione mejor con música normal.
- Corrige la geometría de centro en dispositivos con un número par de zonas y mantiene el visor TypeScript alineado con el render de Python.

**EN:** Mirrors Control Panel's scrollable tab structure, keeps controller focus aligned safely, and makes the audio VU more responsive and consistent on even-zone devices and in the preview.

## Por qué / Why

Las pestañas se comprimían hasta dejar de ser legibles. Además, la restauración de foco de Steam podía dejar el marco del mando en un control distinto de la pestaña activa. En la Legion Go S, la escala lineal y la pareja central de dos zonas hacían que el VU pareciera casi inmóvil y naranja.

**EN:** Tabs became unreadable when compressed, Steam could restore focus to a stale control, and the linear audio scale plus two-zone center geometry made the Legion Go S VU look nearly static and orange.

## Pruebas / Testing

- [x] 319 pruebas backend
- [x] 41 pruebas frontend
- [x] Ruff
- [x] TypeScript (`tsc --noEmit`)
- [x] Build Rollup con Node 20
- [x] Validación en QAM y prueba HID visible en Legion Go S

La validación física se limita a Legion Go S; el resto de consumidores queda cubierto por pruebas automatizadas y conserva sus rutas existentes.
