### PR TITLE
Add performant Android Ambilight

### DIFF
--- a/android/app/src/main/java/com/hooandee/colores/ColoresApplication.kt
+++ b/android/app/src/main/java/com/hooandee/colores/ColoresApplication.kt
@@ -1,6 +1,8 @@
 package com.hooandee.colores
 
 import android.app.Application
+import com.hooandee.colores.ambient.AmbientCaptureSession
+import com.hooandee.colores.ambient.MutableAmbientFrameSource
 import com.hooandee.colores.audio.AudioCaptureSession
 import com.hooandee.colores.audio.MutableAudioLevelSource
 import com.hooandee.colores.apps.ForegroundAppObserver
@@ -26,6 +28,10 @@ class ColoresApplication : Application() {
 
     val audioCaptureSession by lazy { AudioCaptureSession(applicationScope, audioLevelSource) }
 
+    val ambientFrameSource by lazy { MutableAmbientFrameSource() }
+
+    val ambientCaptureSession by lazy { AmbientCaptureSession(this, ambientFrameSource) }
+
     val effectsServiceGate by lazy { ContextServiceGate(this) }
 
     val profileStore: LightingProfileStore by lazy { LightingProfileStore(this) }
@@ -40,7 +46,7 @@ class ColoresApplication : Application() {
     }
 
     val lightingRuntime: LightingRuntime by lazy {
-        LightingRuntime(this, applicationScope, lightingController, audioLevelSource)
+        LightingRuntime(this, applicationScope, lightingController, audioLevelSource, ambientFrameSource)
     }
 
     val profileCoordinator: LightingProfileCoordinator by lazy {

--- a/android/app/src/main/java/com/hooandee/colores/MainActivity.kt
+++ b/android/app/src/main/java/com/hooandee/colores/MainActivity.kt
@@ -26,18 +26,28 @@ import com.hooandee.colores.ui.ColoresViewModel
 
 class MainActivity : AppCompatActivity() {
     private val viewModel by viewModels<ColoresViewModel>()
+    private var projectionRequest = ProjectionRequest.NONE
     private val projectionLauncher =
         registerForActivityResult(ActivityResultContracts.StartActivityForResult()) { result ->
             val data = result.data
             if (result.resultCode == Activity.RESULT_OK && data != null) {
-                viewModel.activateAudio(result.resultCode, data)
+                when (projectionRequest) {
+                    ProjectionRequest.AUDIO -> viewModel.activateAudio(result.resultCode, data)
+                    ProjectionRequest.AMBIENT -> viewModel.activateAmbient(result.resultCode, data)
+                    ProjectionRequest.NONE -> Unit
+                }
             } else {
-                viewModel.onAudioAuthorizationDenied()
+                when (projectionRequest) {
+                    ProjectionRequest.AUDIO -> viewModel.onAudioAuthorizationDenied()
+                    ProjectionRequest.AMBIENT -> viewModel.onAmbientAuthorizationDenied()
+                    ProjectionRequest.NONE -> Unit
+                }
             }
+            projectionRequest = ProjectionRequest.NONE
         }
     private val audioPermissionLauncher =
         registerForActivityResult(ActivityResultContracts.RequestPermission()) { granted ->
-            if (granted) launchProjectionConsent() else viewModel.onAudioAuthorizationDenied()
+            if (granted) launchProjectionConsent(ProjectionRequest.AUDIO) else viewModel.onAudioAuthorizationDenied()
         }
     private val screenOnReceiver =
         object : BroadcastReceiver() {
@@ -59,6 +69,7 @@ class MainActivity : AppCompatActivity() {
                     viewModel = viewModel,
                     onGrantPermission = { startActivity(WriteSettingsPermission.createGrantIntent(this)) },
                     onAudioCaptureRequest = ::requestAudioCapture,
+                    onAmbientCaptureRequest = { launchProjectionConsent(ProjectionRequest.AMBIENT) },
                     onGrantUsage = {
                         startActivity((application as ColoresApplication).usageAccess.settingsIntent())
                     },
@@ -101,14 +112,21 @@ class MainActivity : AppCompatActivity() {
 
     private fun requestAudioCapture() {
         if (ContextCompat.checkSelfPermission(this, Manifest.permission.RECORD_AUDIO) == PackageManager.PERMISSION_GRANTED) {
-            launchProjectionConsent()
+            launchProjectionConsent(ProjectionRequest.AUDIO)
         } else {
             audioPermissionLauncher.launch(Manifest.permission.RECORD_AUDIO)
         }
     }
 
-    private fun launchProjectionConsent() {
+    private fun launchProjectionConsent(request: ProjectionRequest) {
+        projectionRequest = request
         val manager = getSystemService(MediaProjectionManager::class.java)
         projectionLauncher.launch(manager.createScreenCaptureIntent())
+    }
+
+    private enum class ProjectionRequest {
+        NONE,
+        AUDIO,
+        AMBIENT,
     }
 }

--- a/android/app/src/main/java/com/hooandee/colores/ambient/AmbientCaptureSession.kt
+++ b/android/app/src/main/java/com/hooandee/colores/ambient/AmbientCaptureSession.kt
@@ -1,0 +1,61 @@
+package com.hooandee.colores.ambient
+
+import android.content.Context
+import android.media.projection.MediaProjection
+import com.hooandee.colores.device.LedGridCell
+
+data class AmbientCaptureConfig(
+    val zones: Int,
+    val gridLayout: List<LedGridCell>?,
+    val supportsPerZone: Boolean,
+    val captureFps: Int,
+    val samplingMode: AmbientSamplingMode,
+)
+
+object AmbientCaptureCadence {
+    fun shouldProcess(
+        lastFrameMs: Long,
+        nowMs: Long,
+        fps: Int,
+    ): Boolean = lastFrameMs == 0L || nowMs - lastFrameMs >= 1_000L / fps.normalizedAmbientCaptureFps()
+}
+
+internal fun Int.normalizedAmbientCaptureFps(): Int = ((coerceIn(5, 30) + 2) / 5) * 5
+
+class AmbientCaptureSession(
+    private val context: Context,
+    private val source: MutableAmbientFrameSource,
+) {
+    private var capture: AndroidScreenCapture? = null
+
+    fun start(
+        projection: MediaProjection,
+        config: AmbientCaptureConfig,
+        onError: (Throwable) -> Unit,
+    ) {
+        stop(AmbientCaptureStatus.STARTING)
+        val active =
+            AndroidScreenCapture(
+                context = context,
+                projection = projection,
+                initialConfig = config,
+                onFrame = { colors, timestampMs ->
+                    source.update(colors, AmbientCaptureStatus.CAPTURING, timestampMs)
+                },
+                onNoFrames = { source.setStatus(AmbientCaptureStatus.NO_FRAMES) },
+                onError = onError,
+            )
+        capture = active
+        active.start()
+    }
+
+    fun stop(status: AmbientCaptureStatus) {
+        capture?.stop()
+        capture = null
+        source.reset(status)
+    }
+
+    fun updateConfig(config: AmbientCaptureConfig) {
+        capture?.updateConfig(config)
+    }
+}

--- a/android/app/src/main/java/com/hooandee/colores/ambient/AmbientFrameSource.kt
+++ b/android/app/src/main/java/com/hooandee/colores/ambient/AmbientFrameSource.kt
@@ -1,0 +1,54 @@
+package com.hooandee.colores.ambient
+
+import com.hooandee.colores.led.RgbColor
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+
+enum class AmbientCaptureStatus {
+    AUTHORIZATION_REQUIRED,
+    STARTING,
+    CAPTURING,
+    NO_FRAMES,
+    REVOKED,
+    ERROR,
+}
+
+internal val AmbientCaptureStatus.keepsCaptureActive: Boolean
+    get() = this == AmbientCaptureStatus.STARTING || this == AmbientCaptureStatus.CAPTURING || this == AmbientCaptureStatus.NO_FRAMES
+
+internal val AmbientCaptureStatus.needsAuthorization: Boolean
+    get() = this == AmbientCaptureStatus.AUTHORIZATION_REQUIRED || this == AmbientCaptureStatus.REVOKED || this == AmbientCaptureStatus.ERROR
+
+data class AmbientFrameState(
+    val colors: List<RgbColor> = emptyList(),
+    val status: AmbientCaptureStatus = AmbientCaptureStatus.AUTHORIZATION_REQUIRED,
+    val timestampMs: Long = 0L,
+)
+
+interface AmbientFrameSource {
+    val state: StateFlow<AmbientFrameState>
+}
+
+class MutableAmbientFrameSource(
+    initial: AmbientFrameState = AmbientFrameState(),
+) : AmbientFrameSource {
+    private val mutableState = MutableStateFlow(initial)
+    override val state: StateFlow<AmbientFrameState> = mutableState.asStateFlow()
+
+    fun update(
+        colors: List<RgbColor>,
+        status: AmbientCaptureStatus,
+        timestampMs: Long,
+    ) {
+        mutableState.value = AmbientFrameState(colors, status, timestampMs)
+    }
+
+    fun reset(status: AmbientCaptureStatus) {
+        mutableState.value = AmbientFrameState(status = status)
+    }
+
+    fun setStatus(status: AmbientCaptureStatus) {
+        mutableState.value = mutableState.value.copy(status = status)
+    }
+}

--- a/android/app/src/main/java/com/hooandee/colores/ambient/AmbientSampling.kt
+++ b/android/app/src/main/java/com/hooandee/colores/ambient/AmbientSampling.kt
@@ -1,0 +1,146 @@
+package com.hooandee.colores.ambient
+
+import com.hooandee.colores.device.LedGridCell
+import com.hooandee.colores.led.RgbColor
+import kotlin.math.pow
+import kotlin.math.roundToInt
+
+enum class AmbientSamplingMode {
+    FULL_SCENE,
+    BOTTOM_EDGE,
+}
+
+data class AmbientPixelFrame(
+    val width: Int,
+    val height: Int,
+    val pixelStride: Int,
+    val rowStride: Int,
+    val bytes: ByteArray,
+)
+
+object AmbientSampler {
+    fun sample(
+        frame: AmbientPixelFrame,
+        zones: Int,
+        gridLayout: List<LedGridCell>?,
+        supportsPerZone: Boolean,
+        mode: AmbientSamplingMode,
+    ): List<RgbColor> {
+        val zoneCount = zones.coerceAtLeast(1)
+        if (!frame.valid()) return List(zoneCount) { BLACK }
+        if (!supportsPerZone || gridLayout?.size != zoneCount || gridLayout.any { it.stick == null }) {
+            val average = frame.average(Region(0.0, 0.0, 1.0, 1.0))
+            return List(zoneCount) { average }
+        }
+        if (mode == AmbientSamplingMode.BOTTOM_EDGE) {
+            return List(zoneCount) { index ->
+                frame.average(
+                    Region(
+                        x0 = index.toDouble() / zoneCount,
+                        y0 = BOTTOM_EDGE_START,
+                        x1 = (index + 1.0) / zoneCount,
+                        y1 = 1.0,
+                    ),
+                )
+            }
+        }
+
+        val stickIds = gridLayout.mapNotNull(LedGridCell::stick).distinct().sorted()
+        return gridLayout.map { cell ->
+            val stickIndex = stickIds.indexOf(cell.stick).coerceAtLeast(0)
+            val cells = gridLayout.filter { it.stick == cell.stick }
+            val rows = (cells.maxOfOrNull(LedGridCell::row) ?: 0) + 1
+            val columns = (cells.maxOfOrNull(LedGridCell::col) ?: 0) + 1
+            val stickWidth = 1.0 / stickIds.size.coerceAtLeast(1)
+            val stickStart = stickIndex * stickWidth
+            frame.average(
+                Region(
+                    x0 = stickStart + stickWidth * cell.col / columns,
+                    y0 = cell.row.toDouble() / rows,
+                    x1 = stickStart + stickWidth * (cell.col + 1.0) / columns,
+                    y1 = (cell.row + 1.0) / rows,
+                ),
+            )
+        }
+    }
+
+    private fun AmbientPixelFrame.valid(): Boolean =
+        width > 0 &&
+            height > 0 &&
+            pixelStride >= 3 &&
+            rowStride >= width * pixelStride &&
+            bytes.size >= (height - 1) * rowStride + width * pixelStride
+
+    private fun AmbientPixelFrame.average(region: Region): RgbColor {
+        val startX = (region.x0 * width).toInt().coerceIn(0, width - 1)
+        val endX = (region.x1 * width).toInt().coerceIn(startX + 1, width)
+        val startY = (region.y0 * height).toInt().coerceIn(0, height - 1)
+        val endY = (region.y1 * height).toInt().coerceIn(startY + 1, height)
+        var red = 0L
+        var green = 0L
+        var blue = 0L
+        var count = 0L
+        for (y in startY until endY) {
+            for (x in startX until endX) {
+                val offset = y * rowStride + x * pixelStride
+                red += bytes[offset].toInt() and 0xFF
+                green += bytes[offset + 1].toInt() and 0xFF
+                blue += bytes[offset + 2].toInt() and 0xFF
+                count += 1
+            }
+        }
+        return if (count == 0L) BLACK else RgbColor((red / count).toInt(), (green / count).toInt(), (blue / count).toInt())
+    }
+
+    private data class Region(
+        val x0: Double,
+        val y0: Double,
+        val x1: Double,
+        val y1: Double,
+    )
+
+    private val BLACK = RgbColor(0, 0, 0)
+    private const val BOTTOM_EDGE_START = 0.72
+}
+
+object AmbientColorMath {
+    fun vivid(
+        color: RgbColor,
+        percent: Int,
+    ): RgbColor {
+        val factor = 1.0 + percent.coerceIn(0, 100) * 0.015
+        val gray = color.red * 0.299 + color.green * 0.587 + color.blue * 0.114
+        return RgbColor(
+            boosted(gray, color.red, factor),
+            boosted(gray, color.green, factor),
+            boosted(gray, color.blue, factor),
+        )
+    }
+
+    fun smooth(
+        current: RgbColor,
+        target: RgbColor,
+        smoothing: Int,
+        elapsedMs: Long,
+    ): RgbColor {
+        val baseAlpha = maxOf(0.04, 1.0 - smoothing.coerceIn(0, 100) / 100.0)
+        val alpha = 1.0 - (1.0 - baseAlpha).pow(elapsedMs.coerceAtLeast(0L) / 100.0)
+        return RgbColor(
+            mixed(current.red, target.red, alpha),
+            mixed(current.green, target.green, alpha),
+            mixed(current.blue, target.blue, alpha),
+        )
+    }
+
+    private fun boosted(
+        gray: Double,
+        channel: Int,
+        factor: Double,
+    ): Int = (gray + (channel - gray) * factor).roundToInt().coerceIn(0, 255)
+
+    private fun mixed(
+        current: Int,
+        target: Int,
+        alpha: Double,
+    ): Int = (current + (target - current) * alpha).roundToInt().coerceIn(0, 255)
+}

--- a/android/app/src/main/java/com/hooandee/colores/ambient/AndroidScreenCapture.kt
+++ b/android/app/src/main/java/com/hooandee/colores/ambient/AndroidScreenCapture.kt
@@ -1,0 +1,122 @@
+package com.hooandee.colores.ambient
+
+import android.content.Context
+import android.graphics.PixelFormat
+import android.hardware.display.DisplayManager
+import android.hardware.display.VirtualDisplay
+import android.media.ImageReader
+import android.media.projection.MediaProjection
+import android.os.Handler
+import android.os.HandlerThread
+import android.os.SystemClock
+import com.hooandee.colores.led.RgbColor
+
+class AndroidScreenCapture(
+    private val context: Context,
+    private val projection: MediaProjection,
+    initialConfig: AmbientCaptureConfig,
+    private val onFrame: (List<RgbColor>, Long) -> Unit,
+    private val onNoFrames: () -> Unit,
+    private val onError: (Throwable) -> Unit,
+) {
+    @Volatile
+    private var config = initialConfig
+    private var thread: HandlerThread? = null
+    private var handler: Handler? = null
+    private var reader: ImageReader? = null
+    private var display: VirtualDisplay? = null
+    private var lastProcessedMs = 0L
+    @Volatile
+    private var running = false
+
+    private val watchdog =
+        object : Runnable {
+            override fun run() {
+                if (!running) return
+                val now = SystemClock.elapsedRealtime()
+                if (lastProcessedMs == 0L || now - lastProcessedMs >= NO_FRAME_TIMEOUT_MS) onNoFrames()
+                handler?.postDelayed(this, NO_FRAME_TIMEOUT_MS)
+            }
+        }
+
+    fun start() {
+        check(!running)
+        running = true
+        val captureThread = HandlerThread("ColoresAmbientCapture").apply { start() }
+        val captureHandler = Handler(captureThread.looper)
+        val imageReader = ImageReader.newInstance(CAPTURE_WIDTH, CAPTURE_HEIGHT, PixelFormat.RGBA_8888, MAX_IMAGES)
+        thread = captureThread
+        handler = captureHandler
+        reader = imageReader
+        imageReader.setOnImageAvailableListener({ available -> consumeLatest(available) }, captureHandler)
+        display =
+            projection.createVirtualDisplay(
+                "ColoresAmbient",
+                CAPTURE_WIDTH,
+                CAPTURE_HEIGHT,
+                context.resources.displayMetrics.densityDpi,
+                DisplayManager.VIRTUAL_DISPLAY_FLAG_AUTO_MIRROR,
+                imageReader.surface,
+                null,
+                captureHandler,
+            )
+        captureHandler.postDelayed(watchdog, NO_FRAME_TIMEOUT_MS)
+    }
+
+    fun stop() {
+        if (!running) return
+        running = false
+        handler?.removeCallbacksAndMessages(null)
+        reader?.setOnImageAvailableListener(null, null)
+        display?.release()
+        reader?.close()
+        thread?.quitSafely()
+        display = null
+        reader = null
+        handler = null
+        thread = null
+        lastProcessedMs = 0L
+    }
+
+    fun updateConfig(config: AmbientCaptureConfig) {
+        this.config = config
+    }
+
+    private fun consumeLatest(available: ImageReader) {
+        val image = runCatching { available.acquireLatestImage() }.getOrElse {
+            onError(it)
+            return
+        } ?: return
+        try {
+            val now = SystemClock.elapsedRealtime()
+            val activeConfig = config
+            if (!AmbientCaptureCadence.shouldProcess(lastProcessedMs, now, activeConfig.captureFps)) return
+            val plane = image.planes.firstOrNull() ?: return
+            val buffer = plane.buffer
+            buffer.rewind()
+            val bytes = ByteArray(buffer.remaining())
+            buffer.get(bytes)
+            val colors =
+                AmbientSampler.sample(
+                    frame = AmbientPixelFrame(image.width, image.height, plane.pixelStride, plane.rowStride, bytes),
+                    zones = activeConfig.zones,
+                    gridLayout = activeConfig.gridLayout,
+                    supportsPerZone = activeConfig.supportsPerZone,
+                    mode = activeConfig.samplingMode,
+                )
+            lastProcessedMs = now
+            onFrame(colors, now)
+        } catch (error: Throwable) {
+            onError(error)
+        } finally {
+            image.close()
+        }
+    }
+
+    private companion object {
+        const val CAPTURE_WIDTH = 32
+        const val CAPTURE_HEIGHT = 18
+        const val MAX_IMAGES = 2
+        const val NO_FRAME_TIMEOUT_MS = 2_000L
+    }
+}

--- a/android/app/src/main/java/com/hooandee/colores/control/LightingController.kt
+++ b/android/app/src/main/java/com/hooandee/colores/control/LightingController.kt
@@ -1,9 +1,15 @@
 package com.hooandee.colores.control
 
+import com.hooandee.colores.ambient.AmbientCaptureStatus
+import com.hooandee.colores.ambient.AmbientFrameSource
+import com.hooandee.colores.ambient.AmbientFrameState
+import com.hooandee.colores.ambient.MutableAmbientFrameSource
+import com.hooandee.colores.ambient.keepsCaptureActive
 import com.hooandee.colores.audio.AudioLevelSource
 import com.hooandee.colores.audio.AudioLevelState
 import com.hooandee.colores.audio.MutableAudioLevelSource
 import com.hooandee.colores.engine.AudioVuRenderer
+import com.hooandee.colores.engine.AmbientRenderer
 import com.hooandee.colores.engine.AudioScale
 import com.hooandee.colores.engine.AudioSensitivity
 import com.hooandee.colores.engine.BandSet
@@ -45,6 +51,7 @@ enum class AppMode {
     PERFORMANCE,
     CLOCK,
     AUDIO,
+    AMBIENT,
     ;
 
     val isDynamic: Boolean
@@ -71,6 +78,8 @@ data class LightingIntent(
     val temperatureBreathe: Boolean = true,
     val audioScale: AudioScale = AudioScale.DEFAULT,
     val audioSensitivityDb: Int = AudioSensitivity.NORMAL_DB,
+    val ambientVividness: Int = 35,
+    val ambientSmoothing: Int = 45,
 )
 
 data class LightingBinding(
@@ -83,6 +92,7 @@ data class LightingBinding(
     val temperature: TemperatureSource?,
     val performance: PerformanceSource?,
     val audio: AudioLevelSource = MutableAudioLevelSource(),
+    val ambient: AmbientFrameSource = MutableAmbientFrameSource(),
 )
 
 data class LightingSnapshot(
@@ -108,6 +118,9 @@ data class LightingSnapshot(
     val audio: AudioLevelState = AudioLevelState(),
     val audioScale: AudioScale = AudioScale.DEFAULT,
     val audioSensitivityDb: Int = AudioSensitivity.NORMAL_DB,
+    val ambient: AmbientFrameState = AmbientFrameState(),
+    val ambientVividness: Int = 35,
+    val ambientSmoothing: Int = 45,
     val currentFrame: List<RgbColor> = emptyList(),
 )
 
@@ -223,6 +236,12 @@ class LightingController(
 
     fun onAudioStateChanged() = send(Command.AudioStateChanged)
 
+    fun setAmbientVividness(value: Int) = send(Command.SetAmbientVividness(value))
+
+    fun setAmbientSmoothing(value: Int) = send(Command.SetAmbientSmoothing(value))
+
+    fun onAmbientStateChanged() = send(Command.AmbientStateChanged)
+
     private fun send(command: Command) {
         commands.trySend(command)
     }
@@ -250,6 +269,9 @@ class LightingController(
                     it.copy(audioSensitivityDb = command.gainDb.coerceIn(AudioSensitivity.MIN_DB, AudioSensitivity.MAX_DB))
                 }
             Command.AudioStateChanged -> reconcile()
+            is Command.SetAmbientVividness -> mutateIntent { it.copy(ambientVividness = command.value.coerceIn(0, 100)) }
+            is Command.SetAmbientSmoothing -> mutateIntent { it.copy(ambientSmoothing = command.value.coerceIn(0, 100)) }
+            Command.AmbientStateChanged -> reconcile()
             is Command.SetSensorBands -> {
                 sensorBands = command.bands
                 publishSnapshot()
@@ -324,6 +346,7 @@ class LightingController(
             AppMode.GRADIENT -> intent.gradientPresentation == GradientPresentation.ANIMATED || !binding.device.supportsPerZone
             AppMode.EFFECT -> hardwareEffect(binding) == null
             AppMode.AUDIO -> binding.audio.state.value.status.keepsAudioCaptureActive
+            AppMode.AMBIENT -> binding.ambient.state.value.status.keepsCaptureActive
             else -> intent.mode.isDynamic
         }
 
@@ -346,7 +369,11 @@ class LightingController(
             }
             intent.mode == AppMode.AUDIO && !binding.audio.state.value.status.keepsAudioCaptureActive -> {
                 if (manageRenderJob) stopRenderJob()
-                applyAudioUnavailable(binding)
+                applyCaptureUnavailable(binding)
+            }
+            intent.mode == AppMode.AMBIENT && !binding.ambient.state.value.status.keepsCaptureActive -> {
+                if (manageRenderJob) stopRenderJob()
+                applyCaptureUnavailable(binding)
             }
             hwEffect != null -> {
                 if (manageRenderJob) stopRenderJob()
@@ -391,7 +418,7 @@ class LightingController(
         publishSnapshot()
     }
 
-    private suspend fun applyAudioUnavailable(binding: LightingBinding) {
+    private suspend fun applyCaptureUnavailable(binding: LightingBinding) {
         val colors = binding.offFrame()
         runCatching { binding.device.applyZones(colors, intent.brightness, effectivePower()) }.rethrowCancellation()
         lastFrame = colors
@@ -519,6 +546,14 @@ class LightingController(
                     sensitivityDb = { intent.audioSensitivityDb },
                     state = { binding.audio.state.value },
                 )
+            AppMode.AMBIENT ->
+                AmbientRenderer(
+                    zones = zones,
+                    frameIntervalMs = interval,
+                    vividness = { intent.ambientVividness },
+                    smoothing = { intent.ambientSmoothing },
+                    state = { binding.ambient.state.value },
+                )
             else ->
                 EffectRenderer(intent.effectId, zones, interval, { intent.speed }, { resolvePalette(binding) })
         }
@@ -579,6 +614,9 @@ class LightingController(
                 audio = binding?.audio?.state?.value ?: AudioLevelState(),
                 audioScale = intent.audioScale,
                 audioSensitivityDb = intent.audioSensitivityDb,
+                ambient = binding?.ambient?.state?.value ?: AmbientFrameState(),
+                ambientVividness = intent.ambientVividness,
+                ambientSmoothing = intent.ambientSmoothing,
                 currentFrame = lastFrame,
             )
     }
@@ -626,6 +664,12 @@ class LightingController(
         data class SetAudioSensitivity(val gainDb: Int) : Command
 
         data object AudioStateChanged : Command
+
+        data class SetAmbientVividness(val value: Int) : Command
+
+        data class SetAmbientSmoothing(val value: Int) : Command
+
+        data object AmbientStateChanged : Command
 
         data class SetSensorBands(val bands: BandSet) : Command
 

--- a/android/app/src/main/java/com/hooandee/colores/control/LightingPreferences.kt
+++ b/android/app/src/main/java/com/hooandee/colores/control/LightingPreferences.kt
@@ -2,6 +2,8 @@ package com.hooandee.colores.control
 
 import android.content.Context
 import android.content.SharedPreferences
+import com.hooandee.colores.ambient.AmbientSamplingMode
+import com.hooandee.colores.ambient.normalizedAmbientCaptureFps
 import com.hooandee.colores.engine.BandSet
 import com.hooandee.colores.engine.AudioScale
 import com.hooandee.colores.engine.AudioSensitivity
@@ -25,6 +27,10 @@ data class StoredLighting(
     val temperatureBreathe: Boolean = true,
     val audioScale: AudioScale = AudioScale.DEFAULT,
     val audioSensitivityDb: Int = AudioSensitivity.NORMAL_DB,
+    val ambientCaptureFps: Int = 10,
+    val ambientSamplingMode: AmbientSamplingMode = AmbientSamplingMode.FULL_SCENE,
+    val ambientVividness: Int = 35,
+    val ambientSmoothing: Int = 45,
     val sensorBands: BandSet = BandSet.FALLBACK,
 )
 
@@ -85,6 +91,15 @@ class LightingPreferences(
                 audioSensitivityDb =
                     root.optInt("audioSensitivityDb", AudioSensitivity.NORMAL_DB)
                         .coerceIn(AudioSensitivity.MIN_DB, AudioSensitivity.MAX_DB),
+                ambientCaptureFps = root.optInt("ambientCaptureFps", 10).normalizedAmbientCaptureFps(),
+                ambientSamplingMode =
+                    runCatching {
+                        AmbientSamplingMode.valueOf(
+                            root.optString("ambientSamplingMode", AmbientSamplingMode.FULL_SCENE.name),
+                        )
+                    }.getOrDefault(AmbientSamplingMode.FULL_SCENE),
+                ambientVividness = root.optInt("ambientVividness", 35).coerceIn(0, 100),
+                ambientSmoothing = root.optInt("ambientSmoothing", 45).coerceIn(0, 100),
                 sensorBands = decodeBands(root.optJSONObject("sensorBands"), defaults),
             )
         }.getOrDefault(StoredLighting(sensorBands = defaults))
@@ -115,6 +130,10 @@ class LightingPreferences(
                 "audioSensitivityDb",
                 value.audioSensitivityDb.coerceIn(AudioSensitivity.MIN_DB, AudioSensitivity.MAX_DB),
             )
+            .put("ambientCaptureFps", value.ambientCaptureFps.normalizedAmbientCaptureFps())
+            .put("ambientSamplingMode", value.ambientSamplingMode.name)
+            .put("ambientVividness", value.ambientVividness.coerceIn(0, 100))
+            .put("ambientSmoothing", value.ambientSmoothing.coerceIn(0, 100))
             .put(
                 "sensorBands",
                 JSONObject()

--- a/android/app/src/main/java/com/hooandee/colores/control/LightingRuntime.kt
+++ b/android/app/src/main/java/com/hooandee/colores/control/LightingRuntime.kt
@@ -1,6 +1,8 @@
 package com.hooandee.colores.control
 
 import android.content.Context
+import com.hooandee.colores.ambient.AmbientCaptureStatus
+import com.hooandee.colores.ambient.MutableAmbientFrameSource
 import com.hooandee.colores.audio.AudioCaptureStatus
 import com.hooandee.colores.audio.MutableAudioLevelSource
 import com.hooandee.colores.device.AndroidDeviceDetector
@@ -42,6 +44,7 @@ class LightingRuntime(
     private val scope: CoroutineScope,
     private val controller: LightingController,
     private val audio: MutableAudioLevelSource,
+    private val ambient: MutableAmbientFrameSource,
 ) {
     suspend fun restoreSaved(): RestoredLightingBinding? =
         withContext(Dispatchers.IO) {
@@ -89,6 +92,7 @@ class LightingRuntime(
                     stored.mode
                 }
             if (mode == AppMode.AUDIO) audio.reset(AudioCaptureStatus.AUTHORIZATION_REQUIRED)
+            if (mode == AppMode.AMBIENT) ambient.reset(AmbientCaptureStatus.AUTHORIZATION_REQUIRED)
 
             controller.bind(
                 LightingBinding(
@@ -101,6 +105,7 @@ class LightingRuntime(
                     temperature = SysfsThermalSource().takeIf { it.available },
                     performance = PerformanceSources.detect(),
                     audio = audio,
+                    ambient = ambient,
                 ),
                 LightingIntent(
                     mode = mode,
@@ -119,6 +124,8 @@ class LightingRuntime(
                     temperatureBreathe = stored.temperatureBreathe,
                     audioScale = stored.audioScale,
                     audioSensitivityDb = stored.audioSensitivityDb,
+                    ambientVividness = stored.ambientVividness,
+                    ambientSmoothing = stored.ambientSmoothing,
                 ),
             )
             RestoredLightingBinding(

--- a/android/app/src/main/java/com/hooandee/colores/effects/EffectsService.kt
+++ b/android/app/src/main/java/com/hooandee/colores/effects/EffectsService.kt
@@ -19,14 +19,38 @@ import android.util.Log
 import com.hooandee.colores.ColoresApplication
 import com.hooandee.colores.MainActivity
 import com.hooandee.colores.R
+import com.hooandee.colores.ambient.AmbientCaptureConfig
+import com.hooandee.colores.ambient.AmbientCaptureStatus
+import com.hooandee.colores.ambient.AmbientSamplingMode
 import com.hooandee.colores.audio.AndroidPlaybackCapture
 import com.hooandee.colores.audio.AudioCaptureStatus
+import com.hooandee.colores.device.LedGridCell
+import com.hooandee.colores.control.AppMode
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.cancel
 import kotlinx.coroutines.launch
 
 class EffectsService : Service() {
+    private val serviceScope = CoroutineScope(SupervisorJob() + Dispatchers.Main.immediate)
     private var projection: MediaProjection? = null
     private var projectionCallback: MediaProjection.Callback? = null
-    private var audioForegroundActive = false
+    private var projectionOwner: ProjectionOwner? = null
+
+    override fun onCreate() {
+        super.onCreate()
+        serviceScope.launch {
+            application.lightingController.snapshot.collect { snapshot ->
+                when {
+                    projectionOwner == ProjectionOwner.AUDIO && snapshot.mode != AppMode.AUDIO ->
+                        stopAudioCapture(AudioCaptureStatus.AUTHORIZATION_REQUIRED, reconcile = false)
+                    projectionOwner == ProjectionOwner.AMBIENT && snapshot.mode != AppMode.AMBIENT ->
+                        stopAmbientCapture(AmbientCaptureStatus.AUTHORIZATION_REQUIRED, reconcile = false)
+                }
+            }
+        }
+    }
 
     override fun onBind(intent: Intent?): IBinder? = null
 
@@ -46,19 +70,27 @@ class EffectsService : Service() {
                 startForegroundCompat(mediaProjection = false)
                 stopAudioCapture(intent.audioStopStatus(), reconcile = policy.reconcileController)
             }
+            EffectsServiceCommand.START_AMBIENT -> startAmbientCapture(requireNotNull(intent))
+            EffectsServiceCommand.STOP_AMBIENT -> {
+                requireNotNull(intent)
+                startForegroundCompat(mediaProjection = false)
+                stopAmbientCapture(intent.ambientStopStatus(), reconcile = policy.reconcileController)
+            }
+            EffectsServiceCommand.UPDATE_AMBIENT -> intent?.ambientConfig()?.let(application.ambientCaptureSession::updateConfig)
             EffectsServiceCommand.RESTORE -> {
                 startForegroundCompat(mediaProjection = false)
                 application.applicationScope.launch {
                     if (!application.restoreRuntime()) stopSelf(startId)
                 }
             }
-            EffectsServiceCommand.KEEP_ALIVE -> startForegroundCompat(mediaProjection = audioForegroundActive)
+            EffectsServiceCommand.KEEP_ALIVE -> startForegroundCompat(mediaProjection = projectionOwner != null)
         }
         return START_STICKY
     }
 
     override fun onTimeout(startId: Int) {
         stopAudioCapture(AudioCaptureStatus.AUTHORIZATION_REQUIRED)
+        stopAmbientCapture(AmbientCaptureStatus.AUTHORIZATION_REQUIRED)
         stopSelf()
     }
 
@@ -69,6 +101,12 @@ class EffectsService : Service() {
                 ?: AudioCaptureStatus.AUTHORIZATION_REQUIRED
         Log.i(TAG, "destroy status=$terminalStatus")
         stopAudioCapture(terminalStatus, reconcile = false)
+        val ambientStatus = application.ambientFrameSource.state.value.status
+        val ambientTerminal =
+            ambientStatus.takeIf { it == AmbientCaptureStatus.ERROR || it == AmbientCaptureStatus.REVOKED }
+                ?: AmbientCaptureStatus.AUTHORIZATION_REQUIRED
+        stopAmbientCapture(ambientTerminal, reconcile = false)
+        serviceScope.cancel()
         application.effectsServiceGate.onServiceStopped()
         super.onDestroy()
     }
@@ -86,8 +124,8 @@ class EffectsService : Service() {
     }
 
     private fun startAudioCapture(intent: Intent) {
+        stopAmbientCapture(AmbientCaptureStatus.AUTHORIZATION_REQUIRED)
         stopAudioCapture(AudioCaptureStatus.STARTING)
-        audioForegroundActive = true
         startForegroundCompat(mediaProjection = true)
         val resultData = intent.projectionData()
         if (resultData == null || intent.getIntExtra(EXTRA_RESULT_CODE, Activity.RESULT_CANCELED) != Activity.RESULT_OK) {
@@ -100,11 +138,14 @@ class EffectsService : Service() {
             val callback =
                 object : MediaProjection.Callback() {
                     override fun onStop() {
-                        stopAudioCapture(AudioCaptureStatus.REVOKED, stopProjection = false)
-                        stopSelf()
+                        if (projection === active && projectionOwner == ProjectionOwner.AUDIO) {
+                            stopAudioCapture(AudioCaptureStatus.REVOKED, stopProjection = false)
+                            stopSelf()
+                        }
                     }
                 }
             active.registerCallback(callback, Handler(Looper.getMainLooper()))
+            projectionOwner = ProjectionOwner.AUDIO
             projection = active
             projectionCallback = callback
             application.audioCaptureSession.start(AndroidPlaybackCapture(this, active)) { error ->
@@ -126,16 +167,77 @@ class EffectsService : Service() {
         reconcile: Boolean = true,
     ) {
         Log.i(TAG, "stop audio status=$status projection=${projection != null}")
-        audioForegroundActive = false
         application.audioCaptureSession.stop(status)
-        val active = projection
-        val callback = projectionCallback
-        projection = null
-        projectionCallback = null
-        if (active != null && callback != null) runCatching { active.unregisterCallback(callback) }
-        if (stopProjection) runCatching { active?.stop() }
+        if (projectionOwner == ProjectionOwner.AUDIO) {
+            val active = projection
+            val callback = projectionCallback
+            projection = null
+            projectionCallback = null
+            projectionOwner = null
+            if (active != null && callback != null) runCatching { active.unregisterCallback(callback) }
+            if (stopProjection) runCatching { active?.stop() }
+        }
         if (shouldReconcileAudioController(reconcile, application.lightingController.snapshot.value.mode)) {
             application.lightingController.onAudioStateChanged()
+        }
+    }
+
+    private fun startAmbientCapture(intent: Intent) {
+        stopAudioCapture(AudioCaptureStatus.AUTHORIZATION_REQUIRED)
+        stopAmbientCapture(AmbientCaptureStatus.STARTING)
+        startForegroundCompat(mediaProjection = true)
+        val resultData = intent.projectionData()
+        val config = intent.ambientConfig()
+        if (resultData == null || config == null || intent.getIntExtra(EXTRA_RESULT_CODE, Activity.RESULT_CANCELED) != Activity.RESULT_OK) {
+            stopAmbientCapture(AmbientCaptureStatus.AUTHORIZATION_REQUIRED)
+            return
+        }
+        runCatching {
+            val manager = getSystemService(Context.MEDIA_PROJECTION_SERVICE) as MediaProjectionManager
+            val active = manager.getMediaProjection(Activity.RESULT_OK, resultData) ?: error("MediaProjection unavailable")
+            val callback =
+                object : MediaProjection.Callback() {
+                    override fun onStop() {
+                        if (projection === active && projectionOwner == ProjectionOwner.AMBIENT) {
+                            stopAmbientCapture(AmbientCaptureStatus.REVOKED, stopProjection = false)
+                            stopSelf()
+                        }
+                    }
+                }
+            active.registerCallback(callback, Handler(Looper.getMainLooper()))
+            projectionOwner = ProjectionOwner.AMBIENT
+            projection = active
+            projectionCallback = callback
+            application.ambientCaptureSession.start(active, config) { error ->
+                Log.e(TAG, "ambient capture failed", error)
+                stopAmbientCapture(AmbientCaptureStatus.ERROR)
+                stopSelf()
+            }
+            Log.i(TAG, "ambient capture started fps=${config.captureFps} mode=${config.samplingMode}")
+        }.onFailure {
+            Log.e(TAG, "ambient capture setup failed", it)
+            stopAmbientCapture(AmbientCaptureStatus.ERROR)
+            stopSelf()
+        }
+    }
+
+    private fun stopAmbientCapture(
+        status: AmbientCaptureStatus,
+        stopProjection: Boolean = true,
+        reconcile: Boolean = true,
+    ) {
+        application.ambientCaptureSession.stop(status)
+        if (projectionOwner == ProjectionOwner.AMBIENT) {
+            val active = projection
+            val callback = projectionCallback
+            projection = null
+            projectionCallback = null
+            projectionOwner = null
+            if (active != null && callback != null) runCatching { active.unregisterCallback(callback) }
+            if (stopProjection) runCatching { active?.stop() }
+        }
+        if (shouldReconcileAmbientController(reconcile, application.lightingController.snapshot.value.mode)) {
+            application.lightingController.onAmbientStateChanged()
         }
     }
 
@@ -178,6 +280,13 @@ class EffectsService : Service() {
         private const val EXTRA_RESULT_CODE = "result_code"
         private const val EXTRA_PROJECTION_DATA = "projection_data"
         private const val EXTRA_STOP_STATUS = "stop_status"
+        private const val EXTRA_CAPTURE_FPS = "capture_fps"
+        private const val EXTRA_SAMPLING_MODE = "sampling_mode"
+        private const val EXTRA_ZONES = "zones"
+        private const val EXTRA_PER_ZONE = "per_zone"
+        private const val EXTRA_GRID_STICKS = "grid_sticks"
+        private const val EXTRA_GRID_ROWS = "grid_rows"
+        private const val EXTRA_GRID_COLUMNS = "grid_columns"
         private const val CHANNEL_ID = "colores_effects"
         private const val NOTIFICATION_ID = 1001
         private const val TAG = "ColoresEffects"
@@ -208,6 +317,39 @@ class EffectsService : Service() {
             )
         }
 
+        fun startAmbient(
+            context: Context,
+            resultCode: Int,
+            resultData: Intent,
+            config: AmbientCaptureConfig,
+        ) {
+            startService(
+                context,
+                ambientIntent(context, ACTION_START_AMBIENT, config)
+                    .putExtra(EXTRA_RESULT_CODE, resultCode)
+                    .putExtra(EXTRA_PROJECTION_DATA, resultData),
+            )
+        }
+
+        fun updateAmbient(
+            context: Context,
+            config: AmbientCaptureConfig,
+        ) {
+            startService(context, ambientIntent(context, ACTION_UPDATE_AMBIENT, config))
+        }
+
+        fun stopAmbient(
+            context: Context,
+            status: AmbientCaptureStatus = AmbientCaptureStatus.AUTHORIZATION_REQUIRED,
+        ) {
+            startService(
+                context,
+                Intent(context, EffectsService::class.java)
+                    .setAction(ACTION_STOP_AMBIENT)
+                    .putExtra(EXTRA_STOP_STATUS, status.name),
+            )
+        }
+
         fun restore(context: Context) {
             startService(context, Intent(context, EffectsService::class.java).setAction(ACTION_RESTORE))
         }
@@ -220,6 +362,23 @@ class EffectsService : Service() {
             } else {
                 context.startService(intent)
             }
+        }
+
+        private fun ambientIntent(
+            context: Context,
+            action: String,
+            config: AmbientCaptureConfig,
+        ): Intent {
+            val grid = config.gridLayout
+            return Intent(context, EffectsService::class.java)
+                .setAction(action)
+                .putExtra(EXTRA_CAPTURE_FPS, config.captureFps)
+                .putExtra(EXTRA_SAMPLING_MODE, config.samplingMode.name)
+                .putExtra(EXTRA_ZONES, config.zones)
+                .putExtra(EXTRA_PER_ZONE, config.supportsPerZone)
+                .putExtra(EXTRA_GRID_STICKS, grid?.map { it.stick ?: -1 }?.toIntArray())
+                .putExtra(EXTRA_GRID_ROWS, grid?.map { it.row }?.toIntArray())
+                .putExtra(EXTRA_GRID_COLUMNS, grid?.map { it.col }?.toIntArray())
         }
     }
 
@@ -237,4 +396,38 @@ class EffectsService : Service() {
     private fun Intent.audioStopStatus(): AudioCaptureStatus =
         runCatching { AudioCaptureStatus.valueOf(getStringExtra(EXTRA_STOP_STATUS).orEmpty()) }
             .getOrDefault(AudioCaptureStatus.AUTHORIZATION_REQUIRED)
+
+    private fun Intent.ambientStopStatus(): AmbientCaptureStatus =
+        runCatching { AmbientCaptureStatus.valueOf(getStringExtra(EXTRA_STOP_STATUS).orEmpty()) }
+            .getOrDefault(AmbientCaptureStatus.AUTHORIZATION_REQUIRED)
+
+    private fun Intent.ambientConfig(): AmbientCaptureConfig? {
+        val zones = getIntExtra(EXTRA_ZONES, 0)
+        if (zones <= 0) return null
+        val sticks = getIntArrayExtra(EXTRA_GRID_STICKS)
+        val rows = getIntArrayExtra(EXTRA_GRID_ROWS)
+        val columns = getIntArrayExtra(EXTRA_GRID_COLUMNS)
+        val grid =
+            if (sticks?.size == zones && rows?.size == zones && columns?.size == zones) {
+                List(zones) { index ->
+                    LedGridCell(sticks[index].takeIf { it >= 0 }, rows[index], columns[index], position = null)
+                }
+            } else {
+                null
+            }
+        return AmbientCaptureConfig(
+            zones = zones,
+            gridLayout = grid,
+            supportsPerZone = getBooleanExtra(EXTRA_PER_ZONE, false),
+            captureFps = getIntExtra(EXTRA_CAPTURE_FPS, 10),
+            samplingMode =
+                runCatching { AmbientSamplingMode.valueOf(getStringExtra(EXTRA_SAMPLING_MODE).orEmpty()) }
+                    .getOrDefault(AmbientSamplingMode.FULL_SCENE),
+        )
+    }
+
+    private enum class ProjectionOwner {
+        AUDIO,
+        AMBIENT,
+    }
 }

--- a/android/app/src/main/java/com/hooandee/colores/effects/EffectsServiceProtocol.kt
+++ b/android/app/src/main/java/com/hooandee/colores/effects/EffectsServiceProtocol.kt
@@ -4,11 +4,17 @@ import com.hooandee.colores.control.AppMode
 
 internal const val ACTION_START_AUDIO = "com.hooandee.colores.action.START_AUDIO"
 internal const val ACTION_STOP_AUDIO = "com.hooandee.colores.action.STOP_AUDIO"
+internal const val ACTION_START_AMBIENT = "com.hooandee.colores.action.START_AMBIENT"
+internal const val ACTION_STOP_AMBIENT = "com.hooandee.colores.action.STOP_AMBIENT"
+internal const val ACTION_UPDATE_AMBIENT = "com.hooandee.colores.action.UPDATE_AMBIENT"
 internal const val ACTION_RESTORE = "com.hooandee.colores.action.RESTORE"
 
 internal enum class EffectsServiceCommand {
     START_AUDIO,
     STOP_AUDIO,
+    START_AMBIENT,
+    STOP_AMBIENT,
+    UPDATE_AMBIENT,
     RESTORE,
     KEEP_ALIVE,
 }
@@ -26,18 +32,27 @@ internal data class EffectsServiceCommandPolicy(
 internal fun effectsServiceCommandPolicy(command: EffectsServiceCommand): EffectsServiceCommandPolicy =
     EffectsServiceCommandPolicy(
         startMode =
-            if (command == EffectsServiceCommand.STOP_AUDIO) {
+            if (
+                command == EffectsServiceCommand.STOP_AUDIO ||
+                    command == EffectsServiceCommand.STOP_AMBIENT ||
+                    command == EffectsServiceCommand.UPDATE_AMBIENT
+            ) {
                 EffectsServiceStartMode.REGULAR
             } else {
                 EffectsServiceStartMode.FOREGROUND
             },
-        reconcileController = command == EffectsServiceCommand.STOP_AUDIO,
+        reconcileController = command == EffectsServiceCommand.STOP_AUDIO || command == EffectsServiceCommand.STOP_AMBIENT,
     )
 
 internal fun shouldReconcileAudioController(
     requested: Boolean,
     mode: AppMode,
 ): Boolean = requested && mode == AppMode.AUDIO
+
+internal fun shouldReconcileAmbientController(
+    requested: Boolean,
+    mode: AppMode,
+): Boolean = requested && mode == AppMode.AMBIENT
 
 internal fun resolveEffectsServiceCommand(
     intentPresent: Boolean,
@@ -47,6 +62,9 @@ internal fun resolveEffectsServiceCommand(
         !intentPresent -> EffectsServiceCommand.RESTORE
         action == ACTION_START_AUDIO -> EffectsServiceCommand.START_AUDIO
         action == ACTION_STOP_AUDIO -> EffectsServiceCommand.STOP_AUDIO
+        action == ACTION_START_AMBIENT -> EffectsServiceCommand.START_AMBIENT
+        action == ACTION_STOP_AMBIENT -> EffectsServiceCommand.STOP_AMBIENT
+        action == ACTION_UPDATE_AMBIENT -> EffectsServiceCommand.UPDATE_AMBIENT
         action == ACTION_RESTORE -> EffectsServiceCommand.RESTORE
         else -> EffectsServiceCommand.KEEP_ALIVE
     }

--- a/android/app/src/main/java/com/hooandee/colores/engine/Renderer.kt
+++ b/android/app/src/main/java/com/hooandee/colores/engine/Renderer.kt
@@ -1,5 +1,8 @@
 package com.hooandee.colores.engine
 
+import com.hooandee.colores.ambient.AmbientCaptureStatus
+import com.hooandee.colores.ambient.AmbientColorMath
+import com.hooandee.colores.ambient.AmbientFrameState
 import com.hooandee.colores.engine.FrameMath.breatheFactor
 import com.hooandee.colores.engine.FrameMath.clamp8
 import com.hooandee.colores.engine.FrameMath.lerp
@@ -13,6 +16,43 @@ data class RenderTick(
 
 interface Renderer {
     fun render(nowSeconds: Double): RenderTick
+}
+
+class AmbientRenderer(
+    private val zones: Int,
+    private val frameIntervalMs: Long,
+    private val vividness: () -> Int,
+    private val smoothing: () -> Int,
+    private val state: () -> AmbientFrameState,
+) : Renderer {
+    private var displayed: List<RgbColor>? = null
+    private var lastSeconds: Double? = null
+
+    override fun render(nowSeconds: Double): RenderTick {
+        val snapshot = state()
+        val target =
+            if (snapshot.status == AmbientCaptureStatus.CAPTURING && snapshot.colors.isNotEmpty()) {
+                snapshot.colors.fit(zones).map { AmbientColorMath.vivid(it, vividness()) }
+            } else {
+                displayed ?: List(zones) { RgbColor(0, 0, 0) }
+            }
+        val previous = displayed
+        val elapsedMs = lastSeconds?.let { ((nowSeconds - it).coerceAtLeast(0.0) * 1_000).toLong() } ?: 0L
+        val frame =
+            if (previous == null) {
+                target
+            } else {
+                previous.zip(target) { current, next -> AmbientColorMath.smooth(current, next, smoothing(), elapsedMs) }
+            }
+        displayed = frame
+        lastSeconds = nowSeconds
+        return RenderTick(frame, frameIntervalMs)
+    }
+
+    private fun List<RgbColor>.fit(count: Int): List<RgbColor> {
+        val fallback = firstOrNull() ?: RgbColor(0, 0, 0)
+        return List(count.coerceAtLeast(1)) { getOrNull(it) ?: fallback }
+    }
 }
 
 data class EffectPalette(

--- a/android/app/src/main/java/com/hooandee/colores/report/ReportBundle.kt
+++ b/android/app/src/main/java/com/hooandee/colores/report/ReportBundle.kt
@@ -26,6 +26,9 @@ data class AndroidReportSnapshot(
     val power: Boolean,
     val configuredProfiles: Int,
     val automationStatus: String,
+    val ambientStatus: String? = null,
+    val ambientCaptureFps: Int? = null,
+    val ambientSamplingMode: String? = null,
 )
 
 sealed interface ReportResult {
@@ -85,7 +88,14 @@ fun buildReportBundle(
                 .put("mode", snapshot.mode)
                 .put("brightness", snapshot.brightnessValue)
                 .put("power", snapshot.power)
-                .put("automation_status", snapshot.automationStatus),
+                .put("automation_status", snapshot.automationStatus)
+                .put(
+                    "ambient",
+                    JSONObject()
+                        .put("status", snapshot.ambientStatus)
+                        .put("capture_fps", snapshot.ambientCaptureFps)
+                        .put("sampling_mode", snapshot.ambientSamplingMode),
+                ),
         ).put("stores", JSONObject().put("profiles_configured", snapshot.configuredProfiles))
         .put("logs", JSONArray())
         .put("kernel", JSONObject())

--- a/android/app/src/main/java/com/hooandee/colores/ui/ColoresScreen.kt
+++ b/android/app/src/main/java/com/hooandee/colores/ui/ColoresScreen.kt
@@ -17,6 +17,7 @@ fun ColoresScreen(
     viewModel: ColoresViewModel,
     onGrantPermission: () -> Unit,
     onAudioCaptureRequest: () -> Unit,
+    onAmbientCaptureRequest: () -> Unit,
     onGrantUsage: () -> Unit,
     appearance: AppAppearance,
     onThemeModeChange: (ThemeMode) -> Unit,
@@ -80,6 +81,11 @@ fun ColoresScreen(
                 onAudioScaleChange = viewModel::setAudioScale,
                 onAudioSensitivityChange = viewModel::setAudioSensitivity,
                 onAudioCaptureRequest = onAudioCaptureRequest,
+                onAmbientCaptureRequest = onAmbientCaptureRequest,
+                onAmbientCaptureFpsChange = viewModel::setAmbientCaptureFps,
+                onAmbientSamplingModeChange = viewModel::setAmbientSamplingMode,
+                onAmbientVividnessChange = viewModel::setAmbientVividness,
+                onAmbientSmoothingChange = viewModel::setAmbientSmoothing,
             ),
     )
     if (state.profilePickerOpen) {

--- a/android/app/src/main/java/com/hooandee/colores/ui/ColoresViewModel.kt
+++ b/android/app/src/main/java/com/hooandee/colores/ui/ColoresViewModel.kt
@@ -3,6 +3,13 @@ package com.hooandee.colores.ui
 import android.app.Application
 import android.content.Intent
 import android.os.Build
+import com.hooandee.colores.ambient.AmbientCaptureConfig
+import com.hooandee.colores.ambient.AmbientCaptureStatus
+import com.hooandee.colores.ambient.AmbientFrameState
+import com.hooandee.colores.ambient.AmbientSamplingMode
+import com.hooandee.colores.ambient.keepsCaptureActive
+import com.hooandee.colores.ambient.needsAuthorization
+import com.hooandee.colores.ambient.normalizedAmbientCaptureFps
 import androidx.lifecycle.AndroidViewModel
 import androidx.lifecycle.viewModelScope
 import com.hooandee.colores.ColoresApplication
@@ -106,6 +113,11 @@ data class ColoresUiState(
     val audio: AudioLevelState = AudioLevelState(),
     val audioScale: AudioScale = AudioScale.DEFAULT,
     val audioSensitivityDb: Int = AudioSensitivity.NORMAL_DB,
+    val ambient: AmbientFrameState = AmbientFrameState(),
+    val ambientCaptureFps: Int = 10,
+    val ambientSamplingMode: AmbientSamplingMode = AmbientSamplingMode.FULL_SCENE,
+    val ambientVividness: Int = 35,
+    val ambientSmoothing: Int = 45,
     val profileScope: ProfileScope = ProfileScope.Global,
     val profileApps: List<LaunchableApp> = emptyList(),
     val configuredProfiles: List<ConfiguredProfile> = emptyList(),
@@ -138,6 +150,9 @@ data class ColoresUiState(
             audio.status == AudioCaptureStatus.AUTHORIZATION_REQUIRED ||
                 audio.status == AudioCaptureStatus.REVOKED ||
                 audio.status == AudioCaptureStatus.ERROR
+
+    val ambientNeedsAuthorization: Boolean
+        get() = ambient.status.needsAuthorization
 
     val currentEffect: EffectPreset?
         get() = effects.firstOrNull { it.id == effectId }
@@ -183,6 +198,7 @@ data class ColoresUiState(
             if (sensorsAvailable) add(AppMode.BATTERY)
             if (colorEnabled) add(AppMode.CLOCK)
             if (colorEnabled) add(AppMode.AUDIO)
+            if (colorEnabled) add(AppMode.AMBIENT)
         }
 
     fun availableSensorModes(): List<AppMode> =
@@ -237,6 +253,9 @@ class ColoresViewModel(
                         audio = snap.audio,
                         audioScale = snap.audioScale,
                         audioSensitivityDb = snap.audioSensitivityDb,
+                        ambient = snap.ambient,
+                        ambientVividness = snap.ambientVividness,
+                        ambientSmoothing = snap.ambientSmoothing,
                         ledState = current.ledState.copy(power = snap.powerRequested, brightness = snap.brightness),
                     )
                 }
@@ -386,6 +405,7 @@ class ColoresViewModel(
                             temperature = SysfsThermalSource().takeIf { it.available },
                             performance = PerformanceSources.detect(),
                             audio = coloresApplication.audioLevelSource,
+                            ambient = coloresApplication.ambientFrameSource,
                         ),
                         LightingIntent(
                             mode = selectedProfile.mode.coerceAvailable(gradientSupported),
@@ -407,6 +427,8 @@ class ColoresViewModel(
                             temperatureBreathe = selectedProfile.temperatureBreathe,
                             audioScale = storedLighting.audioScale,
                             audioSensitivityDb = storedLighting.audioSensitivityDb,
+                            ambientVividness = storedLighting.ambientVividness,
+                            ambientSmoothing = storedLighting.ambientSmoothing,
                         ),
                     )
                 }
@@ -445,6 +467,10 @@ class ColoresViewModel(
                         sensorBands = storedLighting.sensorBands,
                         audioScale = storedLighting.audioScale,
                         audioSensitivityDb = storedLighting.audioSensitivityDb,
+                        ambientCaptureFps = storedLighting.ambientCaptureFps,
+                        ambientSamplingMode = storedLighting.ambientSamplingMode,
+                        ambientVividness = storedLighting.ambientVividness,
+                        ambientSmoothing = storedLighting.ambientSmoothing,
                         profileApps = apps,
                         configuredProfiles = configuredProfiles,
                         profileScopeState = scopeState,
@@ -520,6 +546,9 @@ class ColoresViewModel(
                 power = current.ledState.power,
                 configuredProfiles = current.configuredProfiles.size,
                 automationStatus = current.automationStatus.name.lowercase(),
+                ambientStatus = current.ambient.status.name.lowercase(),
+                ambientCaptureFps = current.ambientCaptureFps,
+                ambientSamplingMode = current.ambientSamplingMode.name.lowercase(),
             )
         mutableState.update { it.copy(reportSubmission = ReportSubmissionState(sending = true)) }
         viewModelScope.launch {
@@ -610,10 +639,13 @@ class ColoresViewModel(
                 mode
             }
         if (target == current.mode && target == current.profileStoredMode) return
-        if (target == AppMode.AUDIO) return
+        if (target == AppMode.AUDIO || target == AppMode.AMBIENT) return
         if (target == AppMode.GRADIENT && !current.gradientAvailable) return
         if (current.mode == AppMode.AUDIO) {
             EffectsService.stopAudio(getApplication(), AudioCaptureStatus.AUTHORIZATION_REQUIRED)
+        }
+        if (current.mode == AppMode.AMBIENT) {
+            EffectsService.stopAmbient(getApplication(), AmbientCaptureStatus.AUTHORIZATION_REQUIRED)
         }
         when (target) {
             AppMode.GRADIENT -> updateGradient(current.gradient.copy(mode = LightingMode.GRADIENT), apply = false)
@@ -683,8 +715,12 @@ class ColoresViewModel(
     }
 
     fun setPower(power: Boolean) {
-        if (!power && mutableState.value.mode == AppMode.AUDIO) {
-            EffectsService.stopAudio(getApplication(), AudioCaptureStatus.AUTHORIZATION_REQUIRED)
+        if (!power) {
+            when (mutableState.value.mode) {
+                AppMode.AUDIO -> EffectsService.stopAudio(getApplication(), AudioCaptureStatus.AUTHORIZATION_REQUIRED)
+                AppMode.AMBIENT -> EffectsService.stopAmbient(getApplication(), AmbientCaptureStatus.AUTHORIZATION_REQUIRED)
+                else -> Unit
+            }
         }
         controller.setPower(power)
         mutableState.update { it.copy(ledState = it.ledState.copy(power = power)) }
@@ -697,16 +733,79 @@ class ColoresViewModel(
     ) {
         val current = mutableState.value
         if (!current.canWrite || !current.colorEnabled) return
-        EffectsService.startAudio(getApplication(), resultCode, resultData)
+        EffectsService.stopAmbient(getApplication(), AmbientCaptureStatus.AUTHORIZATION_REQUIRED)
         coloresApplication.audioLevelSource.reset(AudioCaptureStatus.STARTING)
         controller.setMode(AppMode.AUDIO)
-        mutableState.update { it.copy(mode = AppMode.AUDIO, audio = AudioLevelState(status = AudioCaptureStatus.STARTING)) }
+        mutableState.update {
+            it.copy(
+                mode = AppMode.AUDIO,
+                profileStoredMode = AppMode.AUDIO,
+                audio = AudioLevelState(status = AudioCaptureStatus.STARTING),
+            )
+        }
+        EffectsService.startAudio(getApplication(), resultCode, resultData)
         persistLighting()
     }
 
     fun onAudioAuthorizationDenied() {
         coloresApplication.audioLevelSource.reset(AudioCaptureStatus.AUTHORIZATION_REQUIRED)
         mutableState.update { it.copy(audio = AudioLevelState(status = AudioCaptureStatus.AUTHORIZATION_REQUIRED)) }
+    }
+
+    fun activateAmbient(
+        resultCode: Int,
+        resultData: Intent,
+    ) {
+        val current = mutableState.value
+        if (current.detected == null) return
+        if (!current.canWrite || !current.colorEnabled) return
+        EffectsService.stopAudio(getApplication(), AudioCaptureStatus.AUTHORIZATION_REQUIRED)
+        val config = current.ambientCaptureConfig() ?: return
+        coloresApplication.ambientFrameSource.reset(AmbientCaptureStatus.STARTING)
+        controller.setMode(AppMode.AMBIENT)
+        mutableState.update {
+            it.copy(
+                mode = AppMode.AMBIENT,
+                profileStoredMode = AppMode.AMBIENT,
+                ambient = AmbientFrameState(status = AmbientCaptureStatus.STARTING),
+            )
+        }
+        EffectsService.startAmbient(getApplication(), resultCode, resultData, config)
+        persistLighting()
+    }
+
+    fun onAmbientAuthorizationDenied() {
+        coloresApplication.ambientFrameSource.reset(AmbientCaptureStatus.AUTHORIZATION_REQUIRED)
+        mutableState.update {
+            it.copy(ambient = AmbientFrameState(status = AmbientCaptureStatus.AUTHORIZATION_REQUIRED))
+        }
+    }
+
+    fun setAmbientCaptureFps(value: Int) {
+        val fps = value.normalizedAmbientCaptureFps()
+        mutableState.update { it.copy(ambientCaptureFps = fps) }
+        updateActiveAmbientConfig()
+        persistGlobalModifiers()
+    }
+
+    fun setAmbientSamplingMode(mode: AmbientSamplingMode) {
+        mutableState.update { it.copy(ambientSamplingMode = mode) }
+        updateActiveAmbientConfig()
+        persistGlobalModifiers()
+    }
+
+    fun setAmbientVividness(value: Int) {
+        val clamped = value.coerceIn(0, 100)
+        controller.setAmbientVividness(clamped)
+        mutableState.update { it.copy(ambientVividness = clamped) }
+        persistGlobalModifiers()
+    }
+
+    fun setAmbientSmoothing(value: Int) {
+        val clamped = value.coerceIn(0, 100)
+        controller.setAmbientSmoothing(clamped)
+        mutableState.update { it.copy(ambientSmoothing = clamped) }
+        persistGlobalModifiers()
     }
 
     fun setBrightness(brightness: Int) {
@@ -968,9 +1067,23 @@ class ColoresViewModel(
                 temperatureBreathe = global.temperatureBreathe,
                 audioScale = current.audioScale,
                 audioSensitivityDb = current.audioSensitivityDb,
+                ambientCaptureFps = current.ambientCaptureFps,
+                ambientSamplingMode = current.ambientSamplingMode,
+                ambientVividness = current.ambientVividness,
+                ambientSmoothing = current.ambientSmoothing,
                 sensorBands = current.sensorBands,
             ),
         )
+    }
+
+    private fun updateActiveAmbientConfig() {
+        val current = mutableState.value
+        if (
+            current.mode == AppMode.AMBIENT &&
+            current.ambient.status.keepsCaptureActive
+        ) {
+            current.ambientCaptureConfig()?.let { EffectsService.updateAmbient(getApplication(), it) }
+        }
     }
 }
 
@@ -981,6 +1094,17 @@ private fun AppMode.coerceAvailable(gradientSupported: Boolean): AppMode =
 
 private fun ColoresUiState.gradientStopCount(): Int =
     gradientPresentation?.editorStopCount(detected?.capabilities?.zones ?: 2) ?: 2
+
+private fun ColoresUiState.ambientCaptureConfig(): AmbientCaptureConfig? {
+    val device = detected ?: return null
+    return AmbientCaptureConfig(
+        zones = device.capabilities.zones,
+        gridLayout = device.gridLayout,
+        supportsPerZone = device.capabilities.perZone,
+        captureFps = ambientCaptureFps,
+        samplingMode = ambientSamplingMode,
+    )
+}
 
 private fun android.content.Context.readAsset(name: String): String =
     assets.open(name).bufferedReader().use { it.readText() }

--- a/android/app/src/main/java/com/hooandee/colores/ui/DashboardScreen.kt
+++ b/android/app/src/main/java/com/hooandee/colores/ui/DashboardScreen.kt
@@ -235,7 +235,11 @@ private fun DashboardBody(
             selected = state.mode,
             enabled = state.canWrite,
             onModeChange = { mode ->
-                if (mode == AppMode.AUDIO) modeActions.onAudioCaptureRequest() else modeActions.onModeChange(mode)
+                when (mode) {
+                    AppMode.AUDIO -> modeActions.onAudioCaptureRequest()
+                    AppMode.AMBIENT -> modeActions.onAmbientCaptureRequest()
+                    else -> modeActions.onModeChange(mode)
+                }
             },
         )
         DashboardModeLayout(

--- a/android/app/src/main/java/com/hooandee/colores/ui/ModePanels.kt
+++ b/android/app/src/main/java/com/hooandee/colores/ui/ModePanels.kt
@@ -44,6 +44,8 @@ import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import com.hooandee.colores.R
+import com.hooandee.colores.ambient.AmbientCaptureStatus
+import com.hooandee.colores.ambient.AmbientSamplingMode
 import com.hooandee.colores.audio.AudioCaptureStatus
 import com.hooandee.colores.control.AppMode
 import com.hooandee.colores.engine.EffectNeed
@@ -67,6 +69,11 @@ data class ModeActions(
     val onAudioScaleChange: (AudioScale) -> Unit,
     val onAudioSensitivityChange: (Int) -> Unit,
     val onAudioCaptureRequest: () -> Unit,
+    val onAmbientCaptureRequest: () -> Unit,
+    val onAmbientCaptureFpsChange: (Int) -> Unit,
+    val onAmbientSamplingModeChange: (AmbientSamplingMode) -> Unit,
+    val onAmbientVividnessChange: (Int) -> Unit,
+    val onAmbientSmoothingChange: (Int) -> Unit,
 )
 
 @Composable
@@ -144,6 +151,10 @@ fun ModeControlPanel(
                     modeActions.onAudioScaleChange,
                     modeActions.onAudioSensitivityChange,
                 )
+            }
+        AppMode.AMBIENT ->
+            PanelSurface(modifier) {
+                AmbientPanel(state, onBrightnessChange, modeActions)
             }
     }
 }
@@ -588,6 +599,93 @@ private fun AudioPanel(
     }
 }
 
+@Composable
+private fun AmbientPanel(
+    state: ColoresUiState,
+    onBrightnessChange: (Int) -> Unit,
+    actions: ModeActions,
+) {
+    val status =
+        when (state.ambient.status) {
+            AmbientCaptureStatus.AUTHORIZATION_REQUIRED -> stringResource(R.string.ambient_status_authorization_required)
+            AmbientCaptureStatus.STARTING -> stringResource(R.string.ambient_status_starting)
+            AmbientCaptureStatus.CAPTURING -> stringResource(R.string.ambient_status_capturing)
+            AmbientCaptureStatus.NO_FRAMES -> stringResource(R.string.ambient_status_no_frames)
+            AmbientCaptureStatus.REVOKED -> stringResource(R.string.ambient_status_revoked)
+            AmbientCaptureStatus.ERROR -> stringResource(R.string.ambient_status_error)
+        }
+    ReadoutCard(
+        title = stringResource(R.string.ambient_title),
+        description = stringResource(R.string.ambient_description),
+        value = null,
+        detail = status,
+    )
+    Text(stringResource(R.string.ambient_sampling_title), style = MaterialTheme.typography.labelMedium)
+    SingleChoiceSegmentedButtonRow(Modifier.fillMaxWidth()) {
+        AmbientSamplingMode.entries.forEachIndexed { index, mode ->
+            SegmentedButton(
+                selected = state.ambientSamplingMode == mode,
+                onClick = { actions.onAmbientSamplingModeChange(mode) },
+                enabled = state.canWrite,
+                shape = SegmentedButtonDefaults.itemShape(index, AmbientSamplingMode.entries.size),
+            ) {
+                Text(
+                    if (mode == AmbientSamplingMode.FULL_SCENE) {
+                        stringResource(R.string.ambient_sampling_full)
+                    } else {
+                        stringResource(R.string.ambient_sampling_bottom)
+                    },
+                )
+            }
+        }
+    }
+    DeferredIntSlider(
+        label = stringResource(R.string.ambient_capture_rate),
+        committedValue = state.ambientCaptureFps,
+        valueLabel = { stringResource(R.string.ambient_capture_rate_value, it) },
+        onValueCommit = actions.onAmbientCaptureFpsChange,
+        valueRange = 5..30,
+        steps = 4,
+        enabled = state.canWrite,
+    )
+    Text(
+        stringResource(R.string.ambient_capture_rate_hint),
+        color = MaterialTheme.colorScheme.onSurfaceVariant,
+        style = MaterialTheme.typography.bodySmall,
+    )
+    DeferredIntSlider(
+        label = stringResource(R.string.ambient_vividness),
+        committedValue = state.ambientVividness,
+        valueLabel = { stringResource(R.string.percent_value, it) },
+        onValueCommit = actions.onAmbientVividnessChange,
+        valueRange = 0..100,
+        enabled = state.canWrite,
+    )
+    DeferredIntSlider(
+        label = stringResource(R.string.ambient_smoothing),
+        committedValue = state.ambientSmoothing,
+        valueLabel = { stringResource(R.string.percent_value, it) },
+        onValueCommit = actions.onAmbientSmoothingChange,
+        valueRange = 0..100,
+        enabled = state.canWrite,
+    )
+    Text(
+        stringResource(R.string.ambient_privacy),
+        color = MaterialTheme.colorScheme.onSurfaceVariant,
+        style = MaterialTheme.typography.bodySmall,
+    )
+    if (state.ambientNeedsAuthorization) {
+        OutlinedButton(
+            onClick = actions.onAmbientCaptureRequest,
+            enabled = state.canWrite && state.ledState.power,
+            modifier = Modifier.fillMaxWidth(),
+        ) {
+            Text(stringResource(R.string.ambient_activate))
+        }
+    }
+    BrightnessRow(state, onBrightnessChange)
+}
+
 private fun AudioScale.previewBrush(): Brush =
     Brush.horizontalGradient(
         0f to lowColor.toComposeColor(),
@@ -718,6 +816,7 @@ private fun navLabel(mode: AppMode): String =
         AppMode.BATTERY, AppMode.TEMPERATURE, AppMode.PERFORMANCE -> stringResource(R.string.nav_sensors)
         AppMode.CLOCK -> stringResource(R.string.nav_clock)
         AppMode.AUDIO -> stringResource(R.string.nav_audio)
+        AppMode.AMBIENT -> stringResource(R.string.nav_ambient)
     }
 
 @Composable

--- a/android/app/src/main/java/com/hooandee/colores/ui/SettingsScreen.kt
+++ b/android/app/src/main/java/com/hooandee/colores/ui/SettingsScreen.kt
@@ -280,6 +280,7 @@ private fun profileModeLabel(mode: AppMode): String =
         AppMode.PERFORMANCE -> stringResource(R.string.sensor_performance)
         AppMode.CLOCK -> stringResource(R.string.nav_clock)
         AppMode.AUDIO -> stringResource(R.string.nav_audio)
+        AppMode.AMBIENT -> stringResource(R.string.nav_ambient)
     }
 
 @Composable

--- a/android/app/src/main/res/values-en/strings.xml
+++ b/android/app/src/main/res/values-en/strings.xml
@@ -168,6 +168,7 @@
     <string name="nav_sensors">Sensors</string>
     <string name="nav_clock">Clock</string>
     <string name="nav_audio">Audio</string>
+    <string name="nav_ambient">Ambilight</string>
 
     <string name="effects_title">Effect</string>
     <string name="effect_speed">Speed</string>
@@ -266,6 +267,25 @@
     <string name="audio_status_no_audio">No internal audio detected. Playback may be silent or the source app may block capture.</string>
     <string name="audio_status_revoked">Android revoked capture. You can enable it again.</string>
     <string name="audio_status_error">Capture could not start. You can try again.</string>
+    <string name="ambient_title">Ambilight</string>
+    <string name="ambient_description">The LEDs follow scene colors without capturing at full resolution.</string>
+    <string name="ambient_sampling_title">Capture area</string>
+    <string name="ambient_sampling_full">Full scene</string>
+    <string name="ambient_sampling_bottom">Bottom edge</string>
+    <string name="ambient_capture_rate">Capture rate</string>
+    <string name="ambient_capture_rate_value">%1$d fps</string>
+    <string name="ambient_capture_rate_hint">10 fps is recommended for gaming. A higher rate responds sooner and uses more resources.</string>
+    <string name="ambient_vividness">Color intensity</string>
+    <string name="ambient_smoothing">Smoothing</string>
+    <string name="percent_value">%1$d%%</string>
+    <string name="ambient_privacy">The image is reduced to 32 × 18 and processed in memory. No capture is stored.</string>
+    <string name="ambient_activate">Enable screen capture</string>
+    <string name="ambient_status_authorization_required">Android authorization required</string>
+    <string name="ambient_status_starting">Starting capture</string>
+    <string name="ambient_status_capturing">Screen capture active</string>
+    <string name="ambient_status_no_frames">The screen is not providing frames. The last color is preserved.</string>
+    <string name="ambient_status_revoked">Android revoked capture. You can enable it again.</string>
+    <string name="ambient_status_error">Capture could not start. You can try again.</string>
 
     <string name="charger_only_title">Only while charging</string>
     <string name="charger_only_description">LEDs turn on only while the device is charging.</string>

--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -168,6 +168,7 @@
     <string name="nav_sensors">Sensores</string>
     <string name="nav_clock">Reloj</string>
     <string name="nav_audio">Audio</string>
+    <string name="nav_ambient">Ambilight</string>
 
     <string name="effects_title">Efecto</string>
     <string name="effect_speed">Velocidad</string>
@@ -266,6 +267,25 @@
     <string name="audio_status_no_audio">Sin audio interno detectable. Puede haber silencio o la aplicación puede impedir la captura.</string>
     <string name="audio_status_revoked">Android ha revocado la captura. Puedes activarla de nuevo.</string>
     <string name="audio_status_error">No se pudo iniciar la captura. Puedes intentarlo de nuevo.</string>
+    <string name="ambient_title">Ambilight</string>
+    <string name="ambient_description">Los LEDs siguen los colores de la escena sin capturar a resolución completa.</string>
+    <string name="ambient_sampling_title">Zona de captura</string>
+    <string name="ambient_sampling_full">Escena completa</string>
+    <string name="ambient_sampling_bottom">Borde inferior</string>
+    <string name="ambient_capture_rate">Frecuencia de captura</string>
+    <string name="ambient_capture_rate_value">%1$d fps</string>
+    <string name="ambient_capture_rate_hint">10 fps es el valor recomendado para jugar. Una frecuencia mayor responde antes y consume más recursos.</string>
+    <string name="ambient_vividness">Intensidad de color</string>
+    <string name="ambient_smoothing">Suavizado</string>
+    <string name="percent_value">%1$d%%</string>
+    <string name="ambient_privacy">La imagen se reduce a 32 × 18 y se procesa en memoria. No se guarda ninguna captura.</string>
+    <string name="ambient_activate">Activar captura de pantalla</string>
+    <string name="ambient_status_authorization_required">Necesita autorización de Android</string>
+    <string name="ambient_status_starting">Iniciando captura</string>
+    <string name="ambient_status_capturing">Captura de pantalla activa</string>
+    <string name="ambient_status_no_frames">La pantalla no está entregando imágenes. Se conserva el último color.</string>
+    <string name="ambient_status_revoked">Android ha revocado la captura. Puedes activarla de nuevo.</string>
+    <string name="ambient_status_error">No se pudo iniciar la captura. Puedes intentarlo de nuevo.</string>
 
     <string name="charger_only_title">Solo mientras carga</string>
     <string name="charger_only_description">Los LEDs se encienden solo cuando el dispositivo está cargando.</string>

--- a/android/app/src/test/java/com/hooandee/colores/ambient/AmbientSamplingTest.kt
+++ b/android/app/src/test/java/com/hooandee/colores/ambient/AmbientSamplingTest.kt
@@ -1,0 +1,150 @@
+package com.hooandee.colores.ambient
+
+import com.hooandee.colores.device.LedGridCell
+import com.hooandee.colores.led.RgbColor
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class AmbientSamplingTest {
+    @Test
+    fun `global sampling reads RGBA rows with padding and repeats the average`() {
+        val frame =
+            rgbaFrame(
+                rows =
+                    listOf(
+                        listOf(RgbColor(255, 0, 0), RgbColor(0, 255, 0)),
+                        listOf(RgbColor(0, 0, 255), RgbColor(255, 255, 255)),
+                    ),
+                rowPadding = 8,
+            )
+
+        val sampled =
+            AmbientSampler.sample(
+                frame = frame,
+                zones = 2,
+                gridLayout = null,
+                supportsPerZone = false,
+                mode = AmbientSamplingMode.FULL_SCENE,
+            )
+
+        assertEquals(List(2) { RgbColor(127, 127, 127) }, sampled)
+    }
+
+    @Test
+    fun `full scene maps each stick grid cell across the whole screen`() {
+        val colors =
+            listOf(
+                RgbColor(255, 0, 0),
+                RgbColor(255, 255, 0),
+                RgbColor(0, 255, 0),
+                RgbColor(0, 255, 255),
+                RgbColor(0, 0, 255),
+                RgbColor(255, 0, 255),
+                RgbColor(255, 255, 255),
+                RgbColor(0, 0, 0),
+            )
+        val frame =
+            rgbaFrame(
+                rows =
+                    listOf(
+                        listOf(colors[0], colors[1], colors[4], colors[5]),
+                        listOf(colors[2], colors[3], colors[6], colors[7]),
+                    ),
+            )
+        val layout =
+            listOf(
+                LedGridCell(0, 0, 0, "top_left"),
+                LedGridCell(0, 0, 1, "top_right"),
+                LedGridCell(0, 1, 0, "bottom_left"),
+                LedGridCell(0, 1, 1, "bottom_right"),
+                LedGridCell(1, 0, 0, "top_left"),
+                LedGridCell(1, 0, 1, "top_right"),
+                LedGridCell(1, 1, 0, "bottom_left"),
+                LedGridCell(1, 1, 1, "bottom_right"),
+            )
+
+        val sampled = AmbientSampler.sample(frame, 8, layout, true, AmbientSamplingMode.FULL_SCENE)
+
+        assertEquals(colors, sampled)
+    }
+
+    @Test
+    fun `bottom edge ignores the upper scene`() {
+        val frame =
+            rgbaFrame(
+                rows =
+                    listOf(
+                        List(4) { RgbColor(255, 0, 0) },
+                        List(4) { RgbColor(255, 0, 0) },
+                        List(4) { RgbColor(0, 0, 255) },
+                        List(4) { RgbColor(0, 0, 255) },
+                    ),
+            )
+        val layout = List(4) { index -> LedGridCell(index / 2, 0, index % 2, null) }
+
+        val sampled = AmbientSampler.sample(frame, 4, layout, true, AmbientSamplingMode.BOTTOM_EDGE)
+
+        assertEquals(List(4) { RgbColor(0, 0, 255) }, sampled)
+    }
+
+    @Test
+    fun `invalid frame degrades to black without reading outside its buffer`() {
+        val frame = AmbientPixelFrame(4, 4, pixelStride = 4, rowStride = 16, bytes = ByteArray(7))
+
+        assertEquals(
+            List(3) { RgbColor(0, 0, 0) },
+            AmbientSampler.sample(frame, 3, null, true, AmbientSamplingMode.FULL_SCENE),
+        )
+    }
+
+    @Test
+    fun `vividness matches Decky saturation mapping`() {
+        val base = RgbColor(140, 120, 100)
+
+        assertEquals(base, AmbientColorMath.vivid(base, 0))
+        val vivid = AmbientColorMath.vivid(base, 100)
+        assertTrue(vivid.red - vivid.blue > base.red - base.blue)
+    }
+
+    @Test
+    fun `time based smoothing is stable across capture rates`() {
+        val black = RgbColor(0, 0, 0)
+        val white = RgbColor(255, 255, 255)
+
+        val once = AmbientColorMath.smooth(black, white, smoothing = 75, elapsedMs = 100)
+        val half = AmbientColorMath.smooth(black, white, smoothing = 75, elapsedMs = 50)
+        val twice = AmbientColorMath.smooth(half, white, smoothing = 75, elapsedMs = 50)
+
+        assertTrue(kotlin.math.abs(once.red - twice.red) <= 1)
+        assertEquals(once.red, once.green)
+        assertEquals(once.green, once.blue)
+    }
+
+    @Test
+    fun `capture cadence drops excess frames without building a queue`() {
+        assertEquals(false, AmbientCaptureCadence.shouldProcess(lastFrameMs = 1_000, nowMs = 1_099, fps = 10))
+        assertEquals(true, AmbientCaptureCadence.shouldProcess(lastFrameMs = 1_000, nowMs = 1_100, fps = 10))
+        assertEquals(true, AmbientCaptureCadence.shouldProcess(lastFrameMs = 0, nowMs = 1, fps = 30))
+    }
+
+    private fun rgbaFrame(
+        rows: List<List<RgbColor>>,
+        rowPadding: Int = 0,
+    ): AmbientPixelFrame {
+        val height = rows.size
+        val width = rows.first().size
+        val rowStride = width * 4 + rowPadding
+        val bytes = ByteArray(rowStride * height)
+        rows.forEachIndexed { y, row ->
+            row.forEachIndexed { x, color ->
+                val offset = y * rowStride + x * 4
+                bytes[offset] = color.red.toByte()
+                bytes[offset + 1] = color.green.toByte()
+                bytes[offset + 2] = color.blue.toByte()
+                bytes[offset + 3] = 0xFF.toByte()
+            }
+        }
+        return AmbientPixelFrame(width, height, pixelStride = 4, rowStride = rowStride, bytes = bytes)
+    }
+}

--- a/android/app/src/test/java/com/hooandee/colores/control/LightingControllerTest.kt
+++ b/android/app/src/test/java/com/hooandee/colores/control/LightingControllerTest.kt
@@ -1,5 +1,8 @@
 package com.hooandee.colores.control
 
+import com.hooandee.colores.ambient.AmbientCaptureStatus
+import com.hooandee.colores.ambient.AmbientFrameSource
+import com.hooandee.colores.ambient.MutableAmbientFrameSource
 import com.hooandee.colores.audio.AudioCaptureStatus
 import com.hooandee.colores.audio.AudioLevelSource
 import com.hooandee.colores.audio.MutableAudioLevelSource
@@ -132,7 +135,31 @@ class LightingControllerTest {
         performance: PerformanceSource? = null,
         zones: Int = 2,
         audio: AudioLevelSource = MutableAudioLevelSource(),
-    ) = LightingBinding("dev", device, zones, catalog, bands, battery, temperature, performance, audio)
+        ambient: AmbientFrameSource = MutableAmbientFrameSource(),
+    ) = LightingBinding("dev", device, zones, catalog, bands, battery, temperature, performance, audio, ambient)
+
+    @Test
+    fun `ambient capture and led writes run at independent cadences`() =
+        runTest {
+            val device = FakeDevice(recommendedFrameIntervalMs = 80)
+            val gate = RecordingGate()
+            val ambient = MutableAmbientFrameSource().apply {
+                update(List(8) { RgbColor(it * 20, 10, 5) }, AmbientCaptureStatus.CAPTURING, 1L)
+            }
+            val controller = LightingController(backgroundScope, gate, clockMs = { testScheduler.currentTime })
+            controller.bind(
+                binding(device, zones = 8, ambient = ambient),
+                LightingIntent(mode = AppMode.AMBIENT, ambientSmoothing = 0, ambientVividness = 0),
+            )
+
+            advanceTimeBy(1_000)
+            runCurrent()
+
+            assertTrue(gate.running)
+            assertTrue(device.writes.size in 10..14)
+            assertEquals(ambient.state.value.colors, device.writes.last().colors)
+            assertEquals(AmbientCaptureStatus.CAPTURING, controller.snapshot.value.ambient.status)
+        }
 
     @Test
     fun `audio mode waits black without authorization and stops when leaving the mode`() =

--- a/android/app/src/test/java/com/hooandee/colores/control/LightingPreferencesTest.kt
+++ b/android/app/src/test/java/com/hooandee/colores/control/LightingPreferencesTest.kt
@@ -1,5 +1,6 @@
 package com.hooandee.colores.control
 
+import com.hooandee.colores.ambient.AmbientSamplingMode
 import com.hooandee.colores.engine.BandSet
 import com.hooandee.colores.engine.AudioScale
 import com.hooandee.colores.engine.SensorBand
@@ -37,6 +38,10 @@ class LightingPreferencesTest {
                         peakAt = 76,
                     ),
                 audioSensitivityDb = -7,
+                ambientCaptureFps = 30,
+                ambientSamplingMode = AmbientSamplingMode.BOTTOM_EDGE,
+                ambientVividness = 72,
+                ambientSmoothing = 18,
             )
         prefs.save("rp5", stored)
         assertEquals(stored, prefs.load("rp5"))
@@ -63,6 +68,19 @@ class LightingPreferencesTest {
         prefs.save("thor", StoredLighting(mode = AppMode.AUDIO))
 
         assertEquals(AppMode.AUDIO, prefs.load("thor").mode)
+    }
+
+    @Test
+    fun `invalid ambient options are clamped and keep ambient intent`() {
+        val raw = """{"mode":"AMBIENT","ambientCaptureFps":28,"ambientVividness":999,"ambientSmoothing":-4}"""
+        val prefs = LightingPreferences(read = { raw }, write = { _, _ -> })
+
+        val restored = prefs.load("thor")
+
+        assertEquals(AppMode.AMBIENT, restored.mode)
+        assertEquals(30, restored.ambientCaptureFps)
+        assertEquals(100, restored.ambientVividness)
+        assertEquals(0, restored.ambientSmoothing)
     }
 
     @Test

--- a/android/app/src/test/java/com/hooandee/colores/effects/EffectsServiceProtocolTest.kt
+++ b/android/app/src/test/java/com/hooandee/colores/effects/EffectsServiceProtocolTest.kt
@@ -23,6 +23,9 @@ class EffectsServiceProtocolTest {
     fun `explicit service actions keep their command`() {
         assertEquals(EffectsServiceCommand.START_AUDIO, resolveEffectsServiceCommand(true, ACTION_START_AUDIO))
         assertEquals(EffectsServiceCommand.STOP_AUDIO, resolveEffectsServiceCommand(true, ACTION_STOP_AUDIO))
+        assertEquals(EffectsServiceCommand.START_AMBIENT, resolveEffectsServiceCommand(true, ACTION_START_AMBIENT))
+        assertEquals(EffectsServiceCommand.STOP_AMBIENT, resolveEffectsServiceCommand(true, ACTION_STOP_AMBIENT))
+        assertEquals(EffectsServiceCommand.UPDATE_AMBIENT, resolveEffectsServiceCommand(true, ACTION_UPDATE_AMBIENT))
         assertEquals(EffectsServiceCommand.RESTORE, resolveEffectsServiceCommand(true, ACTION_RESTORE))
     }
 
@@ -39,5 +42,15 @@ class EffectsServiceProtocolTest {
         assertTrue(shouldReconcileAudioController(requested = true, mode = AppMode.AUDIO))
         assertFalse(shouldReconcileAudioController(requested = true, mode = AppMode.COLOR))
         assertFalse(shouldReconcileAudioController(requested = false, mode = AppMode.AUDIO))
+    }
+
+    @Test
+    fun `ambient stop uses a regular start and reconciles only ambient mode`() {
+        val policy = effectsServiceCommandPolicy(EffectsServiceCommand.STOP_AMBIENT)
+
+        assertEquals(EffectsServiceStartMode.REGULAR, policy.startMode)
+        assertTrue(policy.reconcileController)
+        assertTrue(shouldReconcileAmbientController(requested = true, mode = AppMode.AMBIENT))
+        assertFalse(shouldReconcileAmbientController(requested = true, mode = AppMode.COLOR))
     }
 }

--- a/android/app/src/test/java/com/hooandee/colores/engine/AmbientRendererTest.kt
+++ b/android/app/src/test/java/com/hooandee/colores/engine/AmbientRendererTest.kt
@@ -1,0 +1,48 @@
+package com.hooandee.colores.engine
+
+import com.hooandee.colores.ambient.AmbientCaptureStatus
+import com.hooandee.colores.ambient.MutableAmbientFrameSource
+import com.hooandee.colores.led.RgbColor
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class AmbientRendererTest {
+    @Test
+    fun `renders latest sampled frame at device cadence`() {
+        val source = MutableAmbientFrameSource()
+        source.update(listOf(RgbColor(200, 20, 10), RgbColor(10, 20, 200)), AmbientCaptureStatus.CAPTURING, 1L)
+        val renderer = AmbientRenderer(2, 80, vividness = { 0 }, smoothing = { 0 }, state = { source.state.value })
+
+        val tick = renderer.render(0.0)
+
+        assertEquals(80L, tick.nextDelayMs)
+        assertEquals(source.state.value.colors, tick.colors)
+    }
+
+    @Test
+    fun `keeps last frame when capture temporarily has no frames`() {
+        val source = MutableAmbientFrameSource()
+        val renderer = AmbientRenderer(2, 80, vividness = { 0 }, smoothing = { 0 }, state = { source.state.value })
+        source.update(List(2) { RgbColor(50, 60, 70) }, AmbientCaptureStatus.CAPTURING, 1L)
+        renderer.render(0.0)
+        source.reset(AmbientCaptureStatus.NO_FRAMES)
+
+        assertEquals(List(2) { RgbColor(50, 60, 70) }, renderer.render(0.08).colors)
+    }
+
+    @Test
+    fun `smooths from the displayed frame using elapsed time`() {
+        val source = MutableAmbientFrameSource()
+        val renderer = AmbientRenderer(1, 80, vividness = { 0 }, smoothing = { 80 }, state = { source.state.value })
+        source.update(listOf(RgbColor(0, 0, 0)), AmbientCaptureStatus.CAPTURING, 1L)
+        renderer.render(0.0)
+        source.update(listOf(RgbColor(255, 0, 0)), AmbientCaptureStatus.CAPTURING, 2L)
+
+        val first = renderer.render(0.08).colors.single().red
+        val second = renderer.render(0.16).colors.single().red
+
+        assertTrue(first in 1..254)
+        assertTrue(second > first)
+    }
+}

--- a/android/app/src/test/java/com/hooandee/colores/report/ReportBundleTest.kt
+++ b/android/app/src/test/java/com/hooandee/colores/report/ReportBundleTest.kt
@@ -31,6 +31,9 @@ class ReportBundleTest {
             power = true,
             configuredProfiles = 2,
             automationStatus = "active",
+            ambientStatus = "capturing",
+            ambientCaptureFps = 10,
+            ambientSamplingMode = "full_scene",
         )
 
     @Test
@@ -53,6 +56,8 @@ class ReportBundleTest {
         assertEquals("0.1.0", bundle.getJSONObject("environment").getString("plugin_version"))
         assertEquals("htr3212", bundle.getJSONObject("capabilities").getString("driver"))
         assertEquals(2, bundle.getJSONObject("stores").getInt("profiles_configured"))
+        assertEquals(10, bundle.getJSONObject("state").getJSONObject("ambient").getInt("capture_fps"))
+        assertFalse(encoded.contains("pixels"))
         assertFalse(encoded.contains("ABC123456789"))
         assertFalse(encoded.contains("AA:BB:CC:DD:EE:FF"))
         assertFalse(encoded.contains("123e4567-e89b-12d3-a456-426614174000"))

--- a/android/app/src/test/java/com/hooandee/colores/ui/ColoresUiStateTest.kt
+++ b/android/app/src/test/java/com/hooandee/colores/ui/ColoresUiStateTest.kt
@@ -1,5 +1,7 @@
 package com.hooandee.colores.ui
 
+import com.hooandee.colores.ambient.AmbientCaptureStatus
+import com.hooandee.colores.ambient.AmbientFrameState
 import com.hooandee.colores.audio.AudioCaptureStatus
 import com.hooandee.colores.audio.AudioLevelState
 import com.hooandee.colores.control.AppMode
@@ -74,6 +76,8 @@ class ColoresUiStateTest {
 
         assertTrue(AppMode.AUDIO in connected.availableModes())
         assertFalse(AppMode.AUDIO in unavailable.availableModes())
+        assertTrue(AppMode.AMBIENT in connected.availableModes())
+        assertFalse(AppMode.AMBIENT in unavailable.availableModes())
     }
 
     @Test
@@ -87,5 +91,17 @@ class ColoresUiStateTest {
 
         assertTrue(state.audioNeedsAuthorization)
         assertEquals(0.0, state.audio.level, 0.0)
+    }
+
+    @Test
+    fun `selected ambient without a live grant asks for authorization`() {
+        val state =
+            ColoresUiState(
+                detected = thor,
+                mode = AppMode.AMBIENT,
+                ambient = AmbientFrameState(status = AmbientCaptureStatus.REVOKED),
+            )
+
+        assertTrue(state.ambientNeedsAuthorization)
     }
 }

--- a/package.json
+++ b/package.json
@@ -18,6 +18,8 @@
     "@types/react": "19.1.1",
     "@types/react-dom": "19.1.1",
     "@types/webpack": "^5.28.5",
+    "react": "19.2.7",
+    "react-dom": "19.2.7",
     "react-router": "^8.3.0",
     "rollup": "^4.53.3",
     "typescript": "^5.6.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -36,9 +36,15 @@ importers:
       '@types/webpack':
         specifier: ^5.28.5
         version: 5.28.5
+      react:
+        specifier: 19.2.7
+        version: 19.2.7
+      react-dom:
+        specifier: 19.2.7
+        version: 19.2.7(react@19.2.7)
       react-router:
         specifier: ^8.3.0
-        version: 8.3.0(react@19.2.7)
+        version: 8.3.0(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       rollup:
         specifier: ^4.53.3
         version: 4.62.2
@@ -1089,6 +1095,11 @@ packages:
   queue-microtask@1.2.3:
     resolution: {integrity: sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==}
 
+  react-dom@19.2.7:
+    resolution: {integrity: sha512-t0BRVXvbiE/o20Hfw669rLbMCDWtYZLvmJigy2f0MxsXF+71pxhR3xOkspmsO8h3ZlNzyibAmtCa3l4lYKk6gQ==}
+    peerDependencies:
+      react: ^19.2.7
+
   react-icons@5.6.0:
     resolution: {integrity: sha512-RH93p5ki6LfOiIt0UtDyNg/cee+HLVR6cHHtW3wALfo+eOHTp8RnU2kRkI6E+H19zMIs03DyxUG/GfZMOGvmiA==}
     peerDependencies:
@@ -1157,6 +1168,9 @@ packages:
 
   run-parallel@1.2.0:
     resolution: {integrity: sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==}
+
+  scheduler@0.27.0:
+    resolution: {integrity: sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==}
 
   schema-utils@4.3.3:
     resolution: {integrity: sha512-eflK8wEtyOE6+hsaRVPxvUKYCpRgzLqDTb8krvAsRIwOGlHoSgYLgBXoubGgLd2fT41/OUYdb48v4k4WWHQurA==}
@@ -2265,14 +2279,21 @@ snapshots:
 
   queue-microtask@1.2.3: {}
 
+  react-dom@19.2.7(react@19.2.7):
+    dependencies:
+      react: 19.2.7
+      scheduler: 0.27.0
+
   react-icons@5.6.0(react@19.2.7):
     dependencies:
       react: 19.2.7
 
-  react-router@8.3.0(react@19.2.7):
+  react-router@8.3.0(react-dom@19.2.7(react@19.2.7))(react@19.2.7):
     dependencies:
       cookie-es: 3.1.1
       react: 19.2.7
+    optionalDependencies:
+      react-dom: 19.2.7(react@19.2.7)
 
   react@19.2.7: {}
 
@@ -2369,6 +2390,8 @@ snapshots:
   run-parallel@1.2.0:
     dependencies:
       queue-microtask: 1.2.3
+
+  scheduler@0.27.0: {}
 
   schema-utils@4.3.3:
     dependencies:

--- a/shared/platform-support.json
+++ b/shared/platform-support.json
@@ -75,7 +75,7 @@
     {
       "id": "ambilight",
       "contracts": [],
-      "platforms": { "decky": "validated", "android": "deferred", "windows": "deferred" }
+      "platforms": { "decky": "validated", "android": "validated", "windows": "deferred" }
     },
     {
       "id": "audio_vu",


### PR DESCRIPTION
## Qué cambia

- Añade Ambilight nativo en Android con MediaProjection e ImageReader a 32 × 18.
- Ofrece captura de 5 a 30 fps, con 10 fps recomendado, sin ligar esa frecuencia a la cadencia física del driver LED.
- Añade muestreo de escena completa distribuido por sticks y zonas, más la alternativa de borde inferior.
- Incorpora vivacidad, suavizado temporal, persistencia, estados de autorización/revocación y diagnóstico sin guardar capturas.
- Hace Audio VU y Ambilight mutuamente exclusivos dentro del foreground service y protege el lifecycle de proyecciones antiguas.
- Publica Android Ambilight como validado tras el smoke físico en AYN Thor.
- Declara React y React DOM como dependencias de desarrollo para que el nuevo test de i18n de main pueda ejecutarse en una instalación limpia.

## Por qué

La versión Android necesitaba alcanzar la funcionalidad de Decky sin penalizar los juegos. La captura trabaja sobre un buffer mínimo, descarta frames sobrantes y conserva la cadencia segura de cada transporte LED.

## Validación

- Android: `testDebugUnitTest assembleDebug lintDebug`.
- Decky: typecheck, build y 75 pruebas frontend.
- Backend: 409 pruebas.
- AYN Thor, Android 13: MediaProjection real a 32 × 18, PServer con estado 0 y sin errores de captura, AndroidRuntime o I2C.
- melonDS: 59,79 fps sin captura, 59,78 fps a 10 fps y 59,78 fps a 30 fps; p95 de 16,73 ms y ningún intervalo superior a 20 ms en las tres muestras.
- Confirmación visual del usuario: el resultado de escena completa funciona correctamente en la Thor.