### PR TITLE
fix: harden OneXPlayer Apex RGB control

### DIFF
--- a/main.py
+++ b/main.py
@@ -89,6 +89,8 @@ class Plugin:
         if getattr(self, "_ready", False):
             return
         self._stopping = False
+        self._hhd_rgb_lock = asyncio.Lock()
+        self._hhd_rgb_status = None
         self._setup_device(self._build_context())
         self._store = SettingsStore(
             os.path.join(decky.DECKY_PLUGIN_SETTINGS_DIR, "state.json")
@@ -405,31 +407,29 @@ class Plugin:
 
     async def set_force_control(self, on: bool) -> None:
         self._init()
-        if getattr(self, "_stopping", False):
+        if self._stopping:
             decky.logger.warning("Colores: force-control change ignored during shutdown")
             return
         self._settings["force_control"] = on
         self._store.save(self._settings)
         if on:
             claim = await self._claim_hhd_rgb()
-            if claim == "stopping" or getattr(self, "_stopping", False):
+            if claim == "stopping" or self._stopping:
                 return
             self._controller.invalidate()
         else:
             await self._restore_hhd_rgb()
-            if getattr(self, "_stopping", False):
+            if self._stopping:
                 return
         self._apply()
 
     def _uses_hhd_rgb_takeover(self) -> bool:
         return bool(self._capabilities.get("hhdRgbTakeover"))
 
-    def _hhd_operation_lock(self):
-        lock = getattr(self, "_hhd_rgb_lock", None)
-        if lock is None:
-            lock = asyncio.Lock()
-            self._hhd_rgb_lock = lock
-        return lock
+    def _set_hhd_status(self, status, log, message):
+        if self._hhd_rgb_status != status:
+            log(message)
+        self._hhd_rgb_status = status
 
     async def _run_hhd_call(self, call):
         future = asyncio.get_running_loop().run_in_executor(None, call)
@@ -447,21 +447,15 @@ class Plugin:
     async def _claim_hhd_rgb(self) -> str:
         if not self._uses_hhd_rgb_takeover():
             return "not_applicable"
-        async with self._hhd_operation_lock():
-            if getattr(self, "_stopping", False):
+        async with self._hhd_rgb_lock:
+            if self._stopping:
                 return "stopping"
             current = await self._run_hhd_call(self._hhd_rgb.read_rgb)
             if current is None:
-                if getattr(self, "_hhd_rgb_status", None) != "unavailable":
-                    decky.logger.warning(
-                        "Colores: HHD RGB state unavailable; continuing Apex reclaim"
-                    )
-                self._hhd_rgb_status = "unavailable"
+                self._set_hhd_status("unavailable", decky.logger.warning, "Colores: HHD RGB state unavailable; continuing Apex reclaim")
                 return "failed"
             if current is False:
-                if getattr(self, "_hhd_rgb_status", None) != "disabled":
-                    decky.logger.info("Colores: HHD RGB already disabled")
-                self._hhd_rgb_status = "disabled"
+                self._set_hhd_status("disabled", decky.logger.info, "Colores: HHD RGB already disabled")
                 return "unchanged"
             if self._settings.get("hhd_rgb_restore") is not True:
                 self._settings["hhd_rgb_restore"] = True
@@ -471,17 +465,13 @@ class Plugin:
                 self._hhd_rgb_status = "disabled"
                 decky.logger.info("Colores: HHD RGB disabled and confirmed for Apex takeover")
                 return "changed"
-            if getattr(self, "_hhd_rgb_status", None) != "disable_failed":
-                decky.logger.warning(
-                    "Colores: HHD RGB disable was not confirmed; restore marker retained"
-                )
-            self._hhd_rgb_status = "disable_failed"
+            self._set_hhd_status("disable_failed", decky.logger.warning, "Colores: HHD RGB disable was not confirmed; restore marker retained")
             return "failed"
 
     async def _restore_hhd_rgb(self) -> bool:
         if not self._uses_hhd_rgb_takeover():
             return True
-        async with self._hhd_operation_lock():
+        async with self._hhd_rgb_lock:
             if self._settings.get("hhd_rgb_restore") is not True:
                 return True
             confirmed = await self._run_hhd_call(lambda: self._hhd_rgb.set_rgb(True))
@@ -578,11 +568,11 @@ class Plugin:
 
     async def reconnect(self) -> bool:
         self._init()
-        if getattr(self, "_stopping", False):
+        if self._stopping:
             return False
         if self._settings.get("force_control"):
             claim = await self._claim_hhd_rgb()
-            if claim == "stopping" or getattr(self, "_stopping", False):
+            if claim == "stopping" or self._stopping:
                 return False
         self._reprobe_device()
         ok = self._controller.reconnect()
@@ -896,7 +886,7 @@ class Plugin:
             decky.logger.warning("Colores: force-control watch failed: %s", error)
 
     async def _stop_background_tasks(self):
-        async with self._hhd_operation_lock():
+        async with self._hhd_rgb_lock:
             self._stopping = True
         tasks = []
         for attr in ("_reassert_task", "_charger_task", "_force_control_task", "_startup_task"):

--- a/main.py
+++ b/main.py
@@ -57,9 +57,6 @@ CHARGER_POLL_INTERVAL = 3.0
 # so we debounce it — dragging the color wheel must not write flash on every frame.
 STARTUP_PERSIST_DELAY = 1.0
 
-# When "force control" is on, how often we re-assert our LED state to win it back
-# from another RGB tool (e.g. HHD) that keeps reapplying its own colors. A blind
-# re-write, not an ownership check. Only runs on devices that actually conflict.
 FORCE_CONTROL_INTERVAL = 2.0
 
 # Cold-boot LED acquisition: the Ally's RGB node hangs off a USB HID device that can

--- a/main.py
+++ b/main.py
@@ -17,6 +17,7 @@ from power_supply import charger_online, battery_level
 from thermal import apu_temperature
 from performance import gpu_busy_percent, CpuSampler
 from saved_gradients import upsert_gradient, remove_gradient
+from hhd_rgb_control import HhdRgbControl
 import self_updater
 from report import collector as report_collector
 from report import client as report_client
@@ -40,6 +41,7 @@ DEFAULTS = {
     "power_led_off": False,
     "charger_only": False,
     "force_control": False,
+    "hhd_rgb_restore": None,
     "battery_breathe": True,
     "temperature_breathe": True,
     "remember_startup": True,
@@ -89,6 +91,7 @@ class Plugin:
     def _init(self) -> None:
         if getattr(self, "_ready", False):
             return
+        self._stopping = False
         self._setup_device(self._build_context())
         self._store = SettingsStore(
             os.path.join(decky.DECKY_PLUGIN_SETTINGS_DIR, "state.json")
@@ -96,6 +99,7 @@ class Plugin:
         self._settings = self._store.load(DEFAULTS)
         self._settings["ambilight"] = {**DEFAULTS["ambilight"], **self._settings["ambilight"]}
         self._settings["effect"] = {**DEFAULTS["effect"], **self._settings["effect"]}
+        self._hhd_rgb = HhdRgbControl()
         self._ac_online = charger_online()
         level = battery_level()
         self._battery_level = 100 if level is None else level
@@ -246,6 +250,7 @@ class Plugin:
         capabilities = report_collector.capabilities_from(
             state,
             driver=type(self._controller).__name__,
+            route=getattr(self._controller, "route", None),
             led_path=getattr(self._controller, "led_path", None),
             last_error=getattr(self._controller, "last_error", None),
         )
@@ -355,6 +360,9 @@ class Plugin:
             else:
                 caps[feature] = False
         caps["enabledExperiments"] = sorted(enabled)
+        route = getattr(self._controller, "route", None)
+        if route:
+            caps["rgbRoute"] = route
         return caps
 
     async def get_state(self) -> dict:
@@ -400,11 +408,94 @@ class Plugin:
 
     async def set_force_control(self, on: bool) -> None:
         self._init()
+        if getattr(self, "_stopping", False):
+            decky.logger.warning("Colores: force-control change ignored during shutdown")
+            return
         self._settings["force_control"] = on
         self._store.save(self._settings)
         if on:
-            self._controller.invalidate()  # force a full re-init so it reclaims at once
+            claim = await self._claim_hhd_rgb()
+            if claim == "stopping" or getattr(self, "_stopping", False):
+                return
+            self._controller.invalidate()
+        else:
+            await self._restore_hhd_rgb()
+            if getattr(self, "_stopping", False):
+                return
         self._apply()
+
+    def _uses_hhd_rgb_takeover(self) -> bool:
+        return bool(self._capabilities.get("hhdRgbTakeover"))
+
+    def _hhd_operation_lock(self):
+        lock = getattr(self, "_hhd_rgb_lock", None)
+        if lock is None:
+            lock = asyncio.Lock()
+            self._hhd_rgb_lock = lock
+        return lock
+
+    async def _run_hhd_call(self, call):
+        future = asyncio.get_running_loop().run_in_executor(None, call)
+        try:
+            return await asyncio.shield(future)
+        except asyncio.CancelledError:
+            await future
+            raise
+        except Exception as error:
+            decky.logger.warning(
+                "Colores: HHD RGB operation failed: %s", type(error).__name__
+            )
+            return None
+
+    async def _claim_hhd_rgb(self) -> str:
+        if not self._uses_hhd_rgb_takeover():
+            return "not_applicable"
+        async with self._hhd_operation_lock():
+            if getattr(self, "_stopping", False):
+                return "stopping"
+            current = await self._run_hhd_call(self._hhd_rgb.read_rgb)
+            if current is None:
+                if getattr(self, "_hhd_rgb_status", None) != "unavailable":
+                    decky.logger.warning(
+                        "Colores: HHD RGB state unavailable; continuing Apex reclaim"
+                    )
+                self._hhd_rgb_status = "unavailable"
+                return "failed"
+            if current is False:
+                if getattr(self, "_hhd_rgb_status", None) != "disabled":
+                    decky.logger.info("Colores: HHD RGB already disabled")
+                self._hhd_rgb_status = "disabled"
+                return "unchanged"
+            if self._settings.get("hhd_rgb_restore") is not True:
+                self._settings["hhd_rgb_restore"] = True
+                self._store.save(self._settings)
+            confirmed = await self._run_hhd_call(lambda: self._hhd_rgb.set_rgb(False))
+            if confirmed is True:
+                self._hhd_rgb_status = "disabled"
+                decky.logger.info("Colores: HHD RGB disabled and confirmed for Apex takeover")
+                return "changed"
+            if getattr(self, "_hhd_rgb_status", None) != "disable_failed":
+                decky.logger.warning(
+                    "Colores: HHD RGB disable was not confirmed; restore marker retained"
+                )
+            self._hhd_rgb_status = "disable_failed"
+            return "failed"
+
+    async def _restore_hhd_rgb(self) -> bool:
+        if not self._uses_hhd_rgb_takeover():
+            return True
+        async with self._hhd_operation_lock():
+            if self._settings.get("hhd_rgb_restore") is not True:
+                return True
+            confirmed = await self._run_hhd_call(lambda: self._hhd_rgb.set_rgb(True))
+            if confirmed is True:
+                self._settings["hhd_rgb_restore"] = None
+                self._store.save(self._settings)
+                self._hhd_rgb_status = "restored"
+                decky.logger.info("Colores: HHD RGB ownership restored and confirmed")
+                return True
+            decky.logger.warning("Colores: HHD RGB restore not confirmed; retry marker retained")
+            return False
 
     async def set_battery_breathe(self, on: bool) -> None:
         self._init()
@@ -490,6 +581,12 @@ class Plugin:
 
     async def reconnect(self) -> bool:
         self._init()
+        if getattr(self, "_stopping", False):
+            return False
+        if self._settings.get("force_control"):
+            claim = await self._claim_hhd_rgb()
+            if claim == "stopping" or getattr(self, "_stopping", False):
+                return False
         self._reprobe_device()
         ok = self._controller.reconnect()
         self._apply()
@@ -731,11 +828,20 @@ class Plugin:
 
     async def _main(self):
         self._init()
+        if self._settings.get("force_control"):
+            await self._claim_hhd_rgb()
+            self._controller.invalidate()
+        else:
+            await self._restore_hhd_rgb()
         decky.logger.info(
-            "Colores v%s on %s (euid=%s color=%s zones=%s ambilight=%s available=%s ledPath=%s lastError=%s)",
+            "Colores v%s on %s (product=%s board=%s euid=%s driver=%s route=%s color=%s zones=%s ambilight=%s available=%s ledPath=%s lastError=%s)",
             read_version(),
             self._device["name"],
+            self._device.get("product"),
+            self._device.get("board"),
             os.geteuid(),
+            type(self._controller).__name__,
+            getattr(self._controller, "route", None),
             self._capabilities["color"],
             self._capabilities["zones"],
             self._capabilities["ambilight"],
@@ -776,32 +882,38 @@ class Plugin:
             decky.logger.warning("Colores: charger watch failed: %s", error)
 
     async def _force_control_watch(self) -> None:
-        # Another RGB tool (e.g. HHD) keeps reapplying its own colors on its events, so
-        # a one-shot reclaim doesn't hold. Re-assert our state on a coarse tick to win it
-        # back within a couple seconds, even with the menu closed. This is a blind
-        # re-write (no read-back, no ownership check). It is a GENTLE re-assert: it does
-        # NOT invalidate()/re-init, so apply_zones takes its fast path (per-zone color
-        # only, no Aura init handshake or APPLY latch) — re-writing the same color that
-        # way is visually seamless, where a full re-init every tick makes the LEDs blink.
-        # The strong, latched reclaim (invalidate) runs on real reclaim moments instead:
-        # toggling the switch on, panel-open (reconnect), and resume. Skipped while a
-        # render loop (effect/ambilight) is active: that already rewrites ~30fps, and
-        # re-applying would restart it at frame 0. Only created on conflicting devices.
         try:
             while True:
                 await asyncio.sleep(FORCE_CONTROL_INTERVAL)
-                if self._settings.get("force_control") and not self._wants_render_loop():
+                if not self._settings.get("force_control"):
+                    continue
+                if self._uses_hhd_rgb_takeover():
+                    claim = await self._claim_hhd_rgb()
+                    if claim == "changed":
+                        self._controller.invalidate()
+                if not self._wants_render_loop():
                     self._apply()
         except asyncio.CancelledError:
             raise
         except Exception as error:  # never let the background task break plugin load
             decky.logger.warning("Colores: force-control watch failed: %s", error)
 
-    async def _unload(self):
+    async def _stop_background_tasks(self):
+        async with self._hhd_operation_lock():
+            self._stopping = True
+        tasks = []
         for attr in ("_reassert_task", "_charger_task", "_force_control_task", "_startup_task"):
             task = getattr(self, attr, None)
             if task:
                 task.cancel()
+                tasks.append(task)
+        if tasks:
+            await asyncio.gather(*tasks, return_exceptions=True)
+
+    async def _unload(self):
+        await self._stop_background_tasks()
+        if getattr(self, "_ready", False):
+            await self._restore_hhd_rgb()
         if getattr(self, "_ambilight", None):
             self._ambilight.stop()
         if getattr(self, "_engine", None):
@@ -809,4 +921,7 @@ class Plugin:
         decky.logger.info("Colores unloaded")
 
     async def _uninstall(self):
+        await self._stop_background_tasks()
+        if getattr(self, "_ready", False):
+            await self._restore_hhd_rgb()
         decky.logger.info("Colores uninstalled")

--- a/py_modules/device.py
+++ b/py_modules/device.py
@@ -1,7 +1,7 @@
 import os
 
 from device_profiles import resolve_profile
-from led_device import SysfsRgbDevice, NullDevice, ValveLedsDevice, discover_valve_leds
+from led_device import ApexRgbDevice, SysfsRgbDevice, NullDevice, ValveLedsDevice, discover_valve_leds
 from hid_adapters import HID_AVAILABLE, HID_DRIVERS, build_hid_device
 from power_led import PowerLedController
 from power_supply import battery_present
@@ -174,6 +174,7 @@ def build_capabilities(profile, has_led, zones, max_brightness, ambilight, power
         "clockMode": active["color"],
         "audioMode": active["color"],
         "conflictsWithSystemRgb": bool(profile.get("conflicts_with_system_rgb", False)),
+        "hhdRgbTakeover": bool(profile.get("hhd_rgb_takeover", False)),
         "persistentStartup": bool(profile.get("persistent_startup", False)),
         "maxRenderFps": int(profile.get("max_render_fps", 30)),
         "layoutKind": profile.get("layout_kind", "rings"),
@@ -279,6 +280,14 @@ def build_device(sysfs_root="/", ambilight=False):
             color_correction=profile.get("color_correction", [1.0, 1.0, 1.0]),
             latch=profile.get("latch"),
         )
+        if profile.get("prefer_hid") and HID_AVAILABLE:
+            fallback = profile.get("fallback") or {}
+            hid_device = build_hid_device(fallback.get("driver"))
+            if hid_device is not None:
+                correction = fallback.get("color_correction")
+                if correction and hasattr(hid_device, "set_color_correction"):
+                    hid_device.set_color_correction(correction)
+                device = ApexRgbDevice(hid_device, device)
         has_led = True
     else:
         fallback = profile.get("fallback")
@@ -299,6 +308,8 @@ def build_device(sysfs_root="/", ambilight=False):
         profile["experimental"] = _all_experimental(profile)
 
     capabilities = build_capabilities(profile, has_led, zones, max_brightness, ambilight, power_led, battery, temperature)
+    if isinstance(device, ApexRgbDevice):
+        capabilities["reconnectable"] = True
     return {
         "info": info,
         "capabilities": capabilities,

--- a/py_modules/device_profiles.py
+++ b/py_modules/device_profiles.py
@@ -79,6 +79,12 @@ OXP_HID = {
     "experimental": [],
 }
 
+OXP_APEX_HID = {
+    **OXP_HID,
+    "driver": "hid_oxp_apex_v2",
+    "hhd_rgb_takeover": True,
+}
+
 OXP_SYSFS = {
     "driver": "sysfs",
     "color_order": "rgb",
@@ -87,6 +93,12 @@ OXP_SYSFS = {
     "supported_effects": ["breathing", "rainbow", "wave", "cycle"],
     "conflicts_with_system_rgb": True,
     "experimental": [],
+}
+
+OXP_APEX = {
+    **OXP_SYSFS,
+    "prefer_hid": True,
+    "hhd_rgb_takeover": True,
 }
 
 GENERIC = {
@@ -99,6 +111,7 @@ GENERIC = {
 
 ASUS_SYSFS["fallback"] = ASUS_ALLY_HID
 OXP_SYSFS["fallback"] = OXP_HID
+OXP_APEX["fallback"] = OXP_APEX_HID
 
 
 def _copy_bits(bits):
@@ -139,7 +152,7 @@ PROFILES = [
     ("product_contains", "Claw A1M", _profile(MSI_HID, "MSI Claw")),
     ("board", "Fremont", _profile(VALVE_LEDS, "Steam Machine")),
     ("product", "F7F", _profile(VALVE_LEDS, "Steam Machine")),
-    ("product", "ONEXPLAYER APEX", _profile(OXP_SYSFS, "OneXPlayer OneXFly Apex")),
+    ("product", "ONEXPLAYER APEX", _profile(OXP_APEX, "OneXPlayer OneXFly Apex")),
     ("product", "ONEXPLAYER F1Pro", _profile(OXP_SYSFS, "OneXPlayer OneXFly F1 Pro")),
     ("product_contains", "ONEXPLAYER", _profile(OXP_SYSFS, "")),
 ]

--- a/py_modules/hhd_rgb_control.py
+++ b/py_modules/hhd_rgb_control.py
@@ -1,0 +1,87 @@
+from __future__ import annotations
+
+import json
+import logging
+import urllib.error
+import urllib.request
+
+logger = logging.getLogger(__name__)
+
+
+class RejectRedirects(urllib.request.HTTPRedirectHandler):
+    def redirect_request(self, request, fp, code, msg, headers, newurl):
+        url = request.full_url if hasattr(request, "full_url") else ""
+        raise urllib.error.HTTPError(url, code, msg, headers, fp)
+
+
+class HhdRgbControl:
+    def __init__(
+        self,
+        token_path: str = "/etc/hhd/.token",
+        base_url: str = "http://127.0.0.1:5335/api/v1",
+        timeout: float = 8.0,
+        open_request=None,
+    ):
+        self._token_path = token_path
+        self._base_url = base_url.rstrip("/")
+        self._timeout = timeout
+        self._open_request = open_request or urllib.request.build_opener(
+            urllib.request.ProxyHandler({}),
+            RejectRedirects(),
+        ).open
+        self._last_failure = None
+
+    def read_rgb(self) -> bool | None:
+        state = self._request("GET")
+        return self._rgb_from_state(state)
+
+    def set_rgb(self, enabled: bool) -> bool | None:
+        state = self._request(
+            "POST",
+            {"hhd": {"settings": {"rgb": bool(enabled)}}},
+        )
+        echoed = self._rgb_from_state(state)
+        if echoed is None:
+            return None
+        return echoed is bool(enabled)
+
+    def _request(self, method: str, payload: dict | None = None) -> dict | None:
+        try:
+            with open(self._token_path, encoding="utf-8") as handle:
+                token = handle.read().strip()
+            if not token:
+                self._warn_once("empty_token", "HHD RGB control unavailable: empty API token")
+                return None
+            body = None if payload is None else json.dumps(payload).encode("utf-8")
+            request = urllib.request.Request(
+                f"{self._base_url}/state",
+                data=body,
+                method=method,
+                headers={
+                    "Authorization": f"Bearer {token}",
+                    "Content-Type": "application/json",
+                },
+            )
+            with self._open_request(request, timeout=self._timeout) as response:
+                decoded = json.loads(response.read().decode("utf-8"))
+            self._last_failure = None
+            return decoded if isinstance(decoded, dict) else None
+        except (OSError, ValueError, urllib.error.URLError) as exc:
+            self._warn_once(
+                type(exc).__name__,
+                "HHD RGB control request failed: %s",
+                type(exc).__name__,
+            )
+            return None
+
+    def _warn_once(self, key, message, *args):
+        if self._last_failure != key:
+            logger.warning(message, *args)
+        self._last_failure = key
+
+    @staticmethod
+    def _rgb_from_state(state: dict | None) -> bool | None:
+        if not isinstance(state, dict):
+            return None
+        value = state.get("hhd", {}).get("settings", {}).get("rgb")
+        return value if isinstance(value, bool) else None

--- a/py_modules/hhd_rgb_control.py
+++ b/py_modules/hhd_rgb_control.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 import json
 import logging
 import urllib.error
@@ -41,9 +39,7 @@ class HhdRgbControl:
             {"hhd": {"settings": {"rgb": bool(enabled)}}},
         )
         echoed = self._rgb_from_state(state)
-        if echoed is None:
-            return None
-        return echoed is bool(enabled)
+        return None if echoed is None else echoed == bool(enabled)
 
     def _request(self, method: str, payload: dict | None = None) -> dict | None:
         try:

--- a/py_modules/hid_adapters.py
+++ b/py_modules/hid_adapters.py
@@ -1,8 +1,11 @@
+import logging
 import os
 import sys
 from time import monotonic, sleep
 
 from led_device import LedDevice, _clamp8, _clamp_pct, apply_gain
+
+logger = logging.getLogger(__name__)
 
 _HUESYNC_DIR = os.path.join(os.path.dirname(__file__), "huesync")
 if _HUESYNC_DIR not in sys.path:
@@ -94,6 +97,13 @@ OXP_IDS = {
     "usage": [0x0001],
 }
 
+OXP_APEX_IDS = {
+    "vid": [0x1A2C],
+    "pid": [0xB001],
+    "usage_page": [0xFF01],
+    "usage": [0x0001],
+}
+
 
 def _effect_mode(effect_id):
     if not HID_AVAILABLE:
@@ -126,6 +136,7 @@ class _BaseHidDevice(LedDevice):
 
     def __init__(self, transport):
         self._transport = transport
+        self.last_error = None
 
     def set_color_correction(self, gains):
         self._color_correction = tuple(gains)
@@ -141,6 +152,9 @@ class _BaseHidDevice(LedDevice):
         device = self._transport.hid_device
         if device is None:
             if not self._transport.is_ready():
+                self.last_error = getattr(
+                    self._transport, "last_error", "HID interface unavailable"
+                )
                 return False
             device = self._transport.hid_device
         delay = getattr(self._transport, "write_delay", 0)
@@ -152,12 +166,22 @@ class _BaseHidDevice(LedDevice):
                     sleep(remaining)
             try:
                 written = device.write(rep)
+            except Exception as exc:
+                self.last_error = f"write failed: {type(exc).__name__}"
+                self._after_write(rep, None)
+                raise
             finally:
                 if delay:
                     self._transport._last_write_at = monotonic()
+            self._after_write(rep, written)
             if written != len(rep):
+                self.last_error = f"short write: {written}/{len(rep)}"
                 return False
+            self.last_error = None
         return True
+
+    def _after_write(self, _report, _written):
+        return None
 
     @property
     def available(self):
@@ -462,6 +486,8 @@ class AsusAllyHidDevice(_BaseHidDevice):
 
 
 class OxpHidDevice(_BaseHidDevice):
+    route = "hid"
+
     @classmethod
     def create(cls):
         if not HID_AVAILABLE:
@@ -505,6 +531,45 @@ class OxpHidDevice(_BaseHidDevice):
         colors = list(zone_colors) or [(0, 0, 0)]
         return self.apply_solid(colors[0], brightness, power)
 
+    def reconnect(self):
+        ok = super().reconnect()
+        if ok:
+            logger.info("OneXPlayer HID reconnect succeeded")
+        else:
+            logger.warning("OneXPlayer HID reconnect failed: %s", self.last_error)
+        return ok
+
+    def _after_write(self, report, written):
+        command = report[2] if len(report) > 2 else None
+        if command == 0xFD:
+            kind = "enable" if len(report) > 3 and report[3] else "disable"
+        elif command == 0xFE:
+            kind = "color"
+        else:
+            kind = "unknown"
+        message = "OneXPlayer HID packet kind=%s length=%s result=%s"
+        if written != len(report):
+            logger.warning(message + " short write", kind, len(report), written)
+        elif kind != "color" or self._transport.prev_mode != "solid":
+            logger.info(message, kind, len(report), written)
+        else:
+            logger.debug(message, kind, len(report), written)
+
+
+class ApexOxpHidDevice(OxpHidDevice):
+    @classmethod
+    def create(cls):
+        if not HID_AVAILABLE:
+            return None
+        return cls(
+            OxpHidTransport(
+                OXP_APEX_IDS["vid"],
+                OXP_APEX_IDS["pid"],
+                OXP_APEX_IDS["usage_page"],
+                OXP_APEX_IDS["usage"],
+            )
+        )
+
 
 HID_DRIVERS = {
     "hid_msi": MsiHidDevice,
@@ -512,6 +577,7 @@ HID_DRIVERS = {
     "hid_legion_go_s": LegionGoSHidDevice,
     "hid_asus_ally": AsusAllyHidDevice,
     "hid_oxp_v2": OxpHidDevice,
+    "hid_oxp_apex_v2": ApexOxpHidDevice,
 }
 
 

--- a/py_modules/led_device.py
+++ b/py_modules/led_device.py
@@ -67,7 +67,6 @@ class ApexRgbDevice(LedDevice):
     def __init__(self, hid_device, sysfs_device):
         self._devices = {"hid": hid_device, "sysfs": sysfs_device}
         self.route = "hid" if self._is_available(hid_device) else "sysfs"
-        self._active = self._devices[self.route]
         self.last_error = None
         logger.info("Apex RGB route selected: %s", self.route)
 
@@ -80,14 +79,15 @@ class ApexRgbDevice(LedDevice):
 
     @property
     def available(self):
-        return self._is_available(self._active)
+        return self._is_available(self._devices[self.route])
 
     @property
     def led_path(self):
-        return getattr(self._active, "led_path", None)
+        return getattr(self._devices[self.route], "led_path", None)
 
     def supports_per_zone(self):
-        return bool(self._active and self._active.supports_per_zone())
+        device = self._devices[self.route]
+        return bool(device and device.supports_per_zone())
 
     def supports_hardware_effects(self):
         return False
@@ -109,7 +109,7 @@ class ApexRgbDevice(LedDevice):
     def apply_zones(self, zone_colors, brightness, power):
         colors = list(zone_colors)
         primary = self.route
-        if self._apply(self._active, colors, brightness, power):
+        if self._apply(self._devices[primary], colors, brightness, power):
             self.last_error = None
             return True
 
@@ -122,7 +122,7 @@ class ApexRgbDevice(LedDevice):
             fallback,
         )
         if self._activate(fallback, reconnect=fallback == "hid"):
-            if self._apply(self._active, colors, brightness, power):
+            if self._apply(self._devices[fallback], colors, brightness, power):
                 self.last_error = None
                 logger.info("Apex RGB route switched to %s", fallback)
                 return True
@@ -147,7 +147,6 @@ class ApexRgbDevice(LedDevice):
             device.last_error = f"{type(exc).__name__}"
             return False
         self.route = route
-        self._active = device
         return True
 
     def _route_error(self, route, fallback):

--- a/py_modules/led_device.py
+++ b/py_modules/led_device.py
@@ -1,5 +1,9 @@
+import logging
 import os
 import re
+
+
+logger = logging.getLogger(__name__)
 
 
 def _clamp8(value):
@@ -57,6 +61,106 @@ class LedDevice:
 
 class NullDevice(LedDevice):
     pass
+
+
+class ApexRgbDevice(LedDevice):
+    def __init__(self, hid_device, sysfs_device):
+        self._devices = {"hid": hid_device, "sysfs": sysfs_device}
+        self.route = "hid" if self._is_available(hid_device) else "sysfs"
+        self._active = self._devices[self.route]
+        self.last_error = None
+        logger.info("Apex RGB route selected: %s", self.route)
+
+    @staticmethod
+    def _is_available(device):
+        try:
+            return bool(device and device.available)
+        except Exception:
+            return False
+
+    @property
+    def available(self):
+        return self._is_available(self._active)
+
+    @property
+    def led_path(self):
+        return getattr(self._active, "led_path", None)
+
+    def supports_per_zone(self):
+        return bool(self._active and self._active.supports_per_zone())
+
+    def supports_hardware_effects(self):
+        return False
+
+    def invalidate(self):
+        for device in self._devices.values():
+            if device:
+                device.invalidate()
+
+    def reconnect(self):
+        if self._activate("hid", reconnect=True):
+            self.last_error = None
+            logger.info("Apex RGB HID route recovered")
+            return True
+        if self._activate("sysfs", reconnect=True):
+            return True
+        return False
+
+    def apply_zones(self, zone_colors, brightness, power):
+        colors = list(zone_colors)
+        primary = self.route
+        if self._apply(self._active, colors, brightness, power):
+            self.last_error = None
+            return True
+
+        primary_error = self._route_error(primary, "write failed")
+        fallback = "sysfs" if primary == "hid" else "hid"
+        logger.warning(
+            "Apex RGB %s route failed (%s), switching to %s",
+            primary,
+            primary_error,
+            fallback,
+        )
+        if self._activate(fallback, reconnect=fallback == "hid"):
+            if self._apply(self._active, colors, brightness, power):
+                self.last_error = None
+                logger.info("Apex RGB route switched to %s", fallback)
+                return True
+
+        fallback_error = self._route_error(fallback, "unavailable")
+        self.last_error = f"{primary}: {primary_error}; {fallback}: {fallback_error}"
+        logger.error("Apex RGB routes failed: %s", self.last_error)
+        return False
+
+    def apply_solid(self, color, brightness, power):
+        return self.apply_zones([tuple(color)], brightness, power)
+
+    def _activate(self, route, reconnect=False):
+        device = self._devices.get(route)
+        if not device:
+            return False
+        try:
+            if reconnect and not device.reconnect():
+                return False
+            device.invalidate()
+        except Exception as exc:
+            device.last_error = f"{type(exc).__name__}"
+            return False
+        self.route = route
+        self._active = device
+        return True
+
+    def _route_error(self, route, fallback):
+        return getattr(self._devices.get(route), "last_error", None) or fallback
+
+    @staticmethod
+    def _apply(device, colors, brightness, power):
+        try:
+            return bool(device and device.apply_zones(colors, brightness, power))
+        except Exception as exc:
+            if device:
+                device.last_error = type(exc).__name__
+            return False
 
 
 class SysfsRgbDevice(LedDevice):

--- a/py_modules/oxp_hid.py
+++ b/py_modules/oxp_hid.py
@@ -1,6 +1,11 @@
 # OneXPlayer HID V2 ("XFLY") RGB protocol. Wire format documented by HHD and HueSync
 # (BSD-3); original implementation, no third-party code copied.
 
+import logging
+
+
+logger = logging.getLogger(__name__)
+
 CMD_ID = 0x07
 
 LEVEL_HIGH = 0x04
@@ -36,18 +41,57 @@ class OxpHidTransport:
         self.prev_mode = None
         self.write_delay = WRITE_DELAY
         self._last_write_at = None
+        self.last_error = None
+        self._reported_missing = False
 
     def is_ready(self):
         if self.hid_device:
             return True
         import lib_hid as hid
 
-        for device in hid.enumerate():
+        try:
+            devices = hid.enumerate()
+        except Exception as exc:
+            self.last_error = f"enumeration failed: {type(exc).__name__}"
+            logger.warning("OneXPlayer HID enumeration failed: %s", type(exc).__name__)
+            return False
+        for device in devices:
             if device["vendor_id"] not in self._vid:
                 continue
             if self._pid and device["product_id"] not in self._pid:
                 continue
             if device["usage_page"] in self._usage_page and device["usage"] in self._usage:
-                self.hid_device = hid.Device(path=device["path"])
+                try:
+                    self.hid_device = hid.Device(path=device["path"])
+                except Exception as exc:
+                    self.last_error = f"open failed: {type(exc).__name__}"
+                    logger.warning(
+                        "OneXPlayer HID open failed vid=%04x pid=%04x usage_page=%04x usage=%04x interface=%s error=%s",
+                        device["vendor_id"],
+                        device["product_id"],
+                        device["usage_page"],
+                        device["usage"],
+                        device.get("interface_number"),
+                        type(exc).__name__,
+                    )
+                    return False
+                self.last_error = None
+                self._reported_missing = False
+                logger.info(
+                    "OneXPlayer HID opened vid=%04x pid=%04x usage_page=%04x usage=%04x interface=%s",
+                    device["vendor_id"],
+                    device["product_id"],
+                    device["usage_page"],
+                    device["usage"],
+                    device.get("interface_number"),
+                )
                 return True
+        self.last_error = "matching HID interface not found"
+        if not self._reported_missing:
+            pid = ",".join(f"{value:04x}" for value in self._pid) or "*"
+            logger.warning(
+                "OneXPlayer HID interface unavailable vid=1a2c pid=%s usage_page=ff01 usage=0001",
+                pid,
+            )
+            self._reported_missing = True
         return False

--- a/py_modules/report/collector.py
+++ b/py_modules/report/collector.py
@@ -243,7 +243,7 @@ def sysfs_snapshot(
     return redact_obj(snap, home=home, hostname=hostname)
 
 
-def capabilities_from(state: dict, *, driver=None, led_path=None, last_error=None) -> dict:
+def capabilities_from(state: dict, *, driver=None, route=None, led_path=None, last_error=None) -> dict:
     state = state or {}
     caps = state.get("capabilities") or {}
     dev = state.get("device") or {}
@@ -253,6 +253,7 @@ def capabilities_from(state: dict, *, driver=None, led_path=None, last_error=Non
         "board": dev.get("board"),
         "product": dev.get("product"),
         "driver": caps.get("driver") or driver,
+        "route": caps.get("rgbRoute") or route,
         "led_path": caps.get("ledPath") or led_path,
         "last_error": last_error,
         "color": bool(caps.get("color")),

--- a/tests/test_device.py
+++ b/tests/test_device.py
@@ -276,6 +276,7 @@ def test_build_device_oxp_uses_latch_device(tmp_path):
     assert caps["maxRenderFps"] == 10
     assert caps["states"]["color"] == "supported"
     assert caps["conflictsWithSystemRgb"] is True
+    assert caps["hhdRgbTakeover"] is True
     assert ctx["device"].apply_zones([(255, 0, 0)], 100, True) is True
     led = os.path.join(root, "sys/class/leds/oxp:rgb:joystick_rings")
     assert open(os.path.join(led, "enabled")).read() == "true"

--- a/tests/test_device_profiles.py
+++ b/tests/test_device_profiles.py
@@ -126,6 +126,8 @@ def test_onexplayer_apex_profile():
     profile = resolve_profile("ONEXPLAYER APEX", "ONEXPLAYER APEX")
     assert profile["name"] == "OneXPlayer OneXFly Apex"
     assert profile["driver"] == "sysfs"
+    assert profile["prefer_hid"] is True
+    assert profile["hhd_rgb_takeover"] is True
     assert profile["latch"] == [["enabled", "true"], ["effect", "monocolor"]]
     assert profile["max_render_fps"] == 10
     assert profile["experimental"] == []
@@ -135,6 +137,8 @@ def test_onexplayer_f1pro_profile():
     profile = resolve_profile("ONEXPLAYER F1Pro", "ONEXPLAYER F1Pro")
     assert profile["name"] == "OneXPlayer OneXFly F1 Pro"
     assert profile["driver"] == "sysfs"
+    assert profile.get("prefer_hid") is None
+    assert profile.get("hhd_rgb_takeover") is None
     assert profile["latch"] == [["enabled", "true"], ["effect", "monocolor"]]
 
 
@@ -148,6 +152,9 @@ def test_onexplayer_profile_has_hid_fallback():
     profile = resolve_profile("ONEXPLAYER APEX", "ONEXPLAYER APEX")
     fallback = profile.get("fallback")
     assert fallback is not None
-    assert fallback["driver"] == "hid_oxp_v2"
+    assert fallback["driver"] == "hid_oxp_apex_v2"
     assert fallback["max_render_fps"] == 20
     assert fallback["conflicts_with_system_rgb"] is True
+
+    family = resolve_profile("ONEXPLAYER X1 mini", "ONEXPLAYER X1 mini")
+    assert family["fallback"]["driver"] == "hid_oxp_v2"

--- a/tests/test_hhd_rgb_control.py
+++ b/tests/test_hhd_rgb_control.py
@@ -8,7 +8,7 @@ from hhd_rgb_control import HhdRgbControl, RejectRedirects
 
 class Response:
     def __init__(self, body):
-        self._body = json.dumps(body).encode()
+        self._body = body if isinstance(body, bytes) else json.dumps(body).encode()
 
     def __enter__(self):
         return self
@@ -20,18 +20,35 @@ class Response:
         return self._body
 
 
-def test_read_rgb_returns_current_boolean(tmp_path, monkeypatch):
+@pytest.fixture
+def control_factory(tmp_path):
     token = tmp_path / "hhd.token"
     token.write_text("secret\n")
-    seen = {}
 
-    def urlopen(request, timeout):
-        seen["request"] = request
-        seen["timeout"] = timeout
-        return Response({"hhd": {"settings": {"rgb": True}}})
+    def make(body, **options):
+        seen = {}
 
-    monkeypatch.setattr("urllib.request.urlopen", urlopen)
-    control = HhdRgbControl(token_path=str(token), timeout=1.5, open_request=urlopen)
+        def open_request(request, timeout):
+            seen.update(request=request, timeout=timeout)
+            if isinstance(body, BaseException):
+                raise body
+            return Response(body)
+
+        control = HhdRgbControl(
+            token_path=str(token),
+            open_request=open_request,
+            **options,
+        )
+        return control, seen
+
+    return make
+
+
+def test_read_rgb_returns_current_boolean(control_factory):
+    control, seen = control_factory(
+        {"hhd": {"settings": {"rgb": True}}},
+        timeout=1.5,
+    )
 
     assert control.read_rgb() is True
     assert seen["request"].full_url == "http://127.0.0.1:5335/api/v1/state"
@@ -40,54 +57,31 @@ def test_read_rgb_returns_current_boolean(tmp_path, monkeypatch):
     assert seen["timeout"] == 1.5
 
 
-def test_set_rgb_posts_partial_state_and_confirms_echo(tmp_path, monkeypatch):
-    token = tmp_path / "hhd.token"
-    token.write_text("secret")
-    seen = {}
-
-    def urlopen(request, timeout):
-        seen["body"] = json.loads(request.data)
-        seen["method"] = request.get_method()
-        return Response({"hhd": {"settings": {"rgb": False}}})
-
-    monkeypatch.setattr("urllib.request.urlopen", urlopen)
-    control = HhdRgbControl(token_path=str(token), open_request=urlopen)
+def test_set_rgb_posts_partial_state_and_confirms_echo(control_factory):
+    control, seen = control_factory({"hhd": {"settings": {"rgb": False}}})
 
     assert control.set_rgb(False) is True
-    assert seen == {
+    assert {
+        "body": json.loads(seen["request"].data),
+        "method": seen["request"].get_method(),
+    } == {
         "body": {"hhd": {"settings": {"rgb": False}}},
         "method": "POST",
     }
 
 
-def test_set_rgb_rejects_mismatched_echo(tmp_path, monkeypatch):
-    token = tmp_path / "hhd.token"
-    token.write_text("secret")
-    monkeypatch.setattr(
-        "urllib.request.urlopen",
-        lambda *_args, **_kwargs: Response({"hhd": {"settings": {"rgb": True}}}),
-    )
+def test_set_rgb_rejects_mismatched_echo(control_factory):
+    control, _ = control_factory({"hhd": {"settings": {"rgb": True}}})
 
-    assert HhdRgbControl(
-        token_path=str(token), open_request=urllib.request.urlopen
-    ).set_rgb(False) is False
+    assert control.set_rgb(False) is False
 
 
-def test_unavailable_api_returns_none_without_exposing_token(tmp_path, monkeypatch, caplog):
-    token = tmp_path / "hhd.token"
-    token.write_text("do-not-log-this")
+def test_unavailable_api_returns_none_without_exposing_token(control_factory, caplog):
+    control, _ = control_factory(urllib.error.URLError("connection refused"))
 
-    def unavailable(*_args, **_kwargs):
-        raise urllib.error.URLError("connection refused")
-
-    monkeypatch.setattr("urllib.request.urlopen", unavailable)
-
-    control = HhdRgbControl(
-        token_path=str(token), open_request=urllib.request.urlopen
-    )
     assert control.read_rgb() is None
     assert control.read_rgb() is None
-    assert "do-not-log-this" not in caplog.text
+    assert "secret" not in caplog.text
     assert caplog.text.count("HHD RGB control request failed") == 1
 
 
@@ -97,22 +91,10 @@ def test_missing_token_returns_none(monkeypatch):
     assert HhdRgbControl(token_path="/missing").read_rgb() is None
 
 
-def test_invalid_response_returns_none(tmp_path, monkeypatch):
-    token = tmp_path / "hhd.token"
-    token.write_text("secret")
+def test_invalid_response_returns_none(control_factory):
+    control, _ = control_factory(b"not-json")
 
-    class InvalidResponse(Response):
-        def read(self):
-            return b"not-json"
-
-    monkeypatch.setattr(
-        "urllib.request.urlopen",
-        lambda *_args, **_kwargs: InvalidResponse({}),
-    )
-
-    assert HhdRgbControl(
-        token_path=str(token), open_request=urllib.request.urlopen
-    ).read_rgb() is None
+    assert control.read_rgb() is None
 
 
 def test_redirects_are_rejected_before_authorization_can_leave_localhost():

--- a/tests/test_hhd_rgb_control.py
+++ b/tests/test_hhd_rgb_control.py
@@ -1,0 +1,148 @@
+import json
+import urllib.error
+
+import pytest
+
+from hhd_rgb_control import HhdRgbControl, RejectRedirects
+
+
+class Response:
+    def __init__(self, body):
+        self._body = json.dumps(body).encode()
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *_args):
+        return False
+
+    def read(self):
+        return self._body
+
+
+def test_read_rgb_returns_current_boolean(tmp_path, monkeypatch):
+    token = tmp_path / "hhd.token"
+    token.write_text("secret\n")
+    seen = {}
+
+    def urlopen(request, timeout):
+        seen["request"] = request
+        seen["timeout"] = timeout
+        return Response({"hhd": {"settings": {"rgb": True}}})
+
+    monkeypatch.setattr("urllib.request.urlopen", urlopen)
+    control = HhdRgbControl(token_path=str(token), timeout=1.5, open_request=urlopen)
+
+    assert control.read_rgb() is True
+    assert seen["request"].full_url == "http://127.0.0.1:5335/api/v1/state"
+    assert seen["request"].get_method() == "GET"
+    assert seen["request"].get_header("Authorization") == "Bearer secret"
+    assert seen["timeout"] == 1.5
+
+
+def test_set_rgb_posts_partial_state_and_confirms_echo(tmp_path, monkeypatch):
+    token = tmp_path / "hhd.token"
+    token.write_text("secret")
+    seen = {}
+
+    def urlopen(request, timeout):
+        seen["body"] = json.loads(request.data)
+        seen["method"] = request.get_method()
+        return Response({"hhd": {"settings": {"rgb": False}}})
+
+    monkeypatch.setattr("urllib.request.urlopen", urlopen)
+    control = HhdRgbControl(token_path=str(token), open_request=urlopen)
+
+    assert control.set_rgb(False) is True
+    assert seen == {
+        "body": {"hhd": {"settings": {"rgb": False}}},
+        "method": "POST",
+    }
+
+
+def test_set_rgb_rejects_mismatched_echo(tmp_path, monkeypatch):
+    token = tmp_path / "hhd.token"
+    token.write_text("secret")
+    monkeypatch.setattr(
+        "urllib.request.urlopen",
+        lambda *_args, **_kwargs: Response({"hhd": {"settings": {"rgb": True}}}),
+    )
+
+    assert HhdRgbControl(
+        token_path=str(token), open_request=urllib.request.urlopen
+    ).set_rgb(False) is False
+
+
+def test_unavailable_api_returns_none_without_exposing_token(tmp_path, monkeypatch, caplog):
+    token = tmp_path / "hhd.token"
+    token.write_text("do-not-log-this")
+
+    def unavailable(*_args, **_kwargs):
+        raise urllib.error.URLError("connection refused")
+
+    monkeypatch.setattr("urllib.request.urlopen", unavailable)
+
+    control = HhdRgbControl(
+        token_path=str(token), open_request=urllib.request.urlopen
+    )
+    assert control.read_rgb() is None
+    assert control.read_rgb() is None
+    assert "do-not-log-this" not in caplog.text
+    assert caplog.text.count("HHD RGB control request failed") == 1
+
+
+def test_missing_token_returns_none(monkeypatch):
+    monkeypatch.setattr("builtins.open", lambda *_args, **_kwargs: (_ for _ in ()).throw(OSError()))
+
+    assert HhdRgbControl(token_path="/missing").read_rgb() is None
+
+
+def test_invalid_response_returns_none(tmp_path, monkeypatch):
+    token = tmp_path / "hhd.token"
+    token.write_text("secret")
+
+    class InvalidResponse(Response):
+        def read(self):
+            return b"not-json"
+
+    monkeypatch.setattr(
+        "urllib.request.urlopen",
+        lambda *_args, **_kwargs: InvalidResponse({}),
+    )
+
+    assert HhdRgbControl(
+        token_path=str(token), open_request=urllib.request.urlopen
+    ).read_rgb() is None
+
+
+def test_redirects_are_rejected_before_authorization_can_leave_localhost():
+    handler = RejectRedirects()
+    request = object()
+
+    with pytest.raises(urllib.error.HTTPError) as error:
+        handler.redirect_request(
+            request,
+            None,
+            302,
+            "Found",
+            {},
+            "https://example.com/steal-token",
+        )
+
+    assert error.value.code == 302
+
+
+def test_default_opener_disables_environment_proxies(tmp_path, monkeypatch):
+    monkeypatch.setenv("http_proxy", "http://proxy.example:8080")
+    token = tmp_path / "hhd.token"
+    token.write_text("secret")
+
+    control = HhdRgbControl(token_path=str(token))
+    opener = control._open_request.__self__
+    proxies = [
+        handler.proxies
+        for handler in opener.handlers
+        if isinstance(handler, urllib.request.ProxyHandler)
+    ]
+
+    assert proxies == []

--- a/tests/test_hid_adapters.py
+++ b/tests/test_hid_adapters.py
@@ -819,9 +819,7 @@ def test_oxp_steady_state_keeps_protocol_delay(hid_env, monkeypatch):
     assert sleeps == pytest.approx([0.05])
 
 
-def test_oxp_short_write_reconnects_and_retries_full_transition(hid_env):
-    adapters, writes = hid_env
-    sys.modules["lib_hid"].enumerate = lambda vid=0, pid=0: [_oxp_entry()]
+def _short_write_device(writes):
     results = iter([32, 64, 64])
 
     class ShortWriteDevice:
@@ -835,8 +833,19 @@ def test_oxp_short_write_reconnects_and_retries_full_transition(hid_env):
         def close(self):
             pass
 
-    sys.modules["lib_hid"].Device = ShortWriteDevice
-    dev = adapters.OxpHidDevice.create()
+    return ShortWriteDevice
+
+
+def _oxp_with_short_write(hid_env):
+    adapters, writes = hid_env
+    sys.modules["lib_hid"].enumerate = lambda vid=0, pid=0: [_oxp_entry()]
+    sys.modules["lib_hid"].Device = _short_write_device(writes)
+    return adapters.OxpHidDevice.create(), writes
+
+
+def test_oxp_short_write_reconnects_and_retries_full_transition(hid_env):
+    dev, writes = _oxp_with_short_write(hid_env)
+
     assert dev.apply_solid((255, 0, 0), 100, True) is True
     assert [packet[:3] for packet in writes] == [
         bytes([0x07, 0xFF, 0xFD]),
@@ -846,24 +855,8 @@ def test_oxp_short_write_reconnects_and_retries_full_transition(hid_env):
 
 
 def test_oxp_short_write_logs_failure_before_recovery(hid_env, caplog):
-    adapters, writes = hid_env
-    sys.modules["lib_hid"].enumerate = lambda vid=0, pid=0: [_oxp_entry()]
-    results = iter([32, 64, 64])
-
-    class ShortWriteDevice:
-        def __init__(self, path=None):
-            self.path = path
-
-        def write(self, data):
-            writes.append(bytes(data))
-            return next(results)
-
-        def close(self):
-            pass
-
-    sys.modules["lib_hid"].Device = ShortWriteDevice
     caplog.set_level(logging.INFO)
-    dev = adapters.OxpHidDevice.create()
+    dev, _ = _oxp_with_short_write(hid_env)
 
     assert dev.apply_solid((255, 0, 0), 100, True) is True
     assert "kind=enable length=64 result=32" in caplog.text

--- a/tests/test_hid_adapters.py
+++ b/tests/test_hid_adapters.py
@@ -1,4 +1,5 @@
 import importlib
+import logging
 import sys
 import types
 
@@ -596,6 +597,102 @@ def _oxp_entry():
     }
 
 
+def test_oxp_rejects_foreign_pid_with_matching_usage(hid_env):
+    adapters, _ = hid_env
+    foreign = dict(_oxp_entry(), product_id=0xB002)
+    sys.modules["lib_hid"].enumerate = lambda vid=0, pid=0: [foreign]
+
+    assert adapters.ApexOxpHidDevice.create().available is False
+    assert adapters.OxpHidDevice.create().available is True
+
+
+def _make_oxp_root(tmp_path, product):
+    import os
+
+    root = _make_dmi_root(tmp_path, product)
+    led = os.path.join(root, "sys/class/leds", "oxp:rgb:joystick_rings")
+    os.makedirs(led)
+    for name, content in {
+        "multi_index": "red green blue",
+        "multi_max_intensity": "100 100 100",
+        "multi_intensity": "0 0 0",
+        "brightness": "0",
+        "max_brightness": "100",
+        "enabled": "false",
+        "effect": "rainbow",
+    }.items():
+        with open(os.path.join(led, name), "w") as handle:
+            handle.write(content)
+    return root
+
+
+def test_apex_prefers_direct_hid_and_keeps_sysfs_as_fallback(hid_env, tmp_path):
+    import os
+
+    adapters, writes = hid_env
+    sys.modules["lib_hid"].enumerate = lambda vid=0, pid=0: [_oxp_entry()]
+    device = _reload_device()
+    root = _make_oxp_root(tmp_path, "ONEXPLAYER APEX")
+
+    ctx = device.build_device(sysfs_root=root, ambilight=False)
+
+    assert type(ctx["device"]).__name__ == "ApexRgbDevice"
+    assert ctx["device"].route == "hid"
+    assert ctx["capabilities"]["reconnectable"] is True
+    writes.clear()
+    assert ctx["device"].apply_zones([(255, 0, 0)], 100, True) is True
+    assert [packet[:3] for packet in writes] == [
+        bytes([0x07, 0xFF, 0xFD]),
+        bytes([0x07, 0xFF, 0xFE]),
+    ]
+    led = os.path.join(root, "sys/class/leds/oxp:rgb:joystick_rings")
+    assert open(os.path.join(led, "multi_intensity")).read() == "0 0 0"
+    sys.modules.pop("device", None)
+
+
+def test_f1_pro_keeps_existing_sysfs_route(hid_env, tmp_path):
+    sys.modules["lib_hid"].enumerate = lambda vid=0, pid=0: [_oxp_entry()]
+    device = _reload_device()
+    root = _make_oxp_root(tmp_path, "ONEXPLAYER F1Pro")
+
+    ctx = device.build_device(sysfs_root=root, ambilight=False)
+
+    from led_device import SysfsRgbDevice
+
+    assert isinstance(ctx["device"], SysfsRgbDevice)
+    sys.modules.pop("device", None)
+
+
+def test_f1_pro_keeps_wildcard_hid_fallback_without_sysfs(hid_env, tmp_path):
+    adapters, _ = hid_env
+    foreign_pid = dict(_oxp_entry(), product_id=0xB002)
+    sys.modules["lib_hid"].enumerate = lambda vid=0, pid=0: [foreign_pid]
+    device = _reload_device()
+    root = _make_dmi_root(tmp_path, "ONEXPLAYER F1Pro")
+
+    ctx = device.build_device(sysfs_root=root, ambilight=False)
+
+    assert isinstance(ctx["device"], adapters.OxpHidDevice)
+    assert not isinstance(ctx["device"], adapters.ApexOxpHidDevice)
+    assert ctx["capabilities"]["color"] is True
+    sys.modules.pop("device", None)
+
+
+def test_apex_without_sysfs_keeps_exact_hid_takeover_capabilities(hid_env, tmp_path):
+    adapters, _ = hid_env
+    sys.modules["lib_hid"].enumerate = lambda vid=0, pid=0: [_oxp_entry()]
+    device = _reload_device()
+    root = _make_dmi_root(tmp_path, "ONEXPLAYER APEX")
+
+    ctx = device.build_device(sysfs_root=root, ambilight=False)
+
+    assert isinstance(ctx["device"], adapters.ApexOxpHidDevice)
+    assert ctx["device"].route == "hid"
+    assert ctx["capabilities"]["hhdRgbTakeover"] is True
+    assert ctx["capabilities"]["reconnectable"] is True
+    sys.modules.pop("device", None)
+
+
 def test_oxp_solid_enables_then_paints(hid_env):
     adapters, writes = hid_env
     sys.modules["lib_hid"].enumerate = lambda vid=0, pid=0: [_oxp_entry()]
@@ -609,6 +706,23 @@ def test_oxp_solid_enables_then_paints(hid_env):
     assert writes[0][:6] == bytes([0x07, 0xFF, 0xFD, 0x01, 0x05, 0x04])
     assert writes[1][:3] == bytes([0x07, 0xFF, 0xFE])
     assert tuple(writes[1][3:6]) == (255, 0, 0)
+
+
+def test_oxp_logs_sanitized_identity_and_claim_packets(hid_env, caplog):
+    adapters, _ = hid_env
+    sys.modules["lib_hid"].enumerate = lambda vid=0, pid=0: [_oxp_entry()]
+    caplog.set_level(logging.INFO)
+    dev = adapters.OxpHidDevice.create()
+
+    assert dev.available is True
+    assert dev.apply_solid((255, 0, 0), 100, True) is True
+    assert "vid=1a2c" in caplog.text
+    assert "pid=b001" in caplog.text
+    assert "usage_page=ff01" in caplog.text
+    assert "usage=0001" in caplog.text
+    assert "kind=enable length=64 result=64" in caplog.text
+    assert "kind=color length=64 result=64" in caplog.text
+    assert "b'oxp'" not in caplog.text
 
 
 def test_oxp_steady_state_sends_only_color(hid_env):
@@ -729,3 +843,29 @@ def test_oxp_short_write_reconnects_and_retries_full_transition(hid_env):
         bytes([0x07, 0xFF, 0xFD]),
         bytes([0x07, 0xFF, 0xFE]),
     ]
+
+
+def test_oxp_short_write_logs_failure_before_recovery(hid_env, caplog):
+    adapters, writes = hid_env
+    sys.modules["lib_hid"].enumerate = lambda vid=0, pid=0: [_oxp_entry()]
+    results = iter([32, 64, 64])
+
+    class ShortWriteDevice:
+        def __init__(self, path=None):
+            self.path = path
+
+        def write(self, data):
+            writes.append(bytes(data))
+            return next(results)
+
+        def close(self):
+            pass
+
+    sys.modules["lib_hid"].Device = ShortWriteDevice
+    caplog.set_level(logging.INFO)
+    dev = adapters.OxpHidDevice.create()
+
+    assert dev.apply_solid((255, 0, 0), 100, True) is True
+    assert "kind=enable length=64 result=32" in caplog.text
+    assert "short write" in caplog.text.lower()
+    assert "reconnect" in caplog.text.lower()

--- a/tests/test_led_device.py
+++ b/tests/test_led_device.py
@@ -1,8 +1,110 @@
 import os
 
-from py_modules.led_device import SysfsRgbDevice, ValveLedsDevice, discover_valve_leds
+from py_modules.led_device import ApexRgbDevice, SysfsRgbDevice, ValveLedsDevice, discover_valve_leds
 
 _OXP_LATCH = [["enabled", "true"], ["effect", "monocolor"]]
+
+
+class FakeLedDevice:
+    def __init__(self, results, available=True, led_path=None, error="write failed"):
+        self.results = list(results)
+        self._available = available
+        self.led_path = led_path
+        self.last_error = error
+        self.calls = []
+        self.invalidations = 0
+        self.reconnects = 0
+
+    @property
+    def available(self):
+        return self._available
+
+    def apply_zones(self, colors, brightness, power):
+        self.calls.append((list(colors), brightness, power))
+        return self.results.pop(0)
+
+    def invalidate(self):
+        self.invalidations += 1
+
+    def reconnect(self):
+        self.reconnects += 1
+        return self._available
+
+    def supports_per_zone(self):
+        return False
+
+    def supports_hardware_effects(self):
+        return False
+
+
+def test_apex_rgb_uses_hid_primary_without_dual_write():
+    hid = FakeLedDevice([True])
+    sysfs = FakeLedDevice([True], led_path="/sys/oxp")
+    device = ApexRgbDevice(hid, sysfs)
+
+    assert device.route == "hid"
+    assert device.apply_zones([(10, 20, 30)], 70, True) is True
+    assert len(hid.calls) == 1
+    assert sysfs.calls == []
+
+
+def test_apex_rgb_falls_back_to_relatched_sysfs_after_hid_failure(caplog):
+    hid = FakeLedDevice([False], error="short HID write")
+    sysfs = FakeLedDevice([True], led_path="/sys/oxp")
+    device = ApexRgbDevice(hid, sysfs)
+
+    assert device.apply_zones([(10, 20, 30)], 70, True) is True
+    assert device.route == "sysfs"
+    assert sysfs.invalidations == 1
+    assert len(sysfs.calls) == 1
+    assert "hid" in caplog.text.lower()
+    assert "sysfs" in caplog.text.lower()
+
+
+def test_apex_rgb_starts_on_sysfs_when_hid_is_unavailable():
+    hid = FakeLedDevice([], available=False)
+    sysfs = FakeLedDevice([True], led_path="/sys/oxp")
+    device = ApexRgbDevice(hid, sysfs)
+
+    assert device.route == "sysfs"
+    assert device.apply_solid((1, 2, 3), 80, True) is True
+    assert sysfs.calls == [([(1, 2, 3)], 80, True)]
+
+
+def test_apex_rgb_reconnect_recovers_hid_primary():
+    hid = FakeLedDevice([False, True])
+    sysfs = FakeLedDevice([True], led_path="/sys/oxp")
+    device = ApexRgbDevice(hid, sysfs)
+    assert device.apply_zones([(1, 2, 3)], 100, True) is True
+    assert device.route == "sysfs"
+
+    assert device.reconnect() is True
+    assert device.route == "hid"
+    assert hid.reconnects == 1
+    assert hid.invalidations == 1
+    assert device.apply_zones([(4, 5, 6)], 100, True) is True
+
+
+def test_apex_rgb_recovers_hid_immediately_when_sysfs_write_fails():
+    hid = FakeLedDevice([True], available=False)
+    sysfs = FakeLedDevice([False], led_path="/sys/oxp", error="sysfs failed")
+    device = ApexRgbDevice(hid, sysfs)
+    hid._available = True
+
+    assert device.apply_zones([(4, 5, 6)], 100, True) is True
+    assert device.route == "hid"
+    assert hid.reconnects == 1
+    assert hid.invalidations == 1
+    assert len(hid.calls) == 1
+
+
+def test_apex_rgb_reports_both_route_failures():
+    hid = FakeLedDevice([False], error="hid failed")
+    sysfs = FakeLedDevice([False], led_path="/sys/oxp", error="sysfs failed")
+    device = ApexRgbDevice(hid, sysfs)
+
+    assert device.apply_zones([(1, 2, 3)], 100, True) is False
+    assert device.last_error == "hid: hid failed; sysfs: sysfs failed"
 
 
 def _make_led(tmp_path, multi_index="rgb rgb rgb rgb"):

--- a/tests/test_main_routing.py
+++ b/tests/test_main_routing.py
@@ -141,6 +141,9 @@ def _plugin(
 ):
     p = main_module.Plugin()
     p._ready = True
+    p._stopping = False
+    p._hhd_rgb_lock = asyncio.Lock()
+    p._hhd_rgb_status = None
     p._controller = FakeController(hw, per_zone)
     p._engine = FakeEngine()
     p._ambilight = FakeAmbilight()
@@ -167,6 +170,17 @@ def _plugin(
     }
     p._hhd_rgb = FakeHhdRgb()
     return p
+
+
+def _hhd_plugin(
+    main_module, *, reads=None, writes=None, restore=None, force=False, **plugin_options
+):
+    plugin = _plugin(main_module, "solid", hhd_takeover=True, **plugin_options)
+    plugin._settings.update(force_control=force, hhd_rgb_restore=restore)
+    plugin._hhd_rgb = FakeHhdRgb(reads, writes)
+    saved = []
+    plugin._store = types.SimpleNamespace(save=lambda state: saved.append(dict(state)))
+    return plugin, saved
 
 
 @pytest.mark.parametrize(
@@ -605,10 +619,7 @@ def test_set_force_control_persists_and_applies(main_module):
 
 
 def test_apex_force_control_disables_hhd_rgb_and_saves_restore_state(main_module):
-    p = _plugin(main_module, "solid", hhd_takeover=True)
-    p._hhd_rgb = FakeHhdRgb(reads=[True], writes=[True])
-    saved = []
-    p._store = types.SimpleNamespace(save=lambda s: saved.append(dict(s)))
+    p, saved = _hhd_plugin(main_module, reads=[True], writes=[True])
 
     asyncio.run(p.set_force_control(True))
 
@@ -618,30 +629,19 @@ def test_apex_force_control_disables_hhd_rgb_and_saves_restore_state(main_module
     assert p._controller.invalidated is True
 
 
-def test_apex_force_control_restores_hhd_rgb_and_clears_marker(main_module):
-    p = _plugin(main_module, "solid", hhd_takeover=True)
-    p._settings["force_control"] = True
-    p._settings["hhd_rgb_restore"] = True
-    p._hhd_rgb = FakeHhdRgb(writes=[True])
-    saved = []
-    p._store = types.SimpleNamespace(save=lambda s: saved.append(dict(s)))
+@pytest.mark.parametrize(
+    "confirmed,expected_marker",
+    [(True, None), (False, True)],
+    ids=["confirmed-clears-marker", "failed-keeps-marker"],
+)
+def test_apex_hhd_restore_marker(main_module, confirmed, expected_marker):
+    p, saved = _hhd_plugin(main_module, writes=[confirmed], restore=True, force=True)
 
     asyncio.run(p.set_force_control(False))
 
     assert p._hhd_rgb.calls == [("set", True)]
-    assert p._settings["hhd_rgb_restore"] is None
-    assert saved[-1]["hhd_rgb_restore"] is None
-
-
-def test_apex_failed_hhd_restore_keeps_marker_for_retry(main_module):
-    p = _plugin(main_module, "solid", hhd_takeover=True)
-    p._settings["hhd_rgb_restore"] = True
-    p._hhd_rgb = FakeHhdRgb(writes=[False])
-    p._store = types.SimpleNamespace(save=lambda _s: None)
-
-    asyncio.run(p.set_force_control(False))
-
-    assert p._settings["hhd_rgb_restore"] is True
+    assert p._settings["hhd_rgb_restore"] is expected_marker
+    assert saved[-1]["hhd_rgb_restore"] is expected_marker
 
 
 def test_force_control_does_not_touch_hhd_on_other_devices(main_module):
@@ -655,10 +655,7 @@ def test_force_control_does_not_touch_hhd_on_other_devices(main_module):
 
 
 def test_unload_restores_hhd_rgb_ownership(main_module):
-    p = _plugin(main_module, "solid", hhd_takeover=True)
-    p._settings["hhd_rgb_restore"] = True
-    p._hhd_rgb = FakeHhdRgb(writes=[True])
-    p._store = types.SimpleNamespace(save=lambda _s: None)
+    p, _ = _hhd_plugin(main_module, writes=[True], restore=True)
 
     asyncio.run(p._unload())
 
@@ -708,10 +705,7 @@ def test_unload_waits_for_inflight_hhd_claim_before_restore(main_module, monkeyp
 
 
 def test_uninstall_stops_watcher_before_restoring_hhd(main_module):
-    p = _plugin(main_module, "solid", hhd_takeover=True)
-    p._settings["hhd_rgb_restore"] = True
-    p._hhd_rgb = FakeHhdRgb(writes=[True])
-    p._store = types.SimpleNamespace(save=lambda _s: None)
+    p, _ = _hhd_plugin(main_module, writes=[True], restore=True)
 
     async def drive():
         p._force_control_task = asyncio.create_task(asyncio.sleep(60))
@@ -723,9 +717,7 @@ def test_uninstall_stops_watcher_before_restoring_hhd(main_module):
 
 
 def test_force_control_cannot_reclaim_hhd_after_unload_begins(main_module):
-    p = _plugin(main_module, "solid", hhd_takeover=True)
-    p._hhd_rgb = FakeHhdRgb(reads=[True], writes=[True])
-    p._store = types.SimpleNamespace(save=lambda _s: None)
+    p, _ = _hhd_plugin(main_module, reads=[True], writes=[True])
 
     async def drive():
         await p._unload()
@@ -772,35 +764,29 @@ def test_force_control_watch_reasserts_static_mode(main_module, monkeypatch):
     assert p._controller.calls, "watch must re-apply in a static mode"
 
 
-def test_apex_force_control_watch_reclaims_hhd_and_relatches(main_module, monkeypatch):
-    monkeypatch.setattr(main_module, "FORCE_CONTROL_INTERVAL", 0.001)
-    p = _plugin(main_module, "solid", hw=False, per_zone=False, hhd_takeover=True)
-    p._settings["force_control"] = True
-    p._hhd_rgb = FakeHhdRgb(reads=[True], writes=[True])
-    p._store = types.SimpleNamespace(save=lambda _s: None)
-    p._controller.calls.clear()
-
-    _drive_watch(main_module, p)
-
-    assert ("set", False) in p._hhd_rgb.calls
-    assert p._controller.invalidated is True
-    assert p._engine.events
-
-
-def test_apex_force_control_watch_does_not_relatch_when_hhd_is_already_disabled(
-    main_module, monkeypatch
+@pytest.mark.parametrize(
+    "hhd_enabled,expected_invalidated",
+    [(True, True), (False, False)],
+    ids=["reclaim-relatches", "already-disabled"],
+)
+def test_apex_force_control_watch(
+    main_module, monkeypatch, hhd_enabled, expected_invalidated
 ):
     monkeypatch.setattr(main_module, "FORCE_CONTROL_INTERVAL", 0.001)
-    p = _plugin(main_module, "solid", hw=False, per_zone=False, hhd_takeover=True)
-    p._settings["force_control"] = True
-    p._hhd_rgb = FakeHhdRgb(reads=[False] * 30)
-    p._store = types.SimpleNamespace(save=lambda _s: None)
+    p, _ = _hhd_plugin(
+        main_module,
+        reads=[True] if hhd_enabled else [False] * 30,
+        writes=[True],
+        force=True,
+        hw=False,
+    )
     p._controller.calls.clear()
     p._engine.events.clear()
 
     _drive_watch(main_module, p)
 
-    assert p._controller.invalidated is False
+    assert (("set", False) in p._hhd_rgb.calls) is hhd_enabled
+    assert p._controller.invalidated is expected_invalidated
     assert p._engine.events
 
 

--- a/tests/test_main_routing.py
+++ b/tests/test_main_routing.py
@@ -1,5 +1,6 @@
 import asyncio
 import sys
+import threading
 import types
 
 import pytest
@@ -113,6 +114,21 @@ class FakeAudio:
         self.events.append(("start", options))
 
 
+class FakeHhdRgb:
+    def __init__(self, reads=None, writes=None):
+        self.reads = list(reads or [])
+        self.writes = list(writes or [])
+        self.calls = []
+
+    def read_rgb(self):
+        self.calls.append(("read",))
+        return self.reads.pop(0) if self.reads else False
+
+    def set_rgb(self, enabled):
+        self.calls.append(("set", enabled))
+        return self.writes.pop(0) if self.writes else True
+
+
 def _plugin(
     main_module,
     mode,
@@ -121,6 +137,7 @@ def _plugin(
     power=True,
     per_zone=False,
     per_controller=False,
+    hhd_takeover=False,
 ):
     p = main_module.Plugin()
     p._ready = True
@@ -133,6 +150,8 @@ def _plugin(
         "zones": 2,
         "perControllerColor": per_controller,
         "perZone": per_zone,
+        "conflictsWithSystemRgb": hhd_takeover,
+        "hhdRgbTakeover": hhd_takeover,
     }
     p._settings = {
         "power": power,
@@ -143,7 +162,10 @@ def _plugin(
         "gradient_speed": 30,
         "effect": effect or {"id": "breathing", "speed": 50, "use_gradient": False},
         "ambilight": {"saturation": 140, "smoothing": 75, "fps": 10},
+        "force_control": False,
+        "hhd_rgb_restore": None,
     }
+    p._hhd_rgb = FakeHhdRgb()
     return p
 
 
@@ -385,6 +407,38 @@ def test_reconnect_resets_controller_and_reapplies(main_module):
     assert any(c[0] == "solid" for c in p._controller.calls)
 
 
+def test_apex_reconnect_claims_hhd_before_controller_write(main_module):
+    events = []
+    p = _plugin(main_module, "solid", hhd_takeover=True)
+    p._settings["force_control"] = True
+    p._store = types.SimpleNamespace(save=lambda _s: None)
+
+    class OrderedHhd:
+        def read_rgb(self):
+            events.append("hhd-read")
+            return True
+
+        def set_rgb(self, enabled):
+            events.append(f"hhd-set-{enabled}")
+            return True
+
+    class OrderedController(FakeController):
+        def reconnect(self):
+            events.append("controller-reconnect")
+            return super().reconnect()
+
+        def apply_solid(self, color, brightness, power):
+            events.append("controller-write")
+            return super().apply_solid(color, brightness, power)
+
+    p._hhd_rgb = OrderedHhd()
+    p._controller = OrderedController()
+
+    assert asyncio.run(p.reconnect()) is True
+    assert events[:3] == ["hhd-read", "hhd-set-False", "controller-reconnect"]
+    assert events.index("hhd-set-False") < events.index("controller-write")
+
+
 def _late_ctx(device):
     return {
         "info": {"name": "ROG Xbox Ally X"},
@@ -537,6 +591,7 @@ def test_set_battery_breathe_persists(main_module):
 
 def test_force_control_default_is_false(main_module):
     assert main_module.DEFAULTS["force_control"] is False
+    assert main_module.DEFAULTS["hhd_rgb_restore"] is None
 
 
 def test_set_force_control_persists_and_applies(main_module):
@@ -547,6 +602,139 @@ def test_set_force_control_persists_and_applies(main_module):
     assert p._settings["force_control"] is True
     assert saved["v"]["force_control"] is True
     assert p._controller.calls, "set_force_control must re-apply"
+
+
+def test_apex_force_control_disables_hhd_rgb_and_saves_restore_state(main_module):
+    p = _plugin(main_module, "solid", hhd_takeover=True)
+    p._hhd_rgb = FakeHhdRgb(reads=[True], writes=[True])
+    saved = []
+    p._store = types.SimpleNamespace(save=lambda s: saved.append(dict(s)))
+
+    asyncio.run(p.set_force_control(True))
+
+    assert p._hhd_rgb.calls == [("read",), ("set", False)]
+    assert p._settings["hhd_rgb_restore"] is True
+    assert saved[-1]["hhd_rgb_restore"] is True
+    assert p._controller.invalidated is True
+
+
+def test_apex_force_control_restores_hhd_rgb_and_clears_marker(main_module):
+    p = _plugin(main_module, "solid", hhd_takeover=True)
+    p._settings["force_control"] = True
+    p._settings["hhd_rgb_restore"] = True
+    p._hhd_rgb = FakeHhdRgb(writes=[True])
+    saved = []
+    p._store = types.SimpleNamespace(save=lambda s: saved.append(dict(s)))
+
+    asyncio.run(p.set_force_control(False))
+
+    assert p._hhd_rgb.calls == [("set", True)]
+    assert p._settings["hhd_rgb_restore"] is None
+    assert saved[-1]["hhd_rgb_restore"] is None
+
+
+def test_apex_failed_hhd_restore_keeps_marker_for_retry(main_module):
+    p = _plugin(main_module, "solid", hhd_takeover=True)
+    p._settings["hhd_rgb_restore"] = True
+    p._hhd_rgb = FakeHhdRgb(writes=[False])
+    p._store = types.SimpleNamespace(save=lambda _s: None)
+
+    asyncio.run(p.set_force_control(False))
+
+    assert p._settings["hhd_rgb_restore"] is True
+
+
+def test_force_control_does_not_touch_hhd_on_other_devices(main_module):
+    p = _plugin(main_module, "solid", hhd_takeover=False)
+    p._hhd_rgb = FakeHhdRgb(reads=[True], writes=[True])
+    p._store = types.SimpleNamespace(save=lambda _s: None)
+
+    asyncio.run(p.set_force_control(True))
+
+    assert p._hhd_rgb.calls == []
+
+
+def test_unload_restores_hhd_rgb_ownership(main_module):
+    p = _plugin(main_module, "solid", hhd_takeover=True)
+    p._settings["hhd_rgb_restore"] = True
+    p._hhd_rgb = FakeHhdRgb(writes=[True])
+    p._store = types.SimpleNamespace(save=lambda _s: None)
+
+    asyncio.run(p._unload())
+
+    assert p._hhd_rgb.calls == [("set", True)]
+    assert p._settings["hhd_rgb_restore"] is None
+
+
+def test_unload_waits_for_inflight_hhd_claim_before_restore(main_module, monkeypatch):
+    monkeypatch.setattr(main_module, "FORCE_CONTROL_INTERVAL", 0.001)
+    p = _plugin(main_module, "solid", hhd_takeover=True)
+    p._settings["force_control"] = True
+    p._store = types.SimpleNamespace(save=lambda _s: None)
+    claim_started = threading.Event()
+    release_claim = threading.Event()
+
+    class BlockingHhd:
+        def __init__(self):
+            self.calls = []
+
+        def read_rgb(self):
+            self.calls.append(("read",))
+            return True
+
+        def set_rgb(self, enabled):
+            self.calls.append(("set", enabled))
+            if not enabled:
+                claim_started.set()
+                release_claim.wait(1)
+            return True
+
+    p._hhd_rgb = BlockingHhd()
+
+    async def drive():
+        p._force_control_task = asyncio.create_task(p._force_control_watch())
+        while not claim_started.is_set():
+            await asyncio.sleep(0.001)
+        unload = asyncio.create_task(p._unload())
+        await asyncio.sleep(0.01)
+        assert ("set", True) not in p._hhd_rgb.calls
+        release_claim.set()
+        await unload
+
+    asyncio.run(drive())
+
+    assert p._hhd_rgb.calls[-2:] == [("set", False), ("set", True)]
+    assert p._settings["hhd_rgb_restore"] is None
+
+
+def test_uninstall_stops_watcher_before_restoring_hhd(main_module):
+    p = _plugin(main_module, "solid", hhd_takeover=True)
+    p._settings["hhd_rgb_restore"] = True
+    p._hhd_rgb = FakeHhdRgb(writes=[True])
+    p._store = types.SimpleNamespace(save=lambda _s: None)
+
+    async def drive():
+        p._force_control_task = asyncio.create_task(asyncio.sleep(60))
+        await p._uninstall()
+        assert p._force_control_task.cancelled()
+
+    asyncio.run(drive())
+    assert p._hhd_rgb.calls == [("set", True)]
+
+
+def test_force_control_cannot_reclaim_hhd_after_unload_begins(main_module):
+    p = _plugin(main_module, "solid", hhd_takeover=True)
+    p._hhd_rgb = FakeHhdRgb(reads=[True], writes=[True])
+    p._store = types.SimpleNamespace(save=lambda _s: None)
+
+    async def drive():
+        await p._unload()
+        await p.set_force_control(True)
+
+    asyncio.run(drive())
+
+    assert p._hhd_rgb.calls == []
+    assert p._controller.invalidated is False
 
 
 def test_hardware_gradient_uses_device_zone_count(main_module):
@@ -582,6 +770,38 @@ def test_force_control_watch_reasserts_static_mode(main_module, monkeypatch):
     _drive_watch(main_module, p)
     assert p._controller.invalidated is False, "maintenance re-assert must not re-init"
     assert p._controller.calls, "watch must re-apply in a static mode"
+
+
+def test_apex_force_control_watch_reclaims_hhd_and_relatches(main_module, monkeypatch):
+    monkeypatch.setattr(main_module, "FORCE_CONTROL_INTERVAL", 0.001)
+    p = _plugin(main_module, "solid", hw=False, per_zone=False, hhd_takeover=True)
+    p._settings["force_control"] = True
+    p._hhd_rgb = FakeHhdRgb(reads=[True], writes=[True])
+    p._store = types.SimpleNamespace(save=lambda _s: None)
+    p._controller.calls.clear()
+
+    _drive_watch(main_module, p)
+
+    assert ("set", False) in p._hhd_rgb.calls
+    assert p._controller.invalidated is True
+    assert p._engine.events
+
+
+def test_apex_force_control_watch_does_not_relatch_when_hhd_is_already_disabled(
+    main_module, monkeypatch
+):
+    monkeypatch.setattr(main_module, "FORCE_CONTROL_INTERVAL", 0.001)
+    p = _plugin(main_module, "solid", hw=False, per_zone=False, hhd_takeover=True)
+    p._settings["force_control"] = True
+    p._hhd_rgb = FakeHhdRgb(reads=[False] * 30)
+    p._store = types.SimpleNamespace(save=lambda _s: None)
+    p._controller.calls.clear()
+    p._engine.events.clear()
+
+    _drive_watch(main_module, p)
+
+    assert p._controller.invalidated is False
+    assert p._engine.events
 
 
 def test_force_control_watch_skips_running_effect(main_module, monkeypatch):

--- a/tests/test_report_collector.py
+++ b/tests/test_report_collector.py
@@ -113,10 +113,12 @@ def test_capabilities_from_uses_controller_fallback():
     caps = capabilities_from(
         {"capabilities": {"color": True}, "device": {"name": "ROG Ally"}},
         driver="AsusAllyHidDevice",
+        route="hid",
         led_path=None,
         last_error="probe with driver asus failed with error -12",
     )
     assert caps["driver"] == "AsusAllyHidDevice"
+    assert caps["route"] == "hid"
     assert caps["led_path"] is None
     assert caps["last_error"] == "probe with driver asus failed with error -12"
 


### PR DESCRIPTION
## Qué cambia / What changes

- Para la identidad exacta de OneXPlayer Apex, priorizo la ruta HID v2 utilizada por HueSync y conservo `oxp:rgb:joystick_rings` como fallback automático en runtime
- Enciendo los LEDs antes de enviar el primer color, respeto la espera de 300 ms en la transición y mantengo la cadencia de 50 ms durante los cambios normales
- Añado recuperación entre rutas y diagnóstico de ruta activa, identidad HID, paquetes y errores
- Cuando el usuario activa **Forzar control**, reclamo de forma reversible `hhd.settings.rgb`, guardo su estado anterior y lo restauro al desactivar, descargar o desinstalar
- Mantengo intactas las rutas anteriores de F1 Pro, OneXPlayer genéricas y el resto de máquinas

**EN:** For the exact OneXPlayer Apex identity, this prioritizes the HID v2 route used by HueSync, keeps `oxp:rgb:joystick_rings` as an automatic runtime fallback, adds route recovery and diagnostics, and provides reversible opt-in ownership of `hhd.settings.rgb` through **Force Control**. Existing F1 Pro, generic OneXPlayer, and unrelated device routes remain unchanged.

## Por qué / Why

Colores 0.21.2 seleccionaba siempre el nodo sysfs write-only de `hid-oxp` cuando estaba presente. El reporte mostraba escrituras aceptadas sin errores pero sin salida visible, por lo que nunca se intentaba la ruta HID directa. Además, HHD podía conservar el control RGB aunque el usuario hubiera cedido expresamente el control a Colores.

**EN:** Colores 0.21.2 always selected the write-only `hid-oxp` sysfs node when present. The report showed accepted writes with no visible output, so the direct HID route was never attempted. HHD could also retain RGB ownership after the user had explicitly granted control to Colores.

## Pruebas / Testing

- [x] 353 pruebas backend / backend tests
- [x] Ruff
- [x] TypeScript (`pnpm typecheck`)
- [x] `git diff --check`
- [x] Commit convencional / Conventional commit
- [x] Despliegue de aislamiento en Legion Go S `83N6`: `LegionGoSHidDevice`, dos zonas, disponible y sin error backend
- [x] Revisión completa del diff simplificado sin hallazgos bloqueantes
- [ ] Validación física y visual en OneXPlayer Apex

El smoke de Legion Go S valida selección, carga y aislamiento del backend, no la salida visual ni el hardware Apex. La generación del bundle termina en macOS, pero el runner local no sale después de escribir el artefacto sin cambios; la fuente frontend no cambia y CI validará el build Linux.

**EN:** The Legion Go S smoke validates backend selection, loading, and isolation, not visual output or Apex hardware. Bundle generation completes on macOS, but the local runner does not exit after writing the unchanged artifact; frontend source is untouched and CI will validate the Linux build.

Relacionado con #85 / Related to #85. Esta PR no cierra el issue automáticamente / This PR does not close the issue automatically.