### PR TITLE
fix: correct OneXPlayer Apex RGB output

### DIFF
--- a/py_modules/device_profiles.py
+++ b/py_modules/device_profiles.py
@@ -85,6 +85,7 @@ OXP_SYSFS = {
     "latch": [["enabled", "true"], ["effect", "monocolor"]],
     "max_render_fps": 10,
     "supported_effects": ["breathing", "rainbow", "wave", "cycle"],
+    "conflicts_with_system_rgb": True,
     "experimental": [],
 }
 
@@ -96,8 +97,6 @@ GENERIC = {
     "experimental": ["color", "brightness", "effects", "ambilight"],
 }
 
-# The sysfs RGB node isn't guaranteed on every kernel/Bazzite build for the Ally line.
-# When it's missing, build_device drops to the Aura HID driver instead of "no LEDs".
 ASUS_SYSFS["fallback"] = ASUS_ALLY_HID
 OXP_SYSFS["fallback"] = OXP_HID
 

--- a/py_modules/hid_adapters.py
+++ b/py_modules/hid_adapters.py
@@ -44,6 +44,7 @@ try:
     )
     from oxp_hid import (
         OxpHidTransport,
+        STATE_CHANGE_DELAY as OXP_STATE_CHANGE_DELAY,
         brightness_cmd as oxp_brightness_cmd,
         solid_cmd as oxp_solid_cmd,
         LEVEL_HIGH as OXP_LEVEL_HIGH,
@@ -86,8 +87,6 @@ ASUS_ALLY_IDS = {
     "usage": [0x0080],
 }
 
-# Match by VID + usage; PID varies across the OneXPlayer family, so leave it open
-# (one HID fallback covers every OXP model that exposes the XFLY RGB interface).
 OXP_IDS = {
     "vid": [0x1A2C],
     "pid": [],
@@ -491,11 +490,11 @@ class OxpHidDevice(_BaseHidDevice):
         scaled = (_clamp8(r * scale), _clamp8(g * scale), _clamp8(b * scale))
 
         def _do():
-            reps = []
             if self._transport.prev_mode != "solid":
-                reps.append(oxp_brightness_cmd(True, OXP_LEVEL_HIGH))
-            reps.append(oxp_solid_cmd(*scaled))
-            ok = self._write(reps)
+                if not self._write([oxp_brightness_cmd(True, OXP_LEVEL_HIGH)]):
+                    return False
+                sleep(OXP_STATE_CHANGE_DELAY)
+            ok = self._write([oxp_solid_cmd(*scaled)])
             if ok:
                 self._transport.prev_mode = "solid"
             return ok

--- a/py_modules/led_device.py
+++ b/py_modules/led_device.py
@@ -72,6 +72,7 @@ class SysfsRgbDevice(LedDevice):
         self._brightness_path = os.path.join(led_path, "brightness") if led_path else None
         self._has_intensity = bool(self._intensity_path) and os.path.exists(self._intensity_path)
         self._has_brightness = bool(self._brightness_path) and os.path.exists(self._brightness_path)
+        self._channel_maxima = self._read_channel_maxima()
         self._latch = [(os.path.join(led_path, attr), value) for attr, value in (latch or [])] if led_path else []
         self._latched = False
 
@@ -109,8 +110,25 @@ class SysfsRgbDevice(LedDevice):
             return b, g, r
         return r, g, b
 
-    def _format_zone(self, color):
-        r, g, b = self._order(color)
+    def _read_channel_maxima(self):
+        if not self._led_path or self._index_format != "decimal":
+            return None
+        try:
+            with open(os.path.join(self._led_path, "multi_max_intensity")) as handle:
+                values = tuple(int(value) for value in handle.read().split())
+        except (OSError, ValueError):
+            return None
+        if len(values) != self._zones * 3 or any(value <= 0 for value in values):
+            return None
+        return values
+
+    def _format_zone(self, color, zone):
+        channels = self._order(color)
+        if self._channel_maxima:
+            offset = zone * 3
+            maxima = self._channel_maxima[offset : offset + 3]
+            channels = tuple(round(channel * maximum / 255) for channel, maximum in zip(channels, maxima))
+        r, g, b = channels
         if self._index_format == "decimal":
             return f"{r} {g} {b}"
         return f"0x{r:02x}{g:02x}{b:02x}"
@@ -129,7 +147,7 @@ class SysfsRgbDevice(LedDevice):
             return False
         try:
             if self._has_intensity:
-                values = " ".join(self._format_zone(c) for c in self._fit(zone_colors))
+                values = " ".join(self._format_zone(color, zone) for zone, color in enumerate(self._fit(zone_colors)))
                 with open(self._intensity_path, "w") as handle:
                     handle.write(values)
             if self._has_brightness:

--- a/py_modules/oxp_hid.py
+++ b/py_modules/oxp_hid.py
@@ -5,6 +5,7 @@ CMD_ID = 0x07
 
 LEVEL_HIGH = 0x04
 WRITE_DELAY = 0.05
+STATE_CHANGE_DELAY = 0.3
 
 
 def _clamp8(v):

--- a/py_modules/report/collector.py
+++ b/py_modules/report/collector.py
@@ -143,7 +143,17 @@ def kernel_logs(
 _SNAP_MAX_NODES = 64
 _SNAP_MAX_MODULES = 512
 _SNAP_CAP = 60_000
-_LED_VALUE_NODES = ("multi_index", "max_brightness", "brightness", "enabled", "effect", "effect_index", "speed")
+_LED_VALUE_NODES = (
+    "multi_index",
+    "multi_intensity",
+    "multi_max_intensity",
+    "max_brightness",
+    "brightness",
+    "enabled",
+    "effect",
+    "effect_index",
+    "speed",
+)
 
 
 def _glob(root: str, pattern: str) -> list[str]:

--- a/tests/test_device.py
+++ b/tests/test_device.py
@@ -254,6 +254,7 @@ def test_capabilities_conflicts_defaults_false():
 
 _OXP_LED_FILES = {
     "multi_index": "red green blue",
+    "multi_max_intensity": "100 100 100",
     "multi_intensity": "0 0 0",
     "brightness": "0",
     "max_brightness": "100",
@@ -274,11 +275,12 @@ def test_build_device_oxp_uses_latch_device(tmp_path):
     assert caps["maxBrightness"] == 100
     assert caps["maxRenderFps"] == 10
     assert caps["states"]["color"] == "supported"
+    assert caps["conflictsWithSystemRgb"] is True
     assert ctx["device"].apply_zones([(255, 0, 0)], 100, True) is True
     led = os.path.join(root, "sys/class/leds/oxp:rgb:joystick_rings")
     assert open(os.path.join(led, "enabled")).read() == "true"
     assert open(os.path.join(led, "effect")).read() == "monocolor"
-    assert open(os.path.join(led, "multi_intensity")).read() == "255 0 0"
+    assert open(os.path.join(led, "multi_intensity")).read() == "100 0 0"
 
 
 def test_build_device_oxp_without_node_degrades(tmp_path):

--- a/tests/test_hid_adapters.py
+++ b/tests/test_hid_adapters.py
@@ -664,7 +664,7 @@ def test_oxp_invalidate_re_enables(hid_env):
     assert writes[0][:3] == bytes([0x07, 0xFF, 0xFD])
 
 
-def test_oxp_spaces_consecutive_reports_by_protocol_delay(hid_env, monkeypatch):
+def test_oxp_waits_for_apex_mcu_after_enable(hid_env, monkeypatch):
     adapters, writes = hid_env
     sys.modules["lib_hid"].enumerate = lambda vid=0, pid=0: [_oxp_entry()]
     clock = {"now": 0.0}
@@ -680,6 +680,28 @@ def test_oxp_spaces_consecutive_reports_by_protocol_delay(hid_env, monkeypatch):
     dev = adapters.OxpHidDevice.create()
     assert dev.apply_solid((255, 0, 0), 100, True) is True
     assert len(writes) == 2
+    assert sleeps == pytest.approx([0.3])
+
+
+def test_oxp_steady_state_keeps_protocol_delay(hid_env, monkeypatch):
+    adapters, writes = hid_env
+    sys.modules["lib_hid"].enumerate = lambda vid=0, pid=0: [_oxp_entry()]
+    clock = {"now": 0.0}
+    sleeps = []
+
+    monkeypatch.setattr(adapters, "monotonic", lambda: clock["now"], raising=False)
+
+    def advance(delay):
+        sleeps.append(delay)
+        clock["now"] += delay
+
+    monkeypatch.setattr(adapters, "sleep", advance, raising=False)
+    dev = adapters.OxpHidDevice.create()
+    assert dev.apply_solid((255, 0, 0), 100, True) is True
+    sleeps.clear()
+    writes.clear()
+    assert dev.apply_solid((0, 255, 0), 100, True) is True
+    assert len(writes) == 1
     assert sleeps == pytest.approx([0.05])
 
 

--- a/tests/test_led_device.py
+++ b/tests/test_led_device.py
@@ -260,6 +260,7 @@ def _make_oxp_led(tmp_path, with_latch=True):
     led = os.path.join(str(tmp_path), "oxp:rgb:joystick_rings")
     os.makedirs(led)
     open(os.path.join(led, "multi_index"), "w").write("red green blue")
+    open(os.path.join(led, "multi_max_intensity"), "w").write("100 100 100")
     open(os.path.join(led, "multi_intensity"), "w").write("0 0 0")
     open(os.path.join(led, "brightness"), "w").write("0")
     open(os.path.join(led, "max_brightness"), "w").write("100")
@@ -275,8 +276,16 @@ def test_latch_writes_before_color(tmp_path):
     assert device.apply_zones([(255, 0, 0)], 100, True) is True
     assert _read(os.path.join(led, "enabled")) == "true"
     assert _read(os.path.join(led, "effect")) == "monocolor"
-    assert _read(os.path.join(led, "multi_intensity")) == "255 0 0"
+    assert _read(os.path.join(led, "multi_intensity")) == "100 0 0"
     assert _read(os.path.join(led, "brightness")) == "100"
+
+
+def test_decimal_channels_scale_to_multi_max_intensity(tmp_path):
+    led = _make_oxp_led(tmp_path)
+    device = SysfsRgbDevice(led, zones=1, max_brightness=100, index_format="decimal")
+    assert device.apply_zones([(255, 122, 0)], 80, True) is True
+    assert _read(os.path.join(led, "multi_intensity")) == "100 48 0"
+    assert _read(os.path.join(led, "brightness")) == "80"
 
 
 def test_latch_writes_only_once(tmp_path):
@@ -312,7 +321,7 @@ def test_latch_tolerates_missing_attrs(tmp_path):
     led = _make_oxp_led(tmp_path, with_latch=False)
     device = SysfsRgbDevice(led, zones=1, max_brightness=100, index_format="decimal", latch=_OXP_LATCH)
     assert device.apply_zones([(255, 0, 0)], 100, True) is True
-    assert _read(os.path.join(led, "multi_intensity")) == "255 0 0"
+    assert _read(os.path.join(led, "multi_intensity")) == "100 0 0"
 
 
 def test_latch_applies_when_attrs_appear_after_led_node(tmp_path):

--- a/tests/test_report_collector.py
+++ b/tests/test_report_collector.py
@@ -180,6 +180,7 @@ def test_sysfs_snapshot_captures_led_latch_attrs(tmp_path):
     led = tmp_path / "sys/class/leds/oxp:rgb:joystick_rings"
     led.mkdir(parents=True)
     (led / "multi_index").write_text("red green blue")
+    (led / "multi_max_intensity").write_text("100 100 100")
     (led / "max_brightness").write_text("100")
     (led / "brightness").write_text("80")
     (led / "multi_intensity").write_text("0 0 0")
@@ -190,6 +191,8 @@ def test_sysfs_snapshot_captures_led_latch_attrs(tmp_path):
     assert entry["enabled"] == "false"
     assert entry["effect"] == "rainbow"
     assert entry["effect_index"] == "monocolor rainbow breathe"
+    assert entry["multi_intensity"] == "0 0 0"
+    assert entry["multi_max_intensity"] == "100 100 100"
 
 
 def test_sysfs_snapshot_latch_attrs_absent_when_missing(tmp_path):


### PR DESCRIPTION
## Summary

- scale decimal sysfs RGB channels against `multi_max_intensity` so the Apex preserves color proportions instead of clipping values above 100
- wait 300 ms between enabling the OneXPlayer HID fallback and sending its first color while preserving the 50 ms steady-state cadence
- expose the existing system-RGB reclaim path for OneXPlayer sysfs devices
- capture `multi_intensity` and `multi_max_intensity` in reports for hardware diagnosis

## Root cause

The `hid-oxp` LED interface advertises a per-channel maximum of 100, while Colores wrote RGB values in the 0–255 range. Linux clamps channels independently, which changes the requested hue. The raw HID fallback also sent enable and color commands too close together for the Apex MCU processing interval.

## Impact

The OneXPlayer sysfs route remains primary and the XFLY HID transport remains a fallback only when the sysfs node is unavailable. No new device identities or capabilities are introduced.

## Validation

- 320 backend tests passed
- 36 frontend tests passed
- Ruff passed
- TypeScript typecheck passed
- Rollup bundle generation completed
- focused tests cover integrated sysfs scaling, the 300 ms enable transition, and the 50 ms steady-state delay

## Hardware status

The Apex protocol is supported by the Linux `hid-oxp` driver and has external physical validation through HueSync. A Colores test build still needs to be exercised on the reporter's SteamOS Apex before closing the report.

Related to #78.
