### PR TITLE
fix(android): keep hardware learning question visible

### DIFF
--- a/android/app/src/main/java/com/hooandee/colores/ui/HardwareLearningDialog.kt
+++ b/android/app/src/main/java/com/hooandee/colores/ui/HardwareLearningDialog.kt
@@ -93,7 +93,11 @@ internal fun HardwareLearningDialog(
                 Column(Modifier.padding(horizontal = 26.dp, vertical = 22.dp)) {
                     LearningHeader(ui, onDismiss)
                     Spacer(Modifier.height(16.dp))
-                    if (landscape) {
+                    val compactZoneQuestion =
+                        (ui.sessionState as? HardwareLearningState.AwaitingAnswer)?.isHtrZone() == true
+                    if (compactZoneQuestion) {
+                        LearningBody(ui, textAlign = TextAlign.Start, horizontalAlignment = Alignment.Start)
+                    } else if (landscape) {
                         Row(
                             modifier = Modifier.weight(1f, fill = false).fillMaxWidth(),
                             horizontalArrangement = Arrangement.spacedBy(28.dp),

--- a/android/app/src/main/res/values-en/strings.xml
+++ b/android/app/src/main/res/values-en/strings.xml
@@ -364,7 +364,7 @@
     <string name="hardware_learning_grouped_points">All four points light up together</string>
     <string name="hardware_learning_grouped_points_body">The lights are present, but this test could not isolate one point. Colores therefore keeps the confirmed 2-zone control: one color per joystick.</string>
     <string name="hardware_learning_zone_location_title">What lights up in magenta?</string>
-    <string name="hardware_learning_zone_location_body">Choose a corner only if you see one small, localized point. If all four points light up together, or the whole joystick is lit, use that option. If no light appears, choose “Nothing lights up”.</string>
+    <string name="hardware_learning_zone_location_body">Choose a corner only if you see one point. For four points, use “Whole joystick or all four points”.</string>
     <string name="hardware_learning_left_stick">Left joystick</string>
     <string name="hardware_learning_right_stick">Right joystick</string>
     <string name="hardware_learning_none_visible">Nothing lights up</string>

--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -364,7 +364,7 @@
     <string name="hardware_learning_grouped_points">Los cuatro puntos se encienden juntos</string>
     <string name="hardware_learning_grouped_points_body">Las luces existen, pero esta prueba no ha conseguido aislar un punto. Por eso Colores mantiene el control confirmado de 2 zonas: un color por joystick.</string>
     <string name="hardware_learning_zone_location_title">¿Qué se ilumina en magenta?</string>
-    <string name="hardware_learning_zone_location_body">Elige una esquina solo si ves un único punto pequeño y localizado. Si ves los cuatro puntos a la vez o todo el joystick iluminado, usa esa opción. Si no se enciende ninguna luz, elige “No se ilumina nada”.</string>
+    <string name="hardware_learning_zone_location_body">Elige una esquina solo si ves un único punto. Para cuatro puntos, usa “Todo el joystick o los cuatro puntos”.</string>
     <string name="hardware_learning_left_stick">Joystick izquierdo</string>
     <string name="hardware_learning_right_stick">Joystick derecho</string>
     <string name="hardware_learning_none_visible">No se ilumina nada</string>


### PR DESCRIPTION
## Qué cambia / What changes

- Usa una composición compacta durante la pregunta multipunto HTR del aprendizaje de hardware.
- Elimina en ese paso el bloque visual redundante que quitaba espacio a la pregunta.
- Acorta y mantiene alineadas las instrucciones en español e inglés.

## Por qué / Why

En pantallas apaisadas de baja altura, el área fija de respuestas dejaba demasiado poco espacio al bloque superior. El título quedaba recortado y la explicación no era legible sin desplazamiento.

El cambio queda limitado a la UI del tutorial Android. No modifica descubrimiento, perfiles, capacidades, transporte físico ni contratos compartidos.

## Pruebas / Testing

- [x] `:app:lintDebug`
- [x] `:app:testDebugUnitTest` (468 pruebas)
- [x] `:app:assembleDebug`
- [x] Validación visual en una AYN Odin 3: pregunta y controles completos visibles sin scroll
- [x] Commits con formato convencional / Conventional commit messages