### PR TITLE
feat(android): improve HTR discovery and responsive layouts

### DIFF
--- a/android/app/src/main/java/com/hooandee/colores/ColoresApplication.kt
+++ b/android/app/src/main/java/com/hooandee/colores/ColoresApplication.kt
@@ -15,6 +15,7 @@ import com.hooandee.colores.effects.ContextServiceGate
 import com.hooandee.colores.device.learning.HardwareLearningStore
 import com.hooandee.colores.device.learning.HardwareLearningCoordinator
 import com.hooandee.colores.device.learning.Htr3212LearningCartridge
+import com.hooandee.colores.device.learning.PServerHtr3212RegisterReader
 import com.hooandee.colores.device.learning.ProbeCartridgeCatalog
 import com.hooandee.colores.device.learning.RollbackRecovery
 import com.hooandee.colores.device.learning.RollbackStatus
@@ -25,10 +26,10 @@ import com.hooandee.colores.device.learning.restoreAfterLearningRollback
 import com.hooandee.colores.led.PServerSystemSettingsStore
 import com.hooandee.colores.led.AndroidPServerCommandExecutor
 import com.hooandee.colores.led.VerifiedPServerCommandExecutor
-import java.io.File
 import com.hooandee.colores.profiles.LightingProfileCoordinator
 import com.hooandee.colores.profiles.LightingProfileStore
 import com.hooandee.colores.settings.AppPreferences
+import java.io.File
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
@@ -62,12 +63,13 @@ class ColoresApplication : Application() {
                 File(cacheDir, "pserver_learning_status"),
             )
         val settingsStore = PServerSystemSettingsStore(this, executor)
+        val htrRegisterReader = PServerHtr3212RegisterReader(executor, File(cacheDir, "pserver_htr_registers"))
         ProbeCartridgeCatalog(
             listOf(
                 SettingsLearningCartridge(settingsStore),
                 SingleAdcLearningCartridge(),
                 SysfsLearningCartridge(),
-                Htr3212LearningCartridge(settingsStore, executor),
+                Htr3212LearningCartridge(settingsStore, executor, htrRegisterReader),
             ),
         )
     }

--- a/android/app/src/main/java/com/hooandee/colores/MainActivity.kt
+++ b/android/app/src/main/java/com/hooandee/colores/MainActivity.kt
@@ -8,6 +8,7 @@ import android.content.Intent
 import android.content.IntentFilter
 import android.content.pm.PackageManager
 import android.media.projection.MediaProjectionManager
+import android.media.projection.MediaProjectionConfig
 import android.os.Build
 import android.os.Bundle
 import androidx.activity.result.contract.ActivityResultContracts
@@ -142,15 +143,29 @@ class MainActivity : AppCompatActivity() {
     private fun launchProjectionConsent(request: ProjectionRequest) {
         projectionRequest = request
         val manager = getSystemService(MediaProjectionManager::class.java)
-        projectionLauncher.launch(manager.createScreenCaptureIntent())
-    }
-
-    private enum class ProjectionRequest {
-        NONE,
-        AUDIO,
-        AMBIENT,
+        val intent =
+            if (
+                Build.VERSION.SDK_INT >= Build.VERSION_CODES.UPSIDE_DOWN_CAKE &&
+                shouldCaptureDefaultDisplay(request, Build.VERSION.SDK_INT)
+            ) {
+                manager.createScreenCaptureIntent(MediaProjectionConfig.createConfigForDefaultDisplay())
+            } else {
+                manager.createScreenCaptureIntent()
+            }
+        projectionLauncher.launch(intent)
     }
 }
+
+internal enum class ProjectionRequest {
+    NONE,
+    AUDIO,
+    AMBIENT,
+}
+
+internal fun shouldCaptureDefaultDisplay(
+    request: ProjectionRequest,
+    sdk: Int,
+): Boolean = request == ProjectionRequest.AMBIENT && sdk >= Build.VERSION_CODES.UPSIDE_DOWN_CAKE
 
 internal fun shouldRequestNotificationPermission(
     sdk: Int,

--- a/android/app/src/main/java/com/hooandee/colores/ambient/AndroidScreenCapture.kt
+++ b/android/app/src/main/java/com/hooandee/colores/ambient/AndroidScreenCapture.kt
@@ -9,7 +9,33 @@ import android.media.projection.MediaProjection
 import android.os.Handler
 import android.os.HandlerThread
 import android.os.SystemClock
+import android.view.WindowManager
 import com.hooandee.colores.led.RgbColor
+import kotlin.math.roundToInt
+
+internal data class AmbientCaptureDimensions(
+    val width: Int,
+    val height: Int,
+)
+
+internal fun ambientCaptureDimensions(
+    displayWidth: Int,
+    displayHeight: Int,
+    maxLongEdge: Int = 32,
+): AmbientCaptureDimensions {
+    if (displayWidth <= 0 || displayHeight <= 0 || maxLongEdge <= 0) return AmbientCaptureDimensions(32, 18)
+    return if (displayWidth >= displayHeight) {
+        AmbientCaptureDimensions(
+            width = maxLongEdge,
+            height = (maxLongEdge * displayHeight.toFloat() / displayWidth).roundToInt().coerceAtLeast(1),
+        )
+    } else {
+        AmbientCaptureDimensions(
+            width = (maxLongEdge * displayWidth.toFloat() / displayHeight).roundToInt().coerceAtLeast(1),
+            height = maxLongEdge,
+        )
+    }
+}
 
 class AndroidScreenCapture(
     private val context: Context,
@@ -44,7 +70,15 @@ class AndroidScreenCapture(
         running = true
         val captureThread = HandlerThread("ColoresAmbientCapture").apply { start() }
         val captureHandler = Handler(captureThread.looper)
-        val imageReader = ImageReader.newInstance(CAPTURE_WIDTH, CAPTURE_HEIGHT, PixelFormat.RGBA_8888, MAX_IMAGES)
+        val displayBounds = context.getSystemService(WindowManager::class.java).currentWindowMetrics.bounds
+        val captureDimensions = ambientCaptureDimensions(displayBounds.width(), displayBounds.height())
+        val imageReader =
+            ImageReader.newInstance(
+                captureDimensions.width,
+                captureDimensions.height,
+                PixelFormat.RGBA_8888,
+                MAX_IMAGES,
+            )
         thread = captureThread
         handler = captureHandler
         reader = imageReader
@@ -52,8 +86,8 @@ class AndroidScreenCapture(
         display =
             projection.createVirtualDisplay(
                 "ColoresAmbient",
-                CAPTURE_WIDTH,
-                CAPTURE_HEIGHT,
+                captureDimensions.width,
+                captureDimensions.height,
                 context.resources.displayMetrics.densityDpi,
                 DisplayManager.VIRTUAL_DISPLAY_FLAG_AUTO_MIRROR,
                 imageReader.surface,
@@ -114,8 +148,6 @@ class AndroidScreenCapture(
     }
 
     private companion object {
-        const val CAPTURE_WIDTH = 32
-        const val CAPTURE_HEIGHT = 18
         const val MAX_IMAGES = 2
         const val NO_FRAME_TIMEOUT_MS = 2_000L
     }

--- a/android/app/src/main/java/com/hooandee/colores/device/AndroidDeviceDetector.kt
+++ b/android/app/src/main/java/com/hooandee/colores/device/AndroidDeviceDetector.kt
@@ -4,9 +4,12 @@ import android.content.Context
 import android.os.Build
 import android.provider.Settings
 import com.hooandee.colores.device.learning.DetectionOutcome
+import com.hooandee.colores.device.learning.FACT_PSERVER
+import com.hooandee.colores.device.learning.FactEvidence
 import com.hooandee.colores.device.learning.LearnedDeviceBinding
 import com.hooandee.colores.device.learning.HardwareLearningGraph
 import com.hooandee.colores.device.learning.HardwareFact
+import com.hooandee.colores.device.learning.HardwareLearningRoute
 import com.hooandee.colores.device.learning.Htr3212InformationCartridge
 import com.hooandee.colores.device.learning.HTR3212_PROBE_ID
 import com.hooandee.colores.device.learning.HTR3212_PROBE_VERSION
@@ -84,7 +87,7 @@ class AndroidDeviceDetector(
                 GenericLedResolver.joypadCandidate(runCatching { scanJoypad() }.getOrNull()),
                 GenericLedResolver.sysfsCandidate(runCatching { scanSysfs() }.getOrNull()),
             )
-        val route = HardwareLearningGraph(informationCartridges).resolve(identity, seedCandidates)
+        val route = resolveHardwareLearningRoute(identity, pserver, seedCandidates, informationCartridges)
         val candidates = verificationCandidates(route.candidates, exact, exactTransportAvailable, route.facts)
         val learned = resolveLearnedDevice(identity, binding, candidates)
         return resolveDetectionOutcome(
@@ -131,6 +134,23 @@ class AndroidDeviceDetector(
             )
     }
 }
+
+internal fun resolveHardwareLearningRoute(
+    identity: AndroidDeviceIdentity,
+    pserverAvailable: Boolean,
+    seedCandidates: List<ProbeCandidate>,
+    informationCartridges: List<InformationCartridge>,
+): HardwareLearningRoute =
+    HardwareLearningGraph(informationCartridges).resolve(
+        identity = identity,
+        seedCandidates = seedCandidates,
+        seedFacts =
+            if (pserverAvailable) {
+                listOf(HardwareFact(FACT_PSERVER, "present", FactEvidence.OBSERVED, "android-detector"))
+            } else {
+                emptyList()
+            },
+    )
 
 internal fun exactProfileCandidate(device: DetectedAndroidDevice): ProbeCandidate? {
     val descriptor = device.led as? SettingsProviderDescriptor ?: return null

--- a/android/app/src/main/java/com/hooandee/colores/device/learning/HardwareLearningGraph.kt
+++ b/android/app/src/main/java/com/hooandee/colores/device/learning/HardwareLearningGraph.kt
@@ -1,7 +1,9 @@
 package com.hooandee.colores.device.learning
 
 import com.hooandee.colores.device.AndroidDeviceIdentity
+import com.hooandee.colores.led.SettingsProviderDescriptor
 
+internal const val FACT_PSERVER = "transport.pserver"
 internal const val FACT_SETTINGS_PSERVER = "surface.settings_pserver"
 internal const val FACT_HTR3212_LEFT = "controller.htr3212.left"
 internal const val FACT_HTR3212_RIGHT = "controller.htr3212.right"
@@ -54,8 +56,10 @@ class HardwareLearningGraph(
     fun resolve(
         identity: AndroidDeviceIdentity,
         seedCandidates: List<ProbeCandidate>,
+        seedFacts: List<HardwareFact> = emptyList(),
     ): HardwareLearningRoute {
         val facts = linkedMapOf<String, HardwareFact>()
+        seedFacts.forEach { facts.merge(it) }
         seedCandidates.flatMap(::factsForCandidate).forEach { facts.merge(it) }
         val candidates = linkedMapOf<String, ProbeCandidate>()
         seedCandidates.forEach { candidates.putIfAbsent(it.routeKey(), it) }
@@ -78,6 +82,9 @@ class HardwareLearningGraph(
 
 private fun factsForCandidate(candidate: ProbeCandidate): List<HardwareFact> =
     buildList {
+        if ((candidate.descriptor as? SettingsProviderDescriptor)?.transport == "pserver") {
+            add(HardwareFact(FACT_PSERVER, "present", FactEvidence.OBSERVED, candidate.cartridgeId))
+        }
         val surfaceKey =
             when (candidate.surface) {
                 ProbeSurface.SETTINGS_PSERVER -> FACT_SETTINGS_PSERVER

--- a/android/app/src/main/java/com/hooandee/colores/device/learning/Htr3212InformationCartridge.kt
+++ b/android/app/src/main/java/com/hooandee/colores/device/learning/Htr3212InformationCartridge.kt
@@ -1,5 +1,6 @@
 package com.hooandee.colores.device.learning
 
+import com.hooandee.colores.device.GenericVendorLed
 import com.hooandee.colores.led.Htr3212Descriptor
 import com.hooandee.colores.led.SettingsProviderDescriptor
 import java.io.File
@@ -45,7 +46,7 @@ class Htr3212InformationCartridge(
 ) : InformationCartridge {
     override val id = HTR3212_INFORMATION_ID
     override val version = 1
-    override val requiredFactKeys = setOf(FACT_SETTINGS_PSERVER)
+    override val requiredFactKeys = setOf(FACT_PSERVER)
 
     override fun inspect(context: HardwareLearningContext): InformationCartridgeResult {
         val controllers = topologyReader.read()
@@ -63,6 +64,7 @@ class Htr3212InformationCartridge(
             context.candidates
                 .firstOrNull { it.surface == ProbeSurface.SETTINGS_PSERVER }
                 ?.descriptor as? SettingsProviderDescriptor
+                ?: GenericVendorLed.descriptor(STICKS).takeIf { context.hasFact(FACT_PSERVER) }
         val candidate =
             if (base != null && left != null && right != null && left.bus != right.bus) {
                 ProbeCandidate(
@@ -102,6 +104,7 @@ class Htr3212InformationCartridge(
         const val LEFT_DRIVER = "htr3212l"
         const val RIGHT_DRIVER = "htr3212r"
         const val ADDRESS = 0x3c
+        const val STICKS = 2
         const val TOTAL_ZONES = 8
         const val AYN_RGB_START_REGISTER = 0x0d
         val DEFAULT_ORDER = listOf(0, 1, 2, 3)

--- a/android/app/src/main/java/com/hooandee/colores/device/learning/Htr3212LearningCartridge.kt
+++ b/android/app/src/main/java/com/hooandee/colores/device/learning/Htr3212LearningCartridge.kt
@@ -9,9 +9,18 @@ import com.hooandee.colores.led.SettingsProviderDescriptor
 import com.hooandee.colores.led.SystemSettingsStore
 import kotlin.math.roundToInt
 
+fun interface Htr3212RegisterReader {
+    fun read(
+        bus: Int,
+        address: Int,
+        registers: List<Int>,
+    ): List<Int>?
+}
+
 internal class Htr3212LearningCartridge(
     private val store: SystemSettingsStore,
     private val executor: PServerCommandExecutor,
+    private val registerReader: Htr3212RegisterReader = Htr3212RegisterReader { _, _, _ -> null },
     private val settleVendor: () -> Unit = { Thread.sleep(VENDOR_SETTLE_MS) },
     private val settleRepaint: () -> Unit = { Thread.sleep(VENDOR_REPAINT_MS) },
 ) : ProbeCartridge {
@@ -21,18 +30,22 @@ internal class Htr3212LearningCartridge(
 
     override fun accepts(candidate: ProbeCandidate): Boolean {
         val descriptor = candidate.descriptor as? SettingsProviderDescriptor ?: return false
-        val hardware = descriptor.htr3212 ?: return false
         return candidate.cartridgeId == id &&
             candidate.cartridgeVersion == version &&
             candidate.surface == surface &&
-            descriptor.driver == "htr3212" &&
-            descriptor.transport == "pserver" &&
-            descriptor.colorKey == GenericVendorLed.COLOR_KEY &&
-            descriptor.colorFormat == "argb_hex_csv" &&
-            descriptor.brightnessKey == GenericVendorLed.BRIGHTNESS_KEY &&
-            descriptor.enableKeys.isNotEmpty() &&
-            GenericVendorLed.ENABLE_KEYS.containsAll(descriptor.enableKeys) &&
-            descriptor.zones == TOTAL_ZONES &&
+            descriptor.isAcceptedHtrDescriptor()
+    }
+
+    private fun SettingsProviderDescriptor.isAcceptedHtrDescriptor(): Boolean {
+        val hardware = htr3212 ?: return false
+        return driver == "htr3212" &&
+            transport == "pserver" &&
+            colorKey == GenericVendorLed.COLOR_KEY &&
+            colorFormat == "argb_hex_csv" &&
+            brightnessKey == GenericVendorLed.BRIGHTNESS_KEY &&
+            enableKeys.isNotEmpty() &&
+            GenericVendorLed.ENABLE_KEYS.containsAll(enableKeys) &&
+            zones == TOTAL_ZONES &&
             hardware.leftBus in BUS_RANGE &&
             hardware.rightBus in BUS_RANGE &&
             hardware.leftBus != hardware.rightBus &&
@@ -45,20 +58,27 @@ internal class Htr3212LearningCartridge(
     override fun snapshot(candidate: ProbeCandidate): ProbeSnapshot? {
         val descriptor = candidate.descriptor as? SettingsProviderDescriptor ?: return null
         if (!store.available || !executor.available || !accepts(candidate)) return null
-        val color = store.get(descriptor.colorKey) ?: return null
-        val values = linkedMapOf(descriptor.colorKey to color)
-        store.get(descriptor.brightnessKey)?.let { values[descriptor.brightnessKey] = it }
-        descriptor.enableKeys.forEach { key -> store.get(key)?.let { values[key] = it } }
+        val color = store.get(descriptor.colorKey)
+        val powerValues = descriptor.enableKeys.mapNotNull { key -> store.get(key)?.let { key to it } }.toMap(linkedMapOf())
+        val values =
+            when {
+                color != null -> linkedMapOf(descriptor.colorKey to color)
+                powerValues.isNotEmpty() && powerValues.values.all(::isPowerOffValue) -> linkedMapOf()
+                else -> rawSnapshot(descriptor) ?: return null
+            }
+        if (color != null) store.get(descriptor.brightnessKey)?.let { values[descriptor.brightnessKey] = it }
+        values.putAll(powerValues)
         return ProbeSnapshot(values)
     }
 
     override fun supportedSteps(candidate: ProbeCandidate): List<ProbeStep> {
         val descriptor = candidate.descriptor as? SettingsProviderDescriptor ?: return emptyList()
         if (snapshot(candidate) == null) return emptyList()
+        val direct = store.get(descriptor.colorKey) == null
         return buildList {
             add(ProbeStep.COLOR)
             add(ProbeStep.ZONE)
-            if (store.get(descriptor.brightnessKey) != null) {
+            if (direct || store.get(descriptor.brightnessKey) != null) {
                 add(ProbeStep.BRIGHTNESS_LOW)
                 add(ProbeStep.BRIGHTNESS_HIGH)
             }
@@ -77,14 +97,14 @@ internal class Htr3212LearningCartridge(
         val descriptor = candidate.descriptor as? SettingsProviderDescriptor ?: return false
         if (!store.available || !executor.available || !accepts(candidate)) return false
         return when (step) {
-            ProbeStep.COLOR -> prepareVendor(descriptor) && writeFrame(descriptor, List(TOTAL_ZONES) { PROBE_COLOR }, HIGH_LEVEL)
-            ProbeStep.BRIGHTNESS_LOW -> prepareVendor(descriptor) && writeFrame(descriptor, List(TOTAL_ZONES) { PROBE_COLOR }, LOW_LEVEL)
-            ProbeStep.BRIGHTNESS_HIGH -> prepareVendor(descriptor) && writeFrame(descriptor, List(TOTAL_ZONES) { PROBE_COLOR }, HIGH_LEVEL)
+            ProbeStep.COLOR -> prepareDevice(descriptor) && writeFrame(descriptor, List(TOTAL_ZONES) { PROBE_COLOR }, HIGH_LEVEL)
+            ProbeStep.BRIGHTNESS_LOW -> prepareDevice(descriptor) && writeFrame(descriptor, List(TOTAL_ZONES) { PROBE_COLOR }, LOW_LEVEL)
+            ProbeStep.BRIGHTNESS_HIGH -> prepareDevice(descriptor) && writeFrame(descriptor, List(TOTAL_ZONES) { PROBE_COLOR }, HIGH_LEVEL)
             ProbeStep.POWER_OFF -> putPower(descriptor, false)
-            ProbeStep.POWER_ON -> prepareVendor(descriptor) && writeFrame(descriptor, List(TOTAL_ZONES) { PROBE_COLOR }, HIGH_LEVEL)
+            ProbeStep.POWER_ON -> prepareDevice(descriptor) && writeFrame(descriptor, List(TOTAL_ZONES) { PROBE_COLOR }, HIGH_LEVEL)
             ProbeStep.ZONE -> {
                 val index = zone?.takeIf { it in 0 until TOTAL_ZONES } ?: return false
-                if (!prepareVendor(descriptor)) return false
+                if (!prepareDevice(descriptor)) return false
                 val colors = List(TOTAL_ZONES) { if (it == index) PROBE_COLOR else OFF_COLOR }
                 val firstWrite = writeFrame(descriptor, colors, HIGH_LEVEL)
                 settleRepaint()
@@ -99,6 +119,7 @@ internal class Htr3212LearningCartridge(
         snapshot: ProbeSnapshot,
     ): RollbackStatus {
         val descriptor = candidate.descriptor as? SettingsProviderDescriptor ?: return RollbackStatus.RESTORE_FAILED
+        if (descriptor.colorKey !in snapshot.values) return restoreRaw(descriptor, snapshot)
         val allowedKeys = setOf(descriptor.colorKey, descriptor.brightnessKey) + descriptor.enableKeys
         if (!accepts(candidate) || descriptor.colorKey !in snapshot.values || !allowedKeys.containsAll(snapshot.values.keys)) {
             return RollbackStatus.RESTORE_FAILED
@@ -156,14 +177,105 @@ internal class Htr3212LearningCartridge(
         return colorPrepared && brightnessPrepared && powerPrepared
     }
 
+    private fun prepareDevice(descriptor: SettingsProviderDescriptor): Boolean =
+        if (store.get(descriptor.colorKey) == null) {
+            val present = descriptor.enableKeys.any { store.get(it) != null }
+            !present || putPower(descriptor, true)
+        } else {
+            prepareVendor(descriptor)
+        }
+
+    private fun rawSnapshot(descriptor: SettingsProviderDescriptor): LinkedHashMap<String, String>? {
+        val hardware = descriptor.htr3212 ?: return null
+        val registers = (hardware.rgbStartRegister until hardware.rgbStartRegister + CHANNEL_COUNT).toList()
+        val left = registerReader.read(hardware.leftBus, hardware.address, registers)?.validRegisterValues() ?: return null
+        val right = registerReader.read(hardware.rightBus, hardware.address, registers)?.validRegisterValues() ?: return null
+        return linkedMapOf<String, String>().apply {
+            left.forEachIndexed { index, value -> put("$RAW_LEFT_PREFIX$index", value.toString()) }
+            right.forEachIndexed { index, value -> put("$RAW_RIGHT_PREFIX$index", value.toString()) }
+        }
+    }
+
+    private fun restoreRaw(
+        descriptor: SettingsProviderDescriptor,
+        snapshot: ProbeSnapshot,
+    ): RollbackStatus {
+        if (!descriptor.isAcceptedHtrDescriptor()) return RollbackStatus.RESTORE_FAILED
+        val settings = snapshot.values.filterKeys { it in descriptor.enableKeys }
+        val hasRawValues = snapshot.values.keys.any { it.startsWith(RAW_LEFT_PREFIX) || it.startsWith(RAW_RIGHT_PREFIX) }
+        if (!hasRawValues) {
+            if (settings.isEmpty() || settings.size != snapshot.values.size || !settings.values.all(::isPowerOffValue)) {
+                return RollbackStatus.RESTORE_FAILED
+            }
+            return restoreSettings(settings)
+        }
+        val left = snapshot.rawValues(RAW_LEFT_PREFIX) ?: return RollbackStatus.RESTORE_FAILED
+        val right = snapshot.rawValues(RAW_RIGHT_PREFIX) ?: return RollbackStatus.RESTORE_FAILED
+        val allowedKeys = settings.keys + (0 until CHANNEL_COUNT).flatMap { listOf("$RAW_LEFT_PREFIX$it", "$RAW_RIGHT_PREFIX$it") }
+        if (!allowedKeys.containsAll(snapshot.values.keys)) return RollbackStatus.RESTORE_FAILED
+        val directRestored = writeRawFrame(descriptor, left, right)
+        return if (directRestored && restoreSettings(settings) == RollbackStatus.RESTORED_WITHOUT_HARDWARE_READBACK) {
+            RollbackStatus.RESTORED_WITHOUT_HARDWARE_READBACK
+        } else {
+            RollbackStatus.RESTORE_FAILED
+        }
+    }
+
+    private fun restoreSettings(settings: Map<String, String>): RollbackStatus {
+        val accepted = settings.attemptAll(store::put)
+        val restored = settings.all { (key, value) -> store.get(key) == value }
+        return if (accepted && restored) RollbackStatus.RESTORED_WITHOUT_HARDWARE_READBACK else RollbackStatus.RESTORE_FAILED
+    }
+
+    private fun isPowerOffValue(value: String): Boolean =
+        value.split(',').map(String::trim).filter(String::isNotEmpty).let { parts ->
+            parts.isNotEmpty() && parts.all { it.equals("0") || it.equals("false", ignoreCase = true) || it.equals("off", ignoreCase = true) }
+        }
+
+    private fun writeRawFrame(
+        descriptor: SettingsProviderDescriptor,
+        left: List<Int>,
+        right: List<Int>,
+    ): Boolean {
+        val hardware = descriptor.htr3212 ?: return false
+        val colors = { values: List<Int> -> values.chunked(CHANNELS_PER_ZONE).map { RgbColor(it[0], it[1], it[2]) } }
+        val order = (0 until ZONES_PER_STICK).toList()
+        val leftCommand =
+            Htr3212Command.build(
+                hardware.leftBus,
+                hardware.address,
+                colors(left),
+                order,
+                previous = null,
+                rgbStartRegister = hardware.rgbStartRegister,
+                blockWrite = hardware.blockWrite,
+            ) ?: return false
+        val rightCommand =
+            Htr3212Command.build(
+                hardware.rightBus,
+                hardware.address,
+                colors(right),
+                order,
+                previous = null,
+                rgbStartRegister = hardware.rgbStartRegister,
+                blockWrite = hardware.blockWrite,
+            ) ?: return false
+        return listOf(leftCommand, rightCommand).all(executor::execute)
+    }
+
+    private fun List<Int>.validRegisterValues(): List<Int>? = takeIf { size == CHANNEL_COUNT && all { value -> value in 0..255 } }
+
+    private fun ProbeSnapshot.rawValues(prefix: String): List<Int>? =
+        (0 until CHANNEL_COUNT).map { index -> values["$prefix$index"]?.toIntOrNull() ?: return null }.validRegisterValues()
+
     private fun putPower(
         descriptor: SettingsProviderDescriptor,
         enabled: Boolean,
     ): Boolean {
-        val present = descriptor.enableKeys.filter { store.get(it) != null }
+        val present = descriptor.enableKeys.withIndex().filter { (_, key) -> store.get(key) != null }
         if (present.isEmpty()) return false
         val value = if (enabled) "1" else "0"
-        return present.mapIndexed { index, key ->
+        return present.map { (index, key) ->
             store.put(key, if (index == 0) List(STICKS) { value }.joinToString(",") else value)
         }.all { it }
     }
@@ -238,6 +350,8 @@ internal class Htr3212LearningCartridge(
         const val STICKS = 2
         const val ZONES_PER_STICK = 4
         const val TOTAL_ZONES = STICKS * ZONES_PER_STICK
+        const val CHANNELS_PER_ZONE = 3
+        const val CHANNEL_COUNT = ZONES_PER_STICK * CHANNELS_PER_ZONE
         const val LOW_LEVEL = 25
         const val HIGH_LEVEL = 55
         const val HIGH_BRIGHTNESS_SETTING = "0.55"
@@ -247,5 +361,7 @@ internal class Htr3212LearningCartridge(
         val PROBE_COLOR = RgbColor(255, 0, 255)
         val OFF_COLOR = RgbColor(0, 0, 0)
         const val PROBE_COLOR_ARGB = "#FFFF00FF"
+        const val RAW_LEFT_PREFIX = "htr.left."
+        const val RAW_RIGHT_PREFIX = "htr.right."
     }
 }

--- a/android/app/src/main/java/com/hooandee/colores/device/learning/LearnedBindingResolver.kt
+++ b/android/app/src/main/java/com/hooandee/colores/device/learning/LearnedBindingResolver.kt
@@ -2,6 +2,7 @@ package com.hooandee.colores.device.learning
 
 import com.hooandee.colores.device.AndroidDeviceIdentity
 import com.hooandee.colores.device.DetectedAndroidDevice
+import com.hooandee.colores.device.LedGridCell
 import com.hooandee.colores.led.LedDescriptor
 import com.hooandee.colores.led.SettingsProviderDescriptor
 
@@ -27,8 +28,28 @@ internal fun resolveLearnedDevice(
         led = boundDescriptor,
         previewProfileId = null,
         previewCalibration = null,
+        gridLayout = candidate.learnedGridLayout(binding.capabilities.perZone, binding.capabilities.zones),
     )
 }
+
+private fun ProbeCandidate.learnedGridLayout(
+    perZone: Boolean,
+    zones: Int,
+): List<LedGridCell>? =
+    if (surface == ProbeSurface.HTR3212 && perZone && zones == 8) {
+        listOf(
+            LedGridCell(0, 0, 0, "top_left"),
+            LedGridCell(0, 1, 0, "bottom_left"),
+            LedGridCell(0, 1, 1, "bottom_right"),
+            LedGridCell(0, 0, 1, "top_right"),
+            LedGridCell(1, 0, 0, "top_left"),
+            LedGridCell(1, 1, 0, "bottom_left"),
+            LedGridCell(1, 1, 1, "bottom_right"),
+            LedGridCell(1, 0, 1, "top_right"),
+        )
+    } else {
+        null
+    }
 
 internal fun learnedDeviceIdForPromotion(
     identity: AndroidDeviceIdentity,

--- a/android/app/src/main/java/com/hooandee/colores/device/learning/PServerHtr3212RegisterReader.kt
+++ b/android/app/src/main/java/com/hooandee/colores/device/learning/PServerHtr3212RegisterReader.kt
@@ -1,0 +1,55 @@
+package com.hooandee.colores.device.learning
+
+import com.hooandee.colores.led.PServerCommandExecutor
+import java.io.File
+
+internal class PServerHtr3212RegisterReader(
+    private val executor: PServerCommandExecutor,
+    private val outputFile: File,
+) : Htr3212RegisterReader {
+    override fun read(
+        bus: Int,
+        address: Int,
+        registers: List<Int>,
+    ): List<Int>? {
+        if (!executor.available || bus !in BUS_RANGE || address != ADDRESS || registers != PWM_REGISTERS) return null
+        return try {
+            outputFile.writeText("")
+            outputFile.shareWithPServer()
+            val reads = registers.joinToString("; ") { register -> "i2cget -f -y $bus 0x3c 0x%02x".format(register) }
+            if (!executor.execute("{ $reads; } > ${outputFile.absolutePath.shellQuoted()}")) return null
+            val tokens = outputFile.readText().split(Regex("\\s+")).filter(String::isNotBlank)
+            if (tokens.size != registers.size) return null
+            tokens.map { parseByte(it) ?: return null }
+        } catch (_: Throwable) {
+            null
+        } finally {
+            outputFile.restoreOwnerAccess()
+        }
+    }
+
+    private fun parseByte(value: String): Int? =
+        value.removePrefix("0x").toIntOrNull(16)?.takeIf { it in 0..255 }
+
+    private fun File.shareWithPServer() {
+        setReadable(false, false)
+        setReadable(true, false)
+        setWritable(false, false)
+        setWritable(true, false)
+    }
+
+    private fun File.restoreOwnerAccess() {
+        setReadable(false, false)
+        setReadable(true, true)
+        setWritable(false, false)
+        setWritable(true, true)
+    }
+
+    private fun String.shellQuoted(): String = "'${replace("'", "'\"'\"'")}'"
+
+    private companion object {
+        val BUS_RANGE = 0..31
+        const val ADDRESS = 0x3c
+        val PWM_REGISTERS = (0x0d..0x18).toList()
+    }
+}

--- a/android/app/src/main/java/com/hooandee/colores/led/Htr3212LedDevice.kt
+++ b/android/app/src/main/java/com/hooandee/colores/led/Htr3212LedDevice.kt
@@ -175,22 +175,24 @@ internal class Htr3212LedDevice internal constructor(
     ): VendorWriteResult {
         var succeeded = true
         var changed = false
-        if (seedColor && previous?.zoneColors != state.zoneColors) {
+        if (seedColor && previous?.zoneColors != state.zoneColors && store.get(descriptor.colorKey) != null) {
             changed = true
             if (!store.put(descriptor.colorKey, SettingsProviderCodec.encodeColors(state.zoneColors, STICKS))) {
                 succeeded = false
             }
         }
-        if (previous?.brightness != state.brightness) {
+        if (previous?.brightness != state.brightness && store.get(descriptor.brightnessKey) != null) {
             changed = true
             if (!store.put(descriptor.brightnessKey, SettingsProviderCodec.encodeBrightness(state.brightness, vendorDescriptor))) {
                 succeeded = false
             }
         }
         if (previous?.power != state.power) {
-            changed = true
             val values = SettingsProviderCodec.encodePower(state.power, STICKS, descriptor.enableKeys.size)
-            descriptor.enableKeys.zip(values).forEach { (key, value) ->
+            val presentKeys = descriptor.enableKeys.withIndex().filter { (_, key) -> store.get(key) != null }
+            if (presentKeys.isNotEmpty()) changed = true
+            presentKeys.forEach { (index, key) ->
+                val value = values[index]
                 if (!store.put(key, value)) succeeded = false
             }
         }

--- a/android/app/src/main/java/com/hooandee/colores/ui/AppProfilesScreen.kt
+++ b/android/app/src/main/java/com/hooandee/colores/ui/AppProfilesScreen.kt
@@ -48,13 +48,15 @@ fun ProfileSelectorPill(
     state: ColoresUiState,
     onOpen: () -> Unit,
     modifier: Modifier = Modifier,
+    compact: Boolean = false,
 ) {
     val app = state.selectedProfileApp()
     val label = app?.label ?: stringResource(R.string.profile_global)
+    val description = stringResource(R.string.profile_editing, label)
     val shape = RoundedCornerShape(999.dp)
     Surface(
         onClick = onOpen,
-        modifier = modifier.widthIn(max = 220.dp),
+        modifier = modifier.widthIn(max = 220.dp).semantics { contentDescription = description },
         shape = shape,
         color = Color.Transparent,
         contentColor = MaterialTheme.colorScheme.onSurface,
@@ -70,7 +72,7 @@ fun ProfileSelectorPill(
         ) {
             ProfileIcon(app?.icon, label, 24.dp)
             Text(
-                text = stringResource(R.string.profile_editing, label),
+                text = if (compact) label else description,
                 modifier = Modifier.weight(1f, fill = false),
                 style = MaterialTheme.typography.labelMedium,
                 fontWeight = FontWeight.SemiBold,

--- a/android/app/src/main/java/com/hooandee/colores/ui/AudioScaleDialog.kt
+++ b/android/app/src/main/java/com/hooandee/colores/ui/AudioScaleDialog.kt
@@ -92,7 +92,7 @@ internal fun AudioScaleDialog(
                 }
                 Spacer(Modifier.height(12.dp))
                 BoxWithConstraints(Modifier.fillMaxWidth().weight(1f)) {
-                    if (maxWidth >= 720.dp) {
+                    if (shouldUseTwoPaneLayout(maxWidth, maxHeight, 720.dp)) {
                         Row(Modifier.fillMaxSize(), horizontalArrangement = Arrangement.spacedBy(16.dp)) {
                             AudioScaleOverview(model, level, active, projection, { model = model.select(it) }, Modifier.weight(1f).fillMaxHeight())
                             AudioScaleColorEditor(model, projection, { model = it }, Modifier.weight(1f).fillMaxHeight())

--- a/android/app/src/main/java/com/hooandee/colores/ui/ColorControls.kt
+++ b/android/app/src/main/java/com/hooandee/colores/ui/ColorControls.kt
@@ -5,6 +5,7 @@ import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.BoxWithConstraints
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxHeight
@@ -14,10 +15,8 @@ import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
-import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
-import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.SegmentedButton
 import androidx.compose.material3.SegmentedButtonDefaults
@@ -64,6 +63,7 @@ fun ColorControlPanel(
     gradientActions: GradientActions,
     modifier: Modifier = Modifier,
 ) {
+    val compact = LocalCompactDashboard.current
     val projection = state.ledColorProjection
     val editingHsv = state.editingColor.toHsvColor()
     Surface(
@@ -74,13 +74,11 @@ fun ColorControlPanel(
     ) {
         BoxWithConstraints(modifier = Modifier.fillMaxSize()) {
             val fontScale = LocalDensity.current.fontScale
-            val colorAreaHeight = if (maxHeight < 380.dp && fontScale <= 1.15f) 120.dp else 170.dp
-            Column(
-                modifier =
-                    Modifier
-                        .fillMaxSize()
-                        .verticalScroll(rememberScrollState())
-                        .padding(horizontal = 18.dp, vertical = 14.dp),
+            val colorAreaHeight = if (compact || (maxHeight < 380.dp && fontScale <= 1.15f)) 108.dp else 170.dp
+            ScrollablePanelContent(
+                modifier = Modifier.fillMaxSize(),
+                contentPadding = PaddingValues(horizontal = if (compact) 14.dp else 18.dp, vertical = if (compact) 10.dp else 14.dp),
+                verticalArrangement = Arrangement.Top,
             ) {
                 if (colorEnabled) {
                     if (state.gradient.mode == LightingMode.GRADIENT) {
@@ -114,7 +112,7 @@ fun ColorControlPanel(
                                 modifier = Modifier.weight(1.1f),
                                 verticalArrangement = Arrangement.spacedBy(12.dp),
                             ) {
-                                CurrentColor(state, projection)
+                                CurrentColor(state)
                                 DeferredIntSlider(
                                     label = stringResource(R.string.saturation_title),
                                     committedValue = (editingHsv.saturation * 100f).roundToInt(),
@@ -159,6 +157,7 @@ private fun TargetSelector(
     enabled: Boolean,
     onTargetChange: (EditTarget) -> Unit,
 ) {
+    val compact = LocalCompactDashboard.current
     val targets =
         if (perZone) {
             EditTarget.entries
@@ -166,16 +165,21 @@ private fun TargetSelector(
             listOf(EditTarget.BOTH)
         }
     Column(verticalArrangement = Arrangement.spacedBy(4.dp)) {
-        Text(
-            text = stringResource(R.string.target_title),
-            color = MaterialTheme.colorScheme.onSurfaceVariant,
-            style = MaterialTheme.typography.labelMedium,
-            fontWeight = FontWeight.Medium,
-        )
+        if (!compact) {
+            Text(
+                text = stringResource(R.string.target_title),
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                style = MaterialTheme.typography.labelMedium,
+                fontWeight = FontWeight.Medium,
+            )
+        }
         SingleChoiceSegmentedButtonRow(modifier = Modifier.fillMaxWidth()) {
             targets.forEachIndexed { index, item ->
                 SegmentedButton(
-                    modifier = Modifier.height(48.dp),
+                    modifier =
+                        Modifier
+                            .weight(if (item == EditTarget.BOTH && perZone) 0.78f else 1f)
+                            .height(if (compact) 40.dp else 48.dp),
                     selected = target == item,
                     onClick = { onTargetChange(item) },
                     enabled = enabled,
@@ -198,37 +202,23 @@ private fun targetLabel(target: EditTarget): String =
 @Composable
 private fun CurrentColor(
     state: ColoresUiState,
-    projection: LedColorProjection,
 ) {
-    val shownColor = projection.display(state.editingColor)
-    Row(
-        modifier = Modifier.fillMaxWidth(),
-        horizontalArrangement = Arrangement.SpaceBetween,
-        verticalAlignment = Alignment.CenterVertically,
-    ) {
-        Column {
-            Text(
-                text = stringResource(R.string.color_title),
-                style = MaterialTheme.typography.titleMedium,
-                fontWeight = FontWeight.SemiBold,
-            )
-            Text(
-                text =
-                    if (state.mixedTarget) {
-                        stringResource(R.string.target_mixed)
-                    } else {
-                        stringResource(R.string.rgb_sent_value, state.editingColor.toHexString())
-                    },
-                color = MaterialTheme.colorScheme.onSurfaceVariant,
-                style = MaterialTheme.typography.labelMedium,
-            )
-        }
-        Surface(
-            modifier = Modifier.size(34.dp),
-            color = shownColor.toComposeColor(),
-            shape = CircleShape,
-            border = BorderStroke(2.dp, Color.White.copy(alpha = 0.72f)),
-        ) {}
+    Column(modifier = Modifier.fillMaxWidth()) {
+        Text(
+            text = stringResource(R.string.color_title),
+            style = MaterialTheme.typography.titleMedium,
+            fontWeight = FontWeight.SemiBold,
+        )
+        Text(
+            text =
+                if (state.mixedTarget) {
+                    stringResource(R.string.target_mixed)
+                } else {
+                    stringResource(R.string.rgb_sent_value, state.editingColor.toHexString())
+                },
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+            style = MaterialTheme.typography.labelMedium,
+        )
     }
 }
 
@@ -240,16 +230,19 @@ private fun QuickColors(
     projection: LedColorProjection,
     onColorChange: (RgbColor) -> Unit,
 ) {
+    val compact = LocalCompactDashboard.current
     Row(
         modifier = Modifier.fillMaxWidth(),
         horizontalArrangement = Arrangement.spacedBy(12.dp),
         verticalAlignment = Alignment.CenterVertically,
     ) {
-        Text(
-            text = stringResource(R.string.quick_colors),
-            color = MaterialTheme.colorScheme.onSurfaceVariant,
-            style = MaterialTheme.typography.labelMedium,
-        )
+        if (!compact) {
+            Text(
+                text = stringResource(R.string.quick_colors),
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                style = MaterialTheme.typography.labelMedium,
+            )
+        }
         Row(
             modifier = Modifier.weight(1f),
             horizontalArrangement = Arrangement.SpaceBetween,
@@ -262,8 +255,7 @@ private fun QuickColors(
                     onClick = { onColorChange(color) },
                     enabled = enabled,
                     modifier =
-                        Modifier
-                            .size(48.dp)
+                        (if (compact) Modifier.weight(1f).height(44.dp) else Modifier.size(48.dp))
                             .semantics {
                                 contentDescription = description
                                 this.selected = selected
@@ -273,7 +265,7 @@ private fun QuickColors(
                 ) {
                     Box(contentAlignment = Alignment.Center) {
                         Surface(
-                            modifier = Modifier.size(32.dp),
+                            modifier = Modifier.size(if (compact) 28.dp else 32.dp),
                             color = shownColor.toComposeColor(),
                             shape = CircleShape,
                             border =

--- a/android/app/src/main/java/com/hooandee/colores/ui/DashboardScreen.kt
+++ b/android/app/src/main/java/com/hooandee/colores/ui/DashboardScreen.kt
@@ -27,6 +27,7 @@ import androidx.compose.material3.Surface
 import androidx.compose.material3.Switch
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
@@ -164,56 +165,12 @@ private fun DashboardHeader(
     onOpenSettings: () -> Unit,
 ) {
     val settingsLabel = stringResource(R.string.settings_open)
+    val powerLabel = stringResource(R.string.power_title)
     BoxWithConstraints(Modifier.fillMaxWidth()) {
         val showSettingsLabel = maxWidth >= 720.dp
-        Row(
-            modifier = Modifier.fillMaxWidth(),
-            horizontalArrangement = Arrangement.spacedBy(20.dp),
-            verticalAlignment = Alignment.CenterVertically,
-        ) {
-            Column(modifier = Modifier.weight(1f)) {
-                Text(
-                    text = stringResource(R.string.app_name),
-                    color = MaterialTheme.colorScheme.primary,
-                    fontSize = 13.sp,
-                    fontWeight = FontWeight.Bold,
-                    letterSpacing = 2.4.sp,
-                )
-                Row(
-                    horizontalArrangement = Arrangement.spacedBy(10.dp),
-                    verticalAlignment = Alignment.CenterVertically,
-                ) {
-                    Text(
-                        text = state.devicePresentation.friendlyName.ifBlank { stringResource(R.string.device_unknown) },
-                        style = MaterialTheme.typography.titleLarge,
-                        fontWeight = FontWeight.SemiBold,
-                    )
-                    if (state.canWrite) ConnectedPill()
-                    if (state.detected == null && (state.hasHardwareLearningCandidates || state.hardwareLearningNeedsReport)) {
-                        SetupRequiredPill(needsReport = state.hardwareLearningNeedsReport)
-                    }
-                    if (state.detected != null) {
-                        ProfileSelectorPill(state = state, onOpen = onOpenProfiles)
-                    }
-                }
-            }
-            if (state.detected?.capabilities?.power == true) {
-                Row(
-                    horizontalArrangement = Arrangement.spacedBy(10.dp),
-                    verticalAlignment = Alignment.CenterVertically,
-                ) {
-                    Text(
-                        text = stringResource(R.string.power_title),
-                        color = MaterialTheme.colorScheme.onSurfaceVariant,
-                        style = MaterialTheme.typography.labelLarge,
-                    )
-                    Switch(
-                        checked = state.ledState.power,
-                        onCheckedChange = onPowerChange,
-                        enabled = state.canWrite,
-                    )
-                }
-            }
+        val compact = maxWidth < 720.dp
+        @Composable
+        fun SettingsAction() {
             Surface(
                 onClick = onOpenSettings,
                 modifier =
@@ -242,6 +199,108 @@ private fun DashboardHeader(
                 }
             }
         }
+
+        if (compact) {
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.spacedBy(12.dp),
+                verticalAlignment = Alignment.CenterVertically,
+            ) {
+                Column(modifier = Modifier.weight(1f), verticalArrangement = Arrangement.spacedBy(3.dp)) {
+                    Row(
+                        horizontalArrangement = Arrangement.spacedBy(9.dp),
+                        verticalAlignment = Alignment.CenterVertically,
+                    ) {
+                        Text(
+                            text = stringResource(R.string.app_name),
+                            color = MaterialTheme.colorScheme.primary,
+                            fontSize = 12.sp,
+                            fontWeight = FontWeight.Bold,
+                            letterSpacing = 2.2.sp,
+                        )
+                        if (state.canWrite) ConnectedPill(compact = true)
+                    }
+                    Row(
+                        horizontalArrangement = Arrangement.spacedBy(10.dp),
+                        verticalAlignment = Alignment.CenterVertically,
+                    ) {
+                        Text(
+                            text = state.devicePresentation.friendlyName.ifBlank { stringResource(R.string.device_unknown) },
+                            modifier = Modifier.weight(1f, fill = false),
+                            style = MaterialTheme.typography.titleLarge,
+                            fontWeight = FontWeight.SemiBold,
+                            maxLines = 1,
+                        )
+                        if (state.detected == null && (state.hasHardwareLearningCandidates || state.hardwareLearningNeedsReport)) {
+                            SetupRequiredPill(needsReport = state.hardwareLearningNeedsReport)
+                        }
+                        if (state.detected != null) {
+                            ProfileSelectorPill(state = state, onOpen = onOpenProfiles, compact = true)
+                        }
+                    }
+                }
+                if (state.detected?.capabilities?.power == true) {
+                    Switch(
+                        checked = state.ledState.power,
+                        onCheckedChange = onPowerChange,
+                        enabled = state.canWrite,
+                        modifier = Modifier.semantics { contentDescription = powerLabel },
+                    )
+                }
+                SettingsAction()
+            }
+        } else {
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.spacedBy(20.dp),
+                verticalAlignment = Alignment.CenterVertically,
+            ) {
+                Column(modifier = Modifier.weight(1f)) {
+                    Text(
+                        text = stringResource(R.string.app_name),
+                        color = MaterialTheme.colorScheme.primary,
+                        fontSize = 13.sp,
+                        fontWeight = FontWeight.Bold,
+                        letterSpacing = 2.4.sp,
+                    )
+                    Row(
+                        horizontalArrangement = Arrangement.spacedBy(10.dp),
+                        verticalAlignment = Alignment.CenterVertically,
+                    ) {
+                        Text(
+                            text = state.devicePresentation.friendlyName.ifBlank { stringResource(R.string.device_unknown) },
+                            style = MaterialTheme.typography.titleLarge,
+                            fontWeight = FontWeight.SemiBold,
+                        )
+                        if (state.canWrite) ConnectedPill()
+                        if (state.detected == null && (state.hasHardwareLearningCandidates || state.hardwareLearningNeedsReport)) {
+                            SetupRequiredPill(needsReport = state.hardwareLearningNeedsReport)
+                        }
+                        if (state.detected != null) {
+                            ProfileSelectorPill(state = state, onOpen = onOpenProfiles)
+                        }
+                    }
+                }
+                if (state.detected?.capabilities?.power == true) {
+                    Row(
+                        horizontalArrangement = Arrangement.spacedBy(10.dp),
+                        verticalAlignment = Alignment.CenterVertically,
+                    ) {
+                        Text(
+                            text = powerLabel,
+                            color = MaterialTheme.colorScheme.onSurfaceVariant,
+                            style = MaterialTheme.typography.labelLarge,
+                        )
+                        Switch(
+                            checked = state.ledState.power,
+                            onCheckedChange = onPowerChange,
+                            enabled = state.canWrite,
+                        )
+                    }
+                }
+                SettingsAction()
+            }
+        }
     }
 }
 
@@ -262,14 +321,14 @@ private fun SetupRequiredPill(needsReport: Boolean) {
 }
 
 @Composable
-private fun ConnectedPill() {
+private fun ConnectedPill(compact: Boolean = false) {
     Surface(
         color = Color(0xFF17372F),
         contentColor = Color(0xFF82E7C7),
         shape = RoundedCornerShape(999.dp),
     ) {
         Row(
-            modifier = Modifier.padding(horizontal = 10.dp, vertical = 5.dp),
+            modifier = Modifier.padding(horizontal = if (compact) 8.dp else 10.dp, vertical = if (compact) 3.dp else 5.dp),
             horizontalArrangement = Arrangement.spacedBy(6.dp),
             verticalAlignment = Alignment.CenterVertically,
         ) {
@@ -414,18 +473,20 @@ private fun DashboardModeLayout(
             )
         }
 
-        if (maxWidth >= 760.dp) {
-            Row(modifier = Modifier.fillMaxSize(), horizontalArrangement = Arrangement.spacedBy(16.dp)) {
-                Scene(Modifier.weight(0.88f).fillMaxHeight())
-                Panel(Modifier.weight(1.12f).fillMaxHeight())
-            }
-        } else {
-            Column(
-                modifier = Modifier.fillMaxSize().verticalScroll(rememberScrollState()),
-                verticalArrangement = Arrangement.spacedBy(14.dp),
-            ) {
-                Scene(Modifier.fillMaxWidth().height(360.dp))
-                Panel(Modifier.fillMaxWidth().height(440.dp))
+        CompositionLocalProvider(LocalCompactDashboard provides shouldUseCompactDashboardDensity(maxWidth, maxHeight)) {
+            if (shouldUseTwoPaneLayout(maxWidth, maxHeight, 760.dp)) {
+                Row(modifier = Modifier.fillMaxSize(), horizontalArrangement = Arrangement.spacedBy(16.dp)) {
+                    Scene(Modifier.weight(0.88f).fillMaxHeight())
+                    Panel(Modifier.weight(1.12f).fillMaxHeight())
+                }
+            } else {
+                Column(
+                    modifier = Modifier.fillMaxSize().verticalScroll(rememberScrollState()),
+                    verticalArrangement = Arrangement.spacedBy(14.dp),
+                ) {
+                    Scene(Modifier.fillMaxWidth().height(360.dp))
+                    Panel(Modifier.fillMaxWidth().height(440.dp))
+                }
             }
         }
     }

--- a/android/app/src/main/java/com/hooandee/colores/ui/DeviceScene.kt
+++ b/android/app/src/main/java/com/hooandee/colores/ui/DeviceScene.kt
@@ -12,7 +12,6 @@ import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
-import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.shape.CircleShape
@@ -63,8 +62,17 @@ fun DeviceScene(
     ) {
         BoxWithConstraints(modifier = Modifier.fillMaxSize()) {
             val compact = maxHeight < 320.dp
-            val ringSize = if (compact) (maxHeight - 150.dp).coerceIn(40.dp, 112.dp) else 112.dp
             val scenePadding = if (compact) 14.dp else 22.dp
+            val capsuleHorizontalPadding = 18.dp
+            val ringSpacing = 18.dp
+            val preferredRingSize = if (compact) (maxHeight - 150.dp).coerceIn(40.dp, 112.dp) else 112.dp
+            val ringSize =
+                previewRingDiameter(
+                    availableWidth = maxWidth - scenePadding * 2 - capsuleHorizontalPadding * 2,
+                    groupCount = preview.groups.size,
+                    spacing = ringSpacing,
+                    preferredDiameter = preferredRingSize,
+                )
             Column(
                 modifier = Modifier.fillMaxSize().padding(scenePadding),
                 horizontalAlignment = Alignment.CenterHorizontally,
@@ -95,8 +103,8 @@ fun DeviceScene(
                 Spacer(Modifier.weight(1f))
                 GlassPreviewCapsule {
                     Row(
-                        modifier = Modifier.padding(horizontal = 18.dp, vertical = if (compact) 12.dp else 16.dp),
-                        horizontalArrangement = Arrangement.spacedBy(18.dp),
+                        modifier = Modifier.padding(horizontal = capsuleHorizontalPadding, vertical = if (compact) 12.dp else 16.dp),
+                        horizontalArrangement = Arrangement.spacedBy(ringSpacing),
                         verticalAlignment = Alignment.CenterVertically,
                     ) {
                         preview.groups.forEachIndexed { index, segments ->
@@ -122,7 +130,9 @@ fun DeviceScene(
                         enabled = enabled,
                         modifier =
                             Modifier
-                                .heightIn(min = if (compact) 36.dp else 48.dp)
+                                .align(Alignment.CenterHorizontally)
+                                .fillMaxWidth(if (compact) 0.64f else 0.72f)
+                                .height(if (compact) 44.dp else 48.dp)
                                 .semantics {
                                     role = Role.RadioButton
                                     selected = selectedTarget == EditTarget.BOTH

--- a/android/app/src/main/java/com/hooandee/colores/ui/GradientEditorDialog.kt
+++ b/android/app/src/main/java/com/hooandee/colores/ui/GradientEditorDialog.kt
@@ -8,6 +8,7 @@ import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.BoxWithConstraints
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxHeight
@@ -20,10 +21,8 @@ import androidx.compose.foundation.layout.safeDrawingPadding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.layout.widthIn
-import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
-import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.Button
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedButton
@@ -105,7 +104,7 @@ internal fun GradientEditorDialog(
                 }
                 Spacer(Modifier.height(12.dp))
                 BoxWithConstraints(Modifier.fillMaxWidth().weight(1f)) {
-                    if (maxWidth >= 720.dp) {
+                    if (shouldUseTwoPaneLayout(maxWidth, maxHeight, 720.dp)) {
                         Row(
                             modifier = Modifier.fillMaxSize(),
                             horizontalArrangement = Arrangement.spacedBy(16.dp),
@@ -142,8 +141,9 @@ private fun GradientZonesPane(
         color = Color.Transparent,
         shape = RoundedCornerShape(28.dp),
     ) {
-        Column(
-            modifier = Modifier.fillMaxSize().verticalScroll(rememberScrollState()).padding(18.dp),
+        ScrollablePanelContent(
+            modifier = Modifier.fillMaxSize(),
+            contentPadding = PaddingValues(18.dp),
             verticalArrangement = Arrangement.spacedBy(16.dp),
         ) {
             if (animated) {
@@ -413,8 +413,9 @@ private fun GradientColorPane(
         color = Color.Transparent,
         shape = RoundedCornerShape(28.dp),
     ) {
-        Column(
-            modifier = Modifier.fillMaxSize().verticalScroll(rememberScrollState()).padding(18.dp),
+        ScrollablePanelContent(
+            modifier = Modifier.fillMaxSize(),
+            contentPadding = PaddingValues(18.dp),
             verticalArrangement = Arrangement.spacedBy(14.dp),
         ) {
             Row(

--- a/android/app/src/main/java/com/hooandee/colores/ui/HardwareLearningDialog.kt
+++ b/android/app/src/main/java/com/hooandee/colores/ui/HardwareLearningDialog.kt
@@ -78,7 +78,7 @@ internal fun HardwareLearningDialog(
             modifier = Modifier.fillMaxSize().safeDrawingPadding().padding(horizontal = 20.dp, vertical = 16.dp),
             contentAlignment = Alignment.Center,
         ) {
-            val landscape = maxWidth >= 700.dp && maxWidth > maxHeight
+            val landscape = isUsableLandscape(maxWidth, maxHeight)
             Surface(
                 modifier =
                     Modifier

--- a/android/app/src/main/java/com/hooandee/colores/ui/ModePanels.kt
+++ b/android/app/src/main/java/com/hooandee/colores/ui/ModePanels.kt
@@ -23,10 +23,8 @@ import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.LazyRow
 import androidx.compose.foundation.lazy.items
-import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
-import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.ExperimentalMaterial3Api
@@ -64,6 +62,7 @@ import androidx.compose.ui.semantics.contentDescription
 import androidx.compose.ui.semantics.selected
 import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import com.hooandee.colores.R
@@ -167,19 +166,17 @@ private fun PanelSurface(
     modifier: Modifier,
     content: @Composable () -> Unit,
 ) {
+    val compact = LocalCompactDashboard.current
     Surface(
         modifier = modifier.prismaticPanel(RoundedCornerShape(32.dp), strong = true),
         color = Color.Transparent,
         contentColor = MaterialTheme.colorScheme.onSurface,
         shape = RoundedCornerShape(32.dp),
     ) {
-        Column(
-            modifier =
-                Modifier
-                    .fillMaxSize()
-                    .verticalScroll(rememberScrollState())
-                    .padding(horizontal = 18.dp, vertical = 16.dp),
-            verticalArrangement = Arrangement.spacedBy(14.dp),
+        ScrollablePanelContent(
+            modifier = Modifier.fillMaxSize(),
+            contentPadding = PaddingValues(horizontal = if (compact) 14.dp else 18.dp, vertical = if (compact) 12.dp else 16.dp),
+            verticalArrangement = Arrangement.spacedBy(if (compact) 10.dp else 14.dp),
         ) {
             content()
         }
@@ -342,18 +339,28 @@ private fun SensorsPanel(
     onBrightnessChange: (Int) -> Unit,
     modeActions: ModeActions,
 ) {
+    val compact = LocalCompactDashboard.current
     val sensorModes = state.availableSensorModes()
     var editingScale by remember { mutableStateOf<SensorKind?>(null) }
     if (sensorModes.size > 1) {
         SingleChoiceSegmentedButtonRow(modifier = Modifier.fillMaxWidth()) {
             sensorModes.forEachIndexed { index, mode ->
                 SegmentedButton(
-                    modifier = Modifier.height(44.dp),
+                    modifier = Modifier.height(if (compact) 40.dp else 44.dp),
                     selected = state.mode == mode,
                     onClick = { modeActions.onSensorModeChange(mode) },
                     enabled = state.canWrite,
                     shape = SegmentedButtonDefaults.itemShape(index, sensorModes.size),
-                    label = { Text(sensorLabel(mode)) },
+                    contentPadding = PaddingValues(horizontal = if (compact) 4.dp else 12.dp),
+                    icon = {},
+                    label = {
+                        Text(
+                            sensorLabel(mode),
+                            maxLines = 1,
+                            overflow = TextOverflow.Ellipsis,
+                            style = if (compact) MaterialTheme.typography.labelSmall else MaterialTheme.typography.labelLarge,
+                        )
+                    },
                 )
             }
         }
@@ -730,6 +737,7 @@ private fun AudioPanel(
     onScaleChange: (AudioScale) -> Unit,
     onSensitivityChange: (Int) -> Unit,
 ) {
+    val compact = LocalCompactDashboard.current
     var editingScale by remember { mutableStateOf(false) }
     val status =
         when (state.audio.status) {
@@ -813,24 +821,26 @@ private fun AudioPanel(
     OutlinedButton(
         onClick = { editingScale = true },
         enabled = state.canWrite,
-        modifier = Modifier.fillMaxWidth().height(68.dp),
-        contentPadding = PaddingValues(horizontal = 16.dp, vertical = 10.dp),
+        modifier = Modifier.fillMaxWidth().height(if (compact) 58.dp else 68.dp),
+        contentPadding = PaddingValues(horizontal = if (compact) 12.dp else 16.dp, vertical = if (compact) 7.dp else 10.dp),
     ) {
         Row(
             modifier = Modifier.fillMaxWidth(),
-            horizontalArrangement = Arrangement.spacedBy(18.dp),
+            horizontalArrangement = Arrangement.spacedBy(if (compact) 12.dp else 18.dp),
             verticalAlignment = Alignment.CenterVertically,
         ) {
             Column(modifier = Modifier.weight(1f)) {
                 Text(stringResource(R.string.audio_scale_title), fontWeight = FontWeight.SemiBold)
-                Text(
-                    stringResource(R.string.audio_scale_customize),
-                    color = MaterialTheme.colorScheme.onSurfaceVariant,
-                    style = MaterialTheme.typography.bodySmall,
-                    maxLines = 1,
-                )
+                if (!compact) {
+                    Text(
+                        stringResource(R.string.audio_scale_customize),
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                        style = MaterialTheme.typography.bodySmall,
+                        maxLines = 1,
+                    )
+                }
             }
-            Column(modifier = Modifier.width(146.dp), verticalArrangement = Arrangement.spacedBy(5.dp)) {
+            Column(modifier = Modifier.width(if (compact) 104.dp else 146.dp), verticalArrangement = Arrangement.spacedBy(5.dp)) {
                 Box(
                     modifier =
                         Modifier
@@ -858,12 +868,9 @@ private fun AudioPanel(
             }
         }
     }
-    Row(
-        modifier = Modifier.fillMaxWidth(),
-        horizontalArrangement = Arrangement.spacedBy(20.dp),
-        verticalAlignment = Alignment.Top,
-    ) {
-        Column(modifier = Modifier.weight(1f)) {
+    ResponsiveControlPair(
+        secondVisible = state.brightnessEnabled,
+        first = {
             DeferredIntSlider(
                 label = stringResource(R.string.audio_sensitivity_title),
                 committedValue = state.audioSensitivityDb,
@@ -873,20 +880,9 @@ private fun AudioPanel(
                 steps = AudioSensitivity.MAX_DB - AudioSensitivity.MIN_DB - 1,
                 enabled = state.canWrite,
             )
-        }
-        if (state.brightnessEnabled) {
-            Column(modifier = Modifier.weight(1f)) {
-                DeferredIntSlider(
-                    label = stringResource(R.string.brightness_title),
-                    committedValue = state.ledState.brightness,
-                    valueLabel = { stringResource(R.string.brightness_value, it) },
-                    onValueCommit = onBrightnessChange,
-                    valueRange = 0..100,
-                    enabled = state.canWrite,
-                )
-            }
-        }
-    }
+        },
+        second = { BrightnessRow(state, onBrightnessChange) },
+    )
     if (editingScale) {
         AudioScaleDialog(
             initial = state.audioScale,
@@ -948,45 +944,43 @@ private fun AmbientPanel(
         status = status,
         onActivate = actions.onAmbientCaptureRequest,
     )
-    Row(
-        modifier = Modifier.fillMaxWidth(),
-        horizontalArrangement = Arrangement.spacedBy(20.dp),
-        verticalAlignment = Alignment.Top,
-    ) {
-        Column(modifier = Modifier.weight(1f), verticalArrangement = Arrangement.spacedBy(8.dp)) {
-            Text(stringResource(R.string.ambient_sampling_title), style = MaterialTheme.typography.labelMedium)
-            SingleChoiceSegmentedButtonRow(Modifier.fillMaxWidth().padding(horizontal = 1.dp)) {
-                AmbientSamplingMode.entries.forEachIndexed { index, mode ->
-                    val label =
-                        if (mode == AmbientSamplingMode.FULL_SCENE) {
-                            stringResource(R.string.ambient_sampling_full)
-                        } else {
-                            stringResource(R.string.ambient_sampling_bottom)
+    ResponsiveControlPair(
+        first = {
+            Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
+                Text(stringResource(R.string.ambient_sampling_title), style = MaterialTheme.typography.labelMedium)
+                SingleChoiceSegmentedButtonRow(Modifier.fillMaxWidth().padding(horizontal = 1.dp)) {
+                    AmbientSamplingMode.entries.forEachIndexed { index, mode ->
+                        val label =
+                            if (mode == AmbientSamplingMode.FULL_SCENE) {
+                                stringResource(R.string.ambient_sampling_full)
+                            } else {
+                                stringResource(R.string.ambient_sampling_bottom)
+                            }
+                        val accessibleLabel =
+                            if (mode == AmbientSamplingMode.FULL_SCENE) {
+                                stringResource(R.string.ambient_sampling_full_accessibility)
+                            } else {
+                                stringResource(R.string.ambient_sampling_bottom_accessibility)
+                            }
+                        SegmentedButton(
+                            modifier =
+                                Modifier
+                                    .height(46.dp)
+                                    .semantics { contentDescription = accessibleLabel },
+                            selected = state.ambientSamplingMode == mode,
+                            onClick = { actions.onAmbientSamplingModeChange(mode) },
+                            enabled = state.canWrite,
+                            shape = SegmentedButtonDefaults.itemShape(index, AmbientSamplingMode.entries.size),
+                            contentPadding = PaddingValues(horizontal = 8.dp),
+                            icon = {},
+                        ) {
+                            Text(label, maxLines = 1, style = MaterialTheme.typography.labelMedium)
                         }
-                    val accessibleLabel =
-                        if (mode == AmbientSamplingMode.FULL_SCENE) {
-                            stringResource(R.string.ambient_sampling_full_accessibility)
-                        } else {
-                            stringResource(R.string.ambient_sampling_bottom_accessibility)
-                        }
-                    SegmentedButton(
-                        modifier =
-                            Modifier
-                                .height(46.dp)
-                                .semantics { contentDescription = accessibleLabel },
-                        selected = state.ambientSamplingMode == mode,
-                        onClick = { actions.onAmbientSamplingModeChange(mode) },
-                        enabled = state.canWrite,
-                        shape = SegmentedButtonDefaults.itemShape(index, AmbientSamplingMode.entries.size),
-                        contentPadding = PaddingValues(horizontal = 8.dp),
-                        icon = {},
-                    ) {
-                        Text(label, maxLines = 1, style = MaterialTheme.typography.labelMedium)
                     }
                 }
             }
-        }
-        Column(modifier = Modifier.weight(1f)) {
+        },
+        second = {
             DeferredIntSlider(
                 label = stringResource(R.string.ambient_capture_rate),
                 committedValue = state.ambientCaptureFps,
@@ -996,14 +990,10 @@ private fun AmbientPanel(
                 steps = 4,
                 enabled = state.canWrite,
             )
-        }
-    }
-    Row(
-        modifier = Modifier.fillMaxWidth(),
-        horizontalArrangement = Arrangement.spacedBy(20.dp),
-        verticalAlignment = Alignment.Top,
-    ) {
-        Column(modifier = Modifier.weight(1f)) {
+        },
+    )
+    ResponsiveControlPair(
+        first = {
             DeferredIntSlider(
                 label = stringResource(R.string.ambient_vividness),
                 committedValue = state.ambientVividness,
@@ -1012,8 +1002,8 @@ private fun AmbientPanel(
                 valueRange = 0..100,
                 enabled = state.canWrite,
             )
-        }
-        Column(modifier = Modifier.weight(1f)) {
+        },
+        second = {
             DeferredIntSlider(
                 label = stringResource(R.string.ambient_smoothing),
                 committedValue = state.ambientSmoothing,
@@ -1022,8 +1012,8 @@ private fun AmbientPanel(
                 valueRange = 0..100,
                 enabled = state.canWrite,
             )
-        }
-    }
+        },
+    )
     BrightnessRow(state, onBrightnessChange)
 }
 
@@ -1033,7 +1023,13 @@ private fun AmbientSceneWindow(
     status: String,
     onActivate: () -> Unit,
 ) {
+    val compact = LocalCompactDashboard.current
     val capturing = state.ambient.status == AmbientCaptureStatus.CAPTURING
+    val needsAuthorization = state.ambientNeedsAuthorization
+    val lightAuthorization = needsAuthorization && MaterialTheme.colorScheme.background.luminance() > 0.5f
+    val authorizationInk = if (lightAuthorization) MaterialTheme.colorScheme.onSurface else Color(0xFFF4F7FA)
+    val authorizationSurface = MaterialTheme.colorScheme.surfaceContainer
+    val authorizationOutline = MaterialTheme.colorScheme.outlineVariant
     val frameColors =
         if (capturing) {
             state.currentFrame.map { state.ledColorProjection.display(it).toComposeColor() }
@@ -1042,7 +1038,12 @@ private fun AmbientSceneWindow(
         }
     val sceneColors =
         when (frameColors.size) {
-            0 -> listOf(Color(0xFF131A25), Color(0xFF273347), Color(0xFF111723))
+            0 ->
+                if (lightAuthorization) {
+                    listOf(MaterialTheme.colorScheme.surfaceContainerHigh, MaterialTheme.colorScheme.surfaceContainerHighest)
+                } else {
+                    listOf(Color(0xFF131A25), Color(0xFF273347), Color(0xFF111723))
+                }
             1 -> listOf(frameColors.first(), frameColors.first())
             else -> frameColors
         }
@@ -1051,10 +1052,10 @@ private fun AmbientSceneWindow(
             AmbientCaptureStatus.CAPTURING -> Color(0xFF8DE8C5)
             AmbientCaptureStatus.STARTING -> Color(0xFFF4F7FA)
             AmbientCaptureStatus.NO_FRAMES -> Color(0xFFFFC978)
-            AmbientCaptureStatus.AUTHORIZATION_REQUIRED -> Color(0xFFD8E0E7)
+            AmbientCaptureStatus.AUTHORIZATION_REQUIRED ->
+                if (lightAuthorization) MaterialTheme.colorScheme.primary else Color(0xFFD8E0E7)
             AmbientCaptureStatus.REVOKED, AmbientCaptureStatus.ERROR -> Color(0xFFFF9B8F)
         }
-    val needsAuthorization = state.ambientNeedsAuthorization
     val shape = RoundedCornerShape(22.dp)
 
     Box(
@@ -1070,15 +1071,22 @@ private fun AmbientSceneWindow(
             val sceneBrush = Brush.horizontalGradient(sceneColors)
 
             drawRect(if (capturing) sceneBrush else Brush.linearGradient(sceneColors))
-            drawRect(
-                Brush.verticalGradient(
-                    0f to Color.Black.copy(alpha = 0.18f),
-                    0.55f to Color.Black.copy(alpha = 0.04f),
-                    1f to Color.Black.copy(alpha = 0.42f),
-                ),
-            )
+            if (!lightAuthorization) {
+                drawRect(
+                    Brush.verticalGradient(
+                        0f to Color.Black.copy(alpha = 0.18f),
+                        0.55f to Color.Black.copy(alpha = 0.04f),
+                        1f to Color.Black.copy(alpha = 0.42f),
+                    ),
+                )
+            }
             drawRoundRect(
-                color = Color(0xFF070A0F).copy(alpha = if (capturing) 0.84f else 0.94f),
+                color =
+                    if (lightAuthorization) {
+                        authorizationSurface.copy(alpha = 0.88f)
+                    } else {
+                        Color(0xFF070A0F).copy(alpha = if (capturing) 0.84f else 0.94f)
+                    },
                 topLeft = Offset(inset, inset),
                 size = androidx.compose.ui.geometry.Size(size.width - inset * 2f, size.height - inset * 2f),
                 cornerRadius = CornerRadius(innerRadius),
@@ -1124,7 +1132,12 @@ private fun AmbientSceneWindow(
                 )
             }
             drawRoundRect(
-                color = Color.White.copy(alpha = 0.18f),
+                color =
+                    if (lightAuthorization) {
+                        authorizationOutline
+                    } else {
+                        Color.White.copy(alpha = 0.18f)
+                    },
                 topLeft = Offset(inset, inset),
                 size = androidx.compose.ui.geometry.Size(size.width - inset * 2f, size.height - inset * 2f),
                 cornerRadius = CornerRadius(innerRadius),
@@ -1164,7 +1177,7 @@ private fun AmbientSceneWindow(
                 ) {
                     Text(
                         text = stringResource(R.string.ambient_title).uppercase(),
-                        color = Color.White.copy(alpha = 0.72f),
+                        color = authorizationInk.copy(alpha = 0.72f),
                         style = MaterialTheme.typography.labelLarge,
                         fontWeight = FontWeight.Medium,
                         letterSpacing = 1.8.sp,
@@ -1173,7 +1186,7 @@ private fun AmbientSceneWindow(
                         title = stringResource(R.string.ambient_title),
                         description = stringResource(R.string.ambient_description),
                         modifier = Modifier.height(36.dp),
-                        contentColor = Color(0xFFF4F7FA),
+                        contentColor = authorizationInk,
                     )
                 }
                 Row(
@@ -1202,8 +1215,12 @@ private fun AmbientSceneWindow(
                             Modifier
                                 .height(40.dp)
                                 .semantics { contentDescription = activationDescription },
-                        border = BorderStroke(1.dp, Color.White.copy(alpha = 0.58f)),
-                        colors = ButtonDefaults.outlinedButtonColors(contentColor = Color(0xFFF4F7FA)),
+                        border =
+                            BorderStroke(
+                                1.dp,
+                                if (lightAuthorization) MaterialTheme.colorScheme.outline else Color.White.copy(alpha = 0.58f),
+                            ),
+                        colors = ButtonDefaults.outlinedButtonColors(contentColor = authorizationInk),
                     ) {
                         Text(stringResource(R.string.ambient_activate))
                     }
@@ -1232,7 +1249,12 @@ private fun AmbientSceneWindow(
                     ) {
                         Box(Modifier.size(8.dp).background(statusColor, CircleShape))
                         Text(
-                            text = status,
+                            text =
+                                if (compact && state.ambient.status == AmbientCaptureStatus.CAPTURING) {
+                                    stringResource(R.string.ambient_status_capturing_compact)
+                                } else {
+                                    status
+                                },
                             color = statusColor,
                             style = MaterialTheme.typography.bodyLarge,
                             fontWeight = FontWeight.SemiBold,
@@ -1266,6 +1288,49 @@ private fun EditorialModeLayout(
     compactValue: Boolean = false,
     content: @Composable ColumnScope.() -> Unit,
 ) {
+    val compact = LocalCompactDashboard.current
+    if (compact) {
+        Column(
+            modifier = Modifier.fillMaxWidth(),
+            verticalArrangement = Arrangement.spacedBy(10.dp),
+        ) {
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.spacedBy(12.dp),
+                verticalAlignment = Alignment.Top,
+            ) {
+                Column(modifier = Modifier.weight(1f), verticalArrangement = Arrangement.spacedBy(5.dp)) {
+                    Text(
+                        text = title.uppercase(),
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                        style = MaterialTheme.typography.labelMedium,
+                        fontWeight = FontWeight.Medium,
+                        letterSpacing = 1.2.sp,
+                    )
+                    if (status != null) {
+                        Text(
+                            text = status,
+                            color = MaterialTheme.colorScheme.primary,
+                            style = MaterialTheme.typography.labelLarge,
+                            fontWeight = FontWeight.SemiBold,
+                        )
+                    }
+                }
+                Column(horizontalAlignment = Alignment.End) {
+                    Text(
+                        text = value ?: title,
+                        style = if (value != null) MaterialTheme.typography.headlineLarge else MaterialTheme.typography.titleLarge,
+                        fontWeight = FontWeight.Bold,
+                        maxLines = 1,
+                        softWrap = false,
+                    )
+                    ModeExplanationAction(title = title, description = description)
+                }
+            }
+            Column(verticalArrangement = Arrangement.spacedBy(10.dp), content = content)
+        }
+        return
+    }
     val dividerColor = MaterialTheme.colorScheme.outlineVariant.copy(alpha = 0.58f)
     Row(
         modifier = Modifier.fillMaxWidth(),
@@ -1451,6 +1516,31 @@ private fun BrightnessRow(
         valueRange = 0..100,
         enabled = state.canWrite,
     )
+}
+
+@Composable
+private fun ResponsiveControlPair(
+    secondVisible: Boolean = true,
+    first: @Composable () -> Unit,
+    second: @Composable () -> Unit,
+) {
+    if (LocalCompactDashboard.current) {
+        Column(Modifier.fillMaxWidth(), verticalArrangement = Arrangement.spacedBy(8.dp)) {
+            first()
+            if (secondVisible) second()
+        }
+    } else {
+        Row(
+            modifier = Modifier.fillMaxWidth(),
+            horizontalArrangement = Arrangement.spacedBy(20.dp),
+            verticalAlignment = Alignment.Top,
+        ) {
+            Column(modifier = Modifier.weight(1f)) { first() }
+            if (secondVisible) {
+                Column(modifier = Modifier.weight(1f)) { second() }
+            }
+        }
+    }
 }
 
 @Composable

--- a/android/app/src/main/java/com/hooandee/colores/ui/ResponsiveLayout.kt
+++ b/android/app/src/main/java/com/hooandee/colores/ui/ResponsiveLayout.kt
@@ -1,0 +1,34 @@
+package com.hooandee.colores.ui
+
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.dp
+import androidx.compose.runtime.staticCompositionLocalOf
+
+internal val LocalCompactDashboard = staticCompositionLocalOf { false }
+
+internal fun isUsableLandscape(
+    width: Dp,
+    height: Dp,
+): Boolean = width >= 560.dp && width > height
+
+internal fun shouldUseCompactDashboardDensity(
+    width: Dp,
+    height: Dp,
+): Boolean = isUsableLandscape(width, height) && height < 480.dp
+
+internal fun shouldUseTwoPaneLayout(
+    width: Dp,
+    height: Dp,
+    expandedWidth: Dp,
+): Boolean = width >= expandedWidth || isUsableLandscape(width, height)
+
+internal fun previewRingDiameter(
+    availableWidth: Dp,
+    groupCount: Int,
+    spacing: Dp,
+    preferredDiameter: Dp,
+): Dp {
+    if (groupCount <= 0) return preferredDiameter
+    val totalSpacing = spacing * (groupCount - 1)
+    return ((availableWidth - totalSpacing) / groupCount).coerceIn(40.dp, preferredDiameter)
+}

--- a/android/app/src/main/java/com/hooandee/colores/ui/ScrollablePanelContent.kt
+++ b/android/app/src/main/java/com/hooandee/colores/ui/ScrollablePanelContent.kt
@@ -1,0 +1,84 @@
+package com.hooandee.colores.ui
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.ColumnScope
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.derivedStateOf
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Brush
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import com.hooandee.colores.R
+
+@Composable
+internal fun ScrollablePanelContent(
+    modifier: Modifier = Modifier,
+    contentPadding: PaddingValues = PaddingValues(horizontal = 18.dp, vertical = 16.dp),
+    verticalArrangement: Arrangement.Vertical = Arrangement.spacedBy(14.dp),
+    content: @Composable ColumnScope.() -> Unit,
+) {
+    val scrollState = rememberScrollState()
+    val showContinuation by remember { derivedStateOf { scrollState.canScrollForward } }
+    Box(modifier = modifier) {
+        Column(
+            modifier = Modifier.fillMaxSize().verticalScroll(scrollState).padding(contentPadding),
+            verticalArrangement = verticalArrangement,
+            content = content,
+        )
+        if (showContinuation) {
+            Box(
+                modifier =
+                    Modifier
+                        .align(Alignment.BottomCenter)
+                        .fillMaxWidth()
+                        .background(
+                            Brush.verticalGradient(
+                                listOf(
+                                    MaterialTheme.colorScheme.surfaceContainer.copy(alpha = 0f),
+                                    MaterialTheme.colorScheme.surfaceContainer.copy(alpha = 0.94f),
+                                ),
+                            ),
+                        ).padding(top = 24.dp, bottom = 6.dp),
+                contentAlignment = Alignment.Center,
+            ) {
+                Surface(
+                    color = MaterialTheme.colorScheme.surfaceContainerHighest.copy(alpha = 0.98f),
+                    contentColor = MaterialTheme.colorScheme.onSurface,
+                    shape = RoundedCornerShape(999.dp),
+                    tonalElevation = 2.dp,
+                ) {
+                    Row(
+                        modifier = Modifier.padding(horizontal = 12.dp, vertical = 5.dp),
+                        horizontalArrangement = Arrangement.spacedBy(7.dp),
+                        verticalAlignment = Alignment.CenterVertically,
+                    ) {
+                        Text("↓", color = MaterialTheme.colorScheme.primary, fontWeight = FontWeight.Bold)
+                        Text(
+                            stringResource(R.string.more_settings_below),
+                            style = MaterialTheme.typography.labelMedium,
+                            fontWeight = FontWeight.SemiBold,
+                        )
+                    }
+                }
+            }
+        }
+    }
+}

--- a/android/app/src/main/java/com/hooandee/colores/ui/SensorScaleDialog.kt
+++ b/android/app/src/main/java/com/hooandee/colores/ui/SensorScaleDialog.kt
@@ -93,7 +93,7 @@ internal fun SensorScaleDialog(
                 }
                 Spacer(Modifier.height(12.dp))
                 BoxWithConstraints(Modifier.fillMaxWidth().weight(1f)) {
-                    if (maxWidth >= 720.dp) {
+                    if (shouldUseTwoPaneLayout(maxWidth, maxHeight, 720.dp)) {
                         Row(Modifier.fillMaxSize(), horizontalArrangement = Arrangement.spacedBy(16.dp)) {
                             SensorBandList(model, projection, { model = model.select(it) }, Modifier.weight(1f).fillMaxHeight())
                             SensorBandEditor(model, projection, { model = it }, Modifier.weight(1f).fillMaxHeight())

--- a/android/app/src/main/java/com/hooandee/colores/ui/SettingsScreen.kt
+++ b/android/app/src/main/java/com/hooandee/colores/ui/SettingsScreen.kt
@@ -96,7 +96,7 @@ fun SettingsScreen(
     var legalOpen by remember { mutableStateOf(false) }
     PrismaticBackdrop(modifier = Modifier.fillMaxSize()) {
         BoxWithConstraints(Modifier.fillMaxSize()) {
-            if (maxWidth >= 760.dp) {
+            if (shouldUseTwoPaneLayout(maxWidth, maxHeight, 760.dp)) {
                 Column(
                     modifier =
                         Modifier
@@ -313,18 +313,19 @@ private fun ProfilesOverview(state: ColoresUiState) {
                     Text("G", fontWeight = FontWeight.Black, style = MaterialTheme.typography.titleMedium)
                 }
             }
-            Text(
-                stringResource(R.string.settings_profiles_global_base),
-                modifier = Modifier.weight(1f),
-                fontWeight = FontWeight.Bold,
-            )
-            ProfileValue(
-                pluralStringResource(
-                    R.plurals.settings_profiles_count,
-                    state.configuredProfiles.size,
-                    state.configuredProfiles.size,
-                ),
-            )
+            Column(modifier = Modifier.weight(1f), verticalArrangement = Arrangement.spacedBy(5.dp)) {
+                Text(
+                    stringResource(R.string.settings_profiles_global_base),
+                    fontWeight = FontWeight.Bold,
+                )
+                ProfileValue(
+                    pluralStringResource(
+                        R.plurals.settings_profiles_count,
+                        state.configuredProfiles.size,
+                        state.configuredProfiles.size,
+                    ),
+                )
+            }
         }
         Row(
             modifier = Modifier.fillMaxWidth(),

--- a/android/app/src/main/res/values-en/strings.xml
+++ b/android/app/src/main/res/values-en/strings.xml
@@ -30,6 +30,7 @@
     <string name="settings_accent_picker">Glass light picker</string>
     <string name="settings_accent_reset">Restore original light</string>
     <string name="mode_how_it_works">How it works</string>
+    <string name="more_settings_below">More settings below</string>
     <string name="settings_led_preview_description">Adjusts the visual representation to the real LEDs when calibration is available.</string>
     <string name="settings_diagnostics">Your device</string>
     <string name="settings_diagnostic_device">Device</string>
@@ -296,7 +297,7 @@
     <string name="audio_status_revoked">Capture stopped</string>
     <string name="audio_status_error">Could not start</string>
     <string name="ambient_title">Ambilight</string>
-    <string name="ambient_description">The screen is reduced to 32 × 18 in memory. Its colors guide the LEDs, and no capture is stored.\n\n10 fps is recommended for gaming. A higher rate responds sooner and uses more resources.</string>
+    <string name="ambient_description">Ambilight captures the complete display and reduces it in memory to at most 32 pixels on the long edge while preserving its aspect ratio. Its colors guide the LEDs, and no capture is stored.\n\n10 fps is recommended for gaming. A higher rate responds sooner and uses more resources.</string>
     <string name="ambient_sampling_title">Capture area</string>
     <string name="ambient_sampling_full">Full</string>
     <string name="ambient_sampling_bottom">Bottom</string>
@@ -308,12 +309,13 @@
     <string name="ambient_vividness">Color intensity</string>
     <string name="ambient_smoothing">Smoothing</string>
     <string name="percent_value">%1$d%%</string>
-    <string name="ambient_privacy">The image is reduced to 32 × 18 and processed in memory. No capture is stored.</string>
+    <string name="ambient_privacy">To follow every game, Ambilight captures the complete display. The image keeps its aspect ratio, is reduced to at most 32 pixels, and is not stored.</string>
     <string name="ambient_activate">Enable</string>
-    <string name="ambient_activate_accessibility">Enable screen capture</string>
+    <string name="ambient_activate_accessibility">Enable complete display capture</string>
     <string name="ambient_status_authorization_required">Authorization required</string>
     <string name="ambient_status_starting">Starting capture</string>
     <string name="ambient_status_capturing">Screen capture active</string>
+    <string name="ambient_status_capturing_compact">Capturing</string>
     <string name="ambient_status_no_frames">The screen is not providing frames. The last color is preserved.</string>
     <string name="ambient_status_revoked">Android revoked capture. You can enable it again.</string>
     <string name="ambient_status_error">Capture could not start. You can try again.</string>

--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -30,6 +30,7 @@
     <string name="settings_accent_picker">Selector de la luz del cristal</string>
     <string name="settings_accent_reset">Restaurar luz original</string>
     <string name="mode_how_it_works">Cómo funciona</string>
+    <string name="more_settings_below">Más ajustes abajo</string>
     <string name="settings_led_preview_description">Ajusta la representación visual al aspecto real de los LEDs cuando hay una calibración disponible.</string>
     <string name="settings_diagnostics">Tu dispositivo</string>
     <string name="settings_diagnostic_device">Dispositivo</string>
@@ -296,7 +297,7 @@
     <string name="audio_status_revoked">Captura detenida</string>
     <string name="audio_status_error">No se pudo iniciar</string>
     <string name="ambient_title">Ambilight</string>
-    <string name="ambient_description">La pantalla se reduce a 32 × 18 en memoria. Sus colores guían los LEDs y no se guarda ninguna captura.\n\n10 fps es el valor recomendado para jugar. Una frecuencia mayor responde antes y consume más recursos.</string>
+    <string name="ambient_description">Ambilight captura la pantalla completa y la reduce en memoria a un máximo de 32 píxeles en el lado largo, conservando su proporción. Sus colores guían los LEDs y no se guarda ninguna captura.\n\n10 fps es el valor recomendado para jugar. Una frecuencia mayor responde antes y consume más recursos.</string>
     <string name="ambient_sampling_title">Zona de captura</string>
     <string name="ambient_sampling_full">Completa</string>
     <string name="ambient_sampling_bottom">Inferior</string>
@@ -308,12 +309,13 @@
     <string name="ambient_vividness">Intensidad de color</string>
     <string name="ambient_smoothing">Suavizado</string>
     <string name="percent_value">%1$d%%</string>
-    <string name="ambient_privacy">La imagen se reduce a 32 × 18 y se procesa en memoria. No se guarda ninguna captura.</string>
+    <string name="ambient_privacy">Para seguir todos los juegos, Ambilight captura la pantalla completa. La imagen conserva su proporción, se reduce a un máximo de 32 píxeles y no se guarda.</string>
     <string name="ambient_activate">Activar</string>
-    <string name="ambient_activate_accessibility">Activar captura de pantalla</string>
+    <string name="ambient_activate_accessibility">Activar captura de pantalla completa</string>
     <string name="ambient_status_authorization_required">Autorización necesaria</string>
     <string name="ambient_status_starting">Iniciando captura</string>
     <string name="ambient_status_capturing">Captura de pantalla activa</string>
+    <string name="ambient_status_capturing_compact">Capturando</string>
     <string name="ambient_status_no_frames">La pantalla no está entregando imágenes. Se conserva el último color.</string>
     <string name="ambient_status_revoked">Android ha revocado la captura. Puedes activarla de nuevo.</string>
     <string name="ambient_status_error">No se pudo iniciar la captura. Puedes intentarlo de nuevo.</string>

--- a/android/app/src/test/java/com/hooandee/colores/ProjectionCaptureScopeTest.kt
+++ b/android/app/src/test/java/com/hooandee/colores/ProjectionCaptureScopeTest.kt
@@ -1,0 +1,22 @@
+package com.hooandee.colores
+
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class ProjectionCaptureScopeTest {
+    @Test
+    fun `ambilight captures the complete display on Android 14 and newer`() {
+        assertTrue(shouldCaptureDefaultDisplay(ProjectionRequest.AMBIENT, sdk = 34))
+    }
+
+    @Test
+    fun `ambilight keeps compatible user consent before Android 14`() {
+        assertFalse(shouldCaptureDefaultDisplay(ProjectionRequest.AMBIENT, sdk = 33))
+    }
+
+    @Test
+    fun `audio keeps user selected capture on Android 14`() {
+        assertFalse(shouldCaptureDefaultDisplay(ProjectionRequest.AUDIO, sdk = 34))
+    }
+}

--- a/android/app/src/test/java/com/hooandee/colores/ambient/AmbientSamplingTest.kt
+++ b/android/app/src/test/java/com/hooandee/colores/ambient/AmbientSamplingTest.kt
@@ -8,6 +8,28 @@ import org.junit.Test
 
 class AmbientSamplingTest {
     @Test
+    fun `capture surface preserves common landscape display aspect ratios`() {
+        val cases =
+            listOf(
+                Triple(1280 to 960, AmbientCaptureDimensions(32, 24), "4:3"),
+                Triple(1920 to 1080, AmbientCaptureDimensions(32, 18), "16:9"),
+                Triple(1280 to 800, AmbientCaptureDimensions(32, 20), "16:10"),
+                Triple(2400 to 1080, AmbientCaptureDimensions(32, 14), "20:9"),
+                Triple(1024 to 1024, AmbientCaptureDimensions(32, 32), "1:1"),
+            )
+
+        cases.forEach { (display, expected, label) ->
+            assertEquals(label, expected, ambientCaptureDimensions(display.first, display.second))
+        }
+    }
+
+    @Test
+    fun `capture surface preserves portrait display aspect ratios`() {
+        assertEquals(AmbientCaptureDimensions(18, 32), ambientCaptureDimensions(1080, 1920))
+        assertEquals(AmbientCaptureDimensions(24, 32), ambientCaptureDimensions(960, 1280))
+    }
+
+    @Test
     fun `global sampling reads RGBA rows with padding and repeats the average`() {
         val frame =
             rgbaFrame(
@@ -32,7 +54,7 @@ class AmbientSamplingTest {
     }
 
     @Test
-    fun `full scene maps each stick grid cell across the whole screen`() {
+    fun `full scene maps every stick cell across different aspect ratios`() {
         val colors =
             listOf(
                 RgbColor(255, 0, 0),
@@ -43,14 +65,6 @@ class AmbientSamplingTest {
                 RgbColor(255, 0, 255),
                 RgbColor(255, 255, 255),
                 RgbColor(0, 0, 0),
-            )
-        val frame =
-            rgbaFrame(
-                rows =
-                    listOf(
-                        listOf(colors[0], colors[1], colors[4], colors[5]),
-                        listOf(colors[2], colors[3], colors[6], colors[7]),
-                    ),
             )
         val layout =
             listOf(
@@ -64,9 +78,18 @@ class AmbientSamplingTest {
                 LedGridCell(1, 1, 1, "bottom_right"),
             )
 
-        val sampled = AmbientSampler.sample(frame, 8, layout, true, AmbientSamplingMode.FULL_SCENE)
+        listOf(
+            Triple(12, 9, "4:3"),
+            Triple(16, 9, "16:9"),
+            Triple(16, 10, "16:10"),
+            Triple(20, 9, "20:9"),
+            Triple(9, 16, "9:16"),
+        ).forEach { (width, height, label) ->
+            val frame = zonedFrame(width, height, colors)
+            val sampled = AmbientSampler.sample(frame, 8, layout, true, AmbientSamplingMode.FULL_SCENE)
 
-        assertEquals(colors, sampled)
+            assertEquals(label, colors, sampled)
+        }
     }
 
     @Test
@@ -146,5 +169,24 @@ class AmbientSamplingTest {
             }
         }
         return AmbientPixelFrame(width, height, pixelStride = 4, rowStride = rowStride, bytes = bytes)
+    }
+
+    private fun zonedFrame(
+        width: Int,
+        height: Int,
+        colors: List<RgbColor>,
+    ): AmbientPixelFrame {
+        val rows = MutableList(height) { MutableList(width) { RgbColor(0, 0, 0) } }
+        repeat(2) { row ->
+            repeat(4) { column ->
+                val colorIndex = (column / 2) * 4 + row * 2 + column % 2
+                for (y in row * height / 2 until (row + 1) * height / 2) {
+                    for (x in column * width / 4 until (column + 1) * width / 4) {
+                        rows[y][x] = colors[colorIndex]
+                    }
+                }
+            }
+        }
+        return rgbaFrame(rows)
     }
 }

--- a/android/app/src/test/java/com/hooandee/colores/device/AndroidDeviceDetectorTest.kt
+++ b/android/app/src/test/java/com/hooandee/colores/device/AndroidDeviceDetectorTest.kt
@@ -14,6 +14,7 @@ import com.hooandee.colores.device.learning.resolveDetectionOutcome
 import com.hooandee.colores.led.Htr3212Descriptor
 import com.hooandee.colores.led.SettingsProviderDescriptor
 import com.hooandee.colores.led.SingleAdcJoypadDescriptor
+import java.io.File
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
@@ -52,6 +53,52 @@ class AndroidDeviceDetectorTest {
             )
 
         assertEquals(rp5, (result as DetectionOutcome.Resolved).device)
+    }
+
+    @Test
+    fun `validated Nova topology activates its native profile without a binding`() {
+        val shared = File("../../shared")
+        val nova =
+            requireNotNull(
+                DeviceRegistry.parse(
+                    devicesJson = shared.resolve("devices.json").readText(),
+                    previewProfilesJson = shared.resolve("led-preview-profiles.json").readText(),
+                ).match(AndroidDeviceIdentity("Retroid_Pocket_Nova", "kalama", "Moorechip", emptyMap())),
+            )
+
+        val result =
+            resolveDetectionOutcome(
+                identity = AndroidDeviceIdentity("Retroid_Pocket_Nova", "kalama", "Moorechip", emptyMap()),
+                exact = nova,
+                exactTransportAvailable = true,
+                candidates = listOf(candidate),
+                facts = htrFacts(leftBus = 3, rightBus = 6),
+            )
+
+        assertEquals("retroid-pocket-nova", (result as DetectionOutcome.Resolved).device.id)
+    }
+
+    @Test
+    fun `mismatched Nova topology stays in discovery`() {
+        val shared = File("../../shared")
+        val nova =
+            requireNotNull(
+                DeviceRegistry.parse(
+                    devicesJson = shared.resolve("devices.json").readText(),
+                    previewProfilesJson = shared.resolve("led-preview-profiles.json").readText(),
+                ).match(AndroidDeviceIdentity("Retroid_Pocket_Nova", "kalama", "Moorechip", emptyMap())),
+            )
+
+        val result =
+            resolveDetectionOutcome(
+                identity = AndroidDeviceIdentity("Retroid_Pocket_Nova", "kalama", "Moorechip", emptyMap()),
+                exact = nova,
+                exactTransportAvailable = true,
+                candidates = listOf(candidate),
+                facts = htrFacts(leftBus = 3, rightBus = 5),
+            )
+
+        assertTrue(result is DetectionOutcome.Candidates)
     }
 
     @Test

--- a/android/app/src/test/java/com/hooandee/colores/device/AndroidDeviceDetectorTest.kt
+++ b/android/app/src/test/java/com/hooandee/colores/device/AndroidDeviceDetectorTest.kt
@@ -5,6 +5,9 @@ import com.hooandee.colores.device.learning.FACT_HTR3212_LEFT
 import com.hooandee.colores.device.learning.FACT_HTR3212_RIGHT
 import com.hooandee.colores.device.learning.FactEvidence
 import com.hooandee.colores.device.learning.HardwareFact
+import com.hooandee.colores.device.learning.Htr3212InformationCartridge
+import com.hooandee.colores.device.learning.I2cController
+import com.hooandee.colores.device.learning.I2cTopologyReader
 import com.hooandee.colores.device.learning.ProbeCandidate
 import com.hooandee.colores.device.learning.ProbeSurface
 import com.hooandee.colores.device.learning.resolveDetectionOutcome
@@ -197,6 +200,32 @@ class AndroidDeviceDetectorTest {
         val result = resolveDetectionOutcome(identity, exact = null, exactTransportAvailable = false, candidates = emptyList())
 
         assertTrue(result is DetectionOutcome.Unsupported)
+    }
+
+    @Test
+    fun `PServer and an observed HTR pair reach discovery without a vendor color setting`() {
+        val nova = AndroidDeviceIdentity("Retroid Pocket Nova", "kalama", "Moorechip", emptyMap())
+        val cartridge =
+            Htr3212InformationCartridge(
+                I2cTopologyReader {
+                    listOf(
+                        I2cController(3, 0x3c, "htr3212l"),
+                        I2cController(6, 0x3c, "htr3212r"),
+                    )
+                },
+            )
+
+        val route =
+            resolveHardwareLearningRoute(
+                identity = nova,
+                pserverAvailable = true,
+                seedCandidates = emptyList(),
+                informationCartridges = listOf(cartridge),
+            )
+
+        assertEquals(listOf(ProbeSurface.HTR3212), route.candidates.map { it.surface })
+        assertTrue(route.facts.any { it.key == FACT_HTR3212_LEFT })
+        assertTrue(route.facts.any { it.key == FACT_HTR3212_RIGHT })
     }
 
     @Test

--- a/android/app/src/test/java/com/hooandee/colores/device/DeviceRegistryTest.kt
+++ b/android/app/src/test/java/com/hooandee/colores/device/DeviceRegistryTest.kt
@@ -276,6 +276,69 @@ class DeviceRegistryTest {
     }
 
     @Test
+    fun `production registry resolves the Retroid Pocket Nova multipoint profile`() {
+        val shared = File("../../shared")
+        val registry =
+            DeviceRegistry.parse(
+                devicesJson = shared.resolve("devices.json").readText(),
+                previewProfilesJson = shared.resolve("led-preview-profiles.json").readText(),
+            )
+
+        val match =
+            registry.match(
+                AndroidDeviceIdentity(
+                    model = "Retroid_Pocket_Nova",
+                    device = "kalama",
+                    manufacturer = "Moorechip",
+                    productProperties = emptyMap(),
+                ),
+            )
+
+        requireNotNull(match)
+        assertEquals("retroid-pocket-nova", match.id)
+        assertEquals("Retroid Pocket Nova", match.friendlyName)
+        assertEquals(DeviceCapabilities(color = true, brightness = true, perZone = true, zones = 8), match.capabilities)
+        val led = match.led as SettingsProviderDescriptor
+        assertEquals("htr3212", led.driver)
+        assertEquals("pserver", led.transport)
+        assertEquals(GenericVendorLed.ENABLE_KEYS, led.enableKeys)
+        requireNotNull(led.htr3212)
+        assertEquals(3, led.htr3212.leftBus)
+        assertEquals(6, led.htr3212.rightBus)
+        assertEquals(0x3c, led.htr3212.address)
+        assertEquals(listOf(0, 1, 2, 3), led.htr3212.leftOrder)
+        assertEquals(listOf(0, 1, 2, 3), led.htr3212.rightOrder)
+        assertEquals(0x0d, led.htr3212.rgbStartRegister)
+        assertFalse(led.htr3212.blockWrite)
+        assertFalse(led.htr3212.pairedWrite)
+        assertFalse(led.htr3212.explicitInitialization)
+        assertTrue(led.htr3212.automaticActivation)
+        assertEquals(8, match.gridLayout?.size)
+    }
+
+    @Test
+    fun `Nova model aliases remain exact without depending on the shared kalama codename`() {
+        val shared = File("../../shared")
+        val registry =
+            DeviceRegistry.parse(
+                devicesJson = shared.resolve("devices.json").readText(),
+                previewProfilesJson = shared.resolve("led-preview-profiles.json").readText(),
+            )
+
+        val match =
+            registry.match(
+                AndroidDeviceIdentity(
+                    model = "Retroid Pocket Nova",
+                    device = "future-nova-revision",
+                    manufacturer = "Retroid",
+                    productProperties = emptyMap(),
+                ),
+            )
+
+        assertEquals("retroid-pocket-nova", match?.id)
+    }
+
+    @Test
     fun `production registry resolves the calibrated Odin 2 Portal multipoint profile`() {
         val shared = File("../../shared")
         val registry =

--- a/android/app/src/test/java/com/hooandee/colores/device/learning/HardwareLearningGraphTest.kt
+++ b/android/app/src/test/java/com/hooandee/colores/device/learning/HardwareLearningGraphTest.kt
@@ -44,6 +44,22 @@ class HardwareLearningGraphTest {
         assertEquals(1, route.candidates.size)
     }
 
+    @Test
+    fun `observed transport facts unlock information cartridges without probe candidates`() {
+        val cartridge =
+            fakeInformationCartridge("htr", setOf(FACT_PSERVER)) {
+                InformationCartridgeResult(
+                    facts = listOf(HardwareFact("controller.count", "2", FactEvidence.OBSERVED, "htr")),
+                )
+            }
+        val pserver = HardwareFact(FACT_PSERVER, "present", FactEvidence.OBSERVED, "detector")
+
+        val route = HardwareLearningGraph(listOf(cartridge)).resolve(identity, emptyList(), seedFacts = listOf(pserver))
+
+        assertTrue(route.facts.any { it.key == "controller.count" })
+        assertEquals(listOf("htr"), route.inspectedCartridgeIds)
+    }
+
     private fun settingsCandidate() =
         ProbeCandidate(
             cartridgeId = SETTINGS_PROBE_ID,

--- a/android/app/src/test/java/com/hooandee/colores/device/learning/Htr3212InformationCartridgeTest.kt
+++ b/android/app/src/test/java/com/hooandee/colores/device/learning/Htr3212InformationCartridgeTest.kt
@@ -38,6 +38,34 @@ class Htr3212InformationCartridgeTest {
     }
 
     @Test
+    fun `paired controllers and PServer unlock HTR without a vendor color setting`() {
+        val cartridge =
+            Htr3212InformationCartridge(
+                topologyReader =
+                    I2cTopologyReader {
+                        listOf(
+                            I2cController(bus = 3, address = 0x3c, driver = "htr3212l"),
+                            I2cController(bus = 6, address = 0x3c, driver = "htr3212r"),
+                        )
+                    },
+            )
+        val context =
+            HardwareLearningContext(
+                identity = AndroidDeviceIdentity("Retroid Pocket Nova", "kalama", "Moorechip", emptyMap()),
+                facts = listOf(HardwareFact(FACT_PSERVER, "present", FactEvidence.OBSERVED, "detector")),
+                candidates = emptyList(),
+            )
+
+        val result = cartridge.inspect(context)
+
+        val candidate = result.candidates.single()
+        val descriptor = candidate.descriptor as SettingsProviderDescriptor
+        assertEquals(3, descriptor.htr3212?.leftBus)
+        assertEquals(6, descriptor.htr3212?.rightBus)
+        assertEquals(8, descriptor.zones)
+    }
+
+    @Test
     fun `observed RP5 pair enables only its physically validated initialization`() {
         val cartridge =
             Htr3212InformationCartridge(

--- a/android/app/src/test/java/com/hooandee/colores/device/learning/Htr3212LearningCartridgeTest.kt
+++ b/android/app/src/test/java/com/hooandee/colores/device/learning/Htr3212LearningCartridgeTest.kt
@@ -8,6 +8,7 @@ import com.hooandee.colores.led.SettingsProviderDescriptor
 import com.hooandee.colores.led.SystemSettingsStore
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNotNull
 import org.junit.Assert.assertTrue
 import org.junit.Test
 
@@ -100,6 +101,69 @@ class Htr3212LearningCartridgeTest {
     }
 
     @Test
+    fun `missing vendor color uses raw PWM snapshot and restores both sticks`() {
+        val store = FakeSettingsStore(linkedMapOf("joystick_light_enabled" to "1,1"))
+        val executor = FakeExecutor()
+        val reader =
+            Htr3212RegisterReader { bus, address, registers ->
+                if (address != 0x3c || registers != (0x0d..0x18).toList()) return@Htr3212RegisterReader null
+                when (bus) {
+                    3 -> (1..12).toList()
+                    6 -> (13..24).toList()
+                    else -> null
+                }
+            }
+        val cartridge = Htr3212LearningCartridge(store, executor, reader, settleVendor = {})
+        val candidate =
+            candidate(
+                enableKeys = listOf("joystick_light_enabled"),
+                explicitInitialization = false,
+                rightBus = 6,
+            )
+
+        val snapshot = requireNotNull(cartridge.snapshot(candidate))
+        assertTrue(cartridge.execute(candidate, ProbeStep.COLOR))
+
+        assertEquals(RollbackStatus.RESTORED_WITHOUT_HARDWARE_READBACK, cartridge.restore(candidate, snapshot))
+        assertEquals("1,1", store.values["joystick_light_enabled"])
+        assertTrue(executor.commands[executor.commands.lastIndex - 1].contains("0x0d 0x01"))
+        assertTrue(executor.commands[executor.commands.lastIndex - 1].contains("0x18 0x0c"))
+        assertTrue(executor.commands.last().contains("0x0d 0x0d"))
+        assertTrue(executor.commands.last().contains("0x18 0x18"))
+    }
+
+    @Test
+    fun `powered off HTR controllers restore safely without PWM readback`() {
+        val key = "joystick_light_enabled"
+        val store = FakeSettingsStore(linkedMapOf(key to "0,0"))
+        val executor = FakeExecutor()
+        val reader = Htr3212RegisterReader { _, _, _ -> null }
+        val cartridge = Htr3212LearningCartridge(store, executor, reader, settleVendor = {})
+        val candidate = candidate(enableKeys = listOf(key), explicitInitialization = false, rightBus = 6)
+
+        val snapshot = cartridge.snapshot(candidate)
+
+        assertNotNull(snapshot)
+        snapshot ?: return
+        assertTrue(cartridge.execute(candidate, ProbeStep.COLOR))
+        assertEquals("1,1", store.values[key])
+        assertEquals(RollbackStatus.RESTORED_WITHOUT_HARDWARE_READBACK, cartridge.restore(candidate, snapshot))
+        assertEquals("0,0", store.values[key])
+    }
+
+    @Test
+    fun `a single side power setting keeps its scalar encoding`() {
+        val key = "right_joystick_light_enabled"
+        val store = FakeSettingsStore(linkedMapOf(key to "0"))
+        val reader = Htr3212RegisterReader { _, _, _ -> List(12) { 0 } }
+        val cartridge = Htr3212LearningCartridge(store, FakeExecutor(), reader, settleVendor = {})
+
+        assertTrue(cartridge.execute(candidate(), ProbeStep.COLOR))
+
+        assertEquals("1", store.values[key])
+    }
+
+    @Test
     fun `candidate with an unaudited register bank is rejected`() {
         val store = FakeSettingsStore(originalSettings())
         val cartridge = Htr3212LearningCartridge(store, FakeExecutor(), settleVendor = {})
@@ -184,6 +248,7 @@ class Htr3212LearningCartridgeTest {
         blockWrite: Boolean = false,
         pairedWrite: Boolean = false,
         explicitInitialization: Boolean = true,
+        rightBus: Int = 5,
     ): ProbeCandidate =
         ProbeCandidate(
             cartridgeId = HTR3212_PROBE_ID,
@@ -196,7 +261,7 @@ class Htr3212LearningCartridgeTest {
                     htr3212 =
                         Htr3212Descriptor(
                             leftBus = 3,
-                            rightBus = 5,
+                            rightBus = rightBus,
                             address = 0x3c,
                             leftOrder = listOf(0, 1, 2, 3),
                             rightOrder = listOf(0, 1, 2, 3),

--- a/android/app/src/test/java/com/hooandee/colores/device/learning/LearnedBindingTest.kt
+++ b/android/app/src/test/java/com/hooandee/colores/device/learning/LearnedBindingTest.kt
@@ -3,6 +3,7 @@ package com.hooandee.colores.device.learning
 import com.hooandee.colores.device.AndroidDeviceIdentity
 import com.hooandee.colores.device.DetectedAndroidDevice
 import com.hooandee.colores.device.DeviceCapabilities
+import com.hooandee.colores.device.LedGridCell
 import com.hooandee.colores.led.SingleAdcJoypadDescriptor
 import com.hooandee.colores.device.GenericVendorLed
 import com.hooandee.colores.led.Htr3212Descriptor
@@ -87,7 +88,7 @@ class LearnedBindingTest {
     }
 
     @Test
-    fun `calibrated HTR order survives candidate rediscovery`() {
+    fun `calibrated HTR binding restores its two stick grid`() {
         val observedDescriptor =
             GenericVendorLed.descriptor(8).copy(
                 driver = "htr3212",
@@ -128,6 +129,19 @@ class LearnedBindingTest {
         val resolved = requireNotNull(resolveLearnedDevice(identity, htrBinding, listOf(htrCandidate)))
 
         assertEquals(calibratedDescriptor, resolved.led)
+        assertEquals(
+            listOf(
+                LedGridCell(0, 0, 0, "top_left"),
+                LedGridCell(0, 1, 0, "bottom_left"),
+                LedGridCell(0, 1, 1, "bottom_right"),
+                LedGridCell(0, 0, 1, "top_right"),
+                LedGridCell(1, 0, 0, "top_left"),
+                LedGridCell(1, 1, 0, "bottom_left"),
+                LedGridCell(1, 1, 1, "bottom_right"),
+                LedGridCell(1, 0, 1, "top_right"),
+            ),
+            resolved.gridLayout,
+        )
     }
 
     @Test

--- a/android/app/src/test/java/com/hooandee/colores/device/learning/PServerHtr3212RegisterReaderTest.kt
+++ b/android/app/src/test/java/com/hooandee/colores/device/learning/PServerHtr3212RegisterReaderTest.kt
@@ -1,0 +1,72 @@
+package com.hooandee.colores.device.learning
+
+import com.hooandee.colores.led.PServerCommandExecutor
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Rule
+import org.junit.Test
+import org.junit.rules.TemporaryFolder
+
+class PServerHtr3212RegisterReaderTest {
+    @get:Rule
+    val temporaryFolder = TemporaryFolder()
+
+    @Test
+    fun `reads the audited PWM bank through PServer`() {
+        val output = temporaryFolder.newFile("htr-registers")
+        val executor =
+            object : PServerCommandExecutor {
+                override val available = true
+
+                override fun execute(command: String): Boolean {
+                    val expectedReads =
+                        (0x0d..0x18).all { register ->
+                            "i2cget -f -y 3 0x3c 0x%02x".format(register) in command
+                        }
+                    if (expectedReads && output.absolutePath in command) {
+                        output.writeText((1..12).joinToString("\n") { "0x%02x".format(it) })
+                    }
+                    return true
+                }
+            }
+        val reader = PServerHtr3212RegisterReader(executor, output)
+
+        val values = reader.read(3, 0x3c, (0x0d..0x18).toList())
+
+        assertEquals((1..12).toList(), values)
+    }
+
+    @Test
+    fun `rejects reads outside the audited PWM bank`() {
+        val output = temporaryFolder.newFile("htr-registers")
+        val executor =
+            object : PServerCommandExecutor {
+                override val available = true
+
+                override fun execute(command: String): Boolean {
+                    output.writeText("0x01")
+                    return true
+                }
+            }
+        val reader = PServerHtr3212RegisterReader(executor, output)
+
+        assertNull(reader.read(3, 0x3c, listOf(0x01)))
+    }
+
+    @Test
+    fun `rejects malformed output instead of shifting register values`() {
+        val output = temporaryFolder.newFile("htr-registers")
+        val executor =
+            object : PServerCommandExecutor {
+                override val available = true
+
+                override fun execute(command: String): Boolean {
+                    output.writeText((1..12).joinToString("\n", postfix = "\nnot-a-byte") { "0x%02x".format(it) })
+                    return true
+                }
+            }
+        val reader = PServerHtr3212RegisterReader(executor, output)
+
+        assertNull(reader.read(3, 0x3c, (0x0d..0x18).toList()))
+    }
+}

--- a/android/app/src/test/java/com/hooandee/colores/led/Htr3212LedDeviceTest.kt
+++ b/android/app/src/test/java/com/hooandee/colores/led/Htr3212LedDeviceTest.kt
@@ -33,6 +33,25 @@ class Htr3212LedDeviceTest {
 
     @OptIn(ExperimentalCoroutinesApi::class)
     @Test
+    fun `direct HTR control does not create missing optional vendor settings`() =
+        runTest {
+            val store = FakeHtrSettingsStore(existingVendorSettings = false)
+            store.values["enabled"] = "1,1"
+            val executor = FakePServerExecutor()
+            val device = device(store, executor)
+
+            device.readState()
+            assertTrue(device.applyZones(List(8) { RgbColor(20, 30, 40) }, brightness = 70, power = true))
+            runCurrent()
+
+            assertFalse(store.values.containsKey("color"))
+            assertFalse(store.values.containsKey("brightness"))
+            assertEquals("1,1", store.values["enabled"])
+            assertEquals(2, executor.commands.size)
+        }
+
+    @OptIn(ExperimentalCoroutinesApi::class)
+    @Test
     fun `eight zones keep two vendor fallback colors and write both calibrated buses`() =
         runTest {
             val store = FakeHtrSettingsStore()
@@ -360,9 +379,20 @@ class Htr3212LedDeviceTest {
 
 private class FakeHtrSettingsStore(
     override val available: Boolean = true,
+    existingVendorSettings: Boolean = true,
 ) : SystemSettingsStore {
     val values = mutableMapOf<String, String>()
     val writes = mutableListOf<Pair<String, String>>()
+
+    init {
+        if (existingVendorSettings) {
+            values["color"] = "#FFFFFFFF,#FFFFFFFF"
+            values["brightness"] = "1.0"
+            values["enabled"] = "1,1"
+            values["left"] = "1"
+            values["right"] = "1"
+        }
+    }
 
     override fun get(key: String): String? = values[key]
 

--- a/android/app/src/test/java/com/hooandee/colores/ui/ResponsiveLayoutTest.kt
+++ b/android/app/src/test/java/com/hooandee/colores/ui/ResponsiveLayoutTest.kt
@@ -1,0 +1,60 @@
+package com.hooandee.colores.ui
+
+import androidx.compose.ui.unit.dp
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class ResponsiveLayoutTest {
+    @Test
+    fun `handheld landscape aspect ratios use two panes`() {
+        listOf(
+            Triple(600.dp, 450.dp, "4:3"),
+            Triple(640.dp, 360.dp, "16:9"),
+            Triple(640.dp, 400.dp, "16:10"),
+            Triple(800.dp, 360.dp, "20:9"),
+        ).forEach { (width, height, label) ->
+            assertTrue(label, shouldUseTwoPaneLayout(width, height, 720.dp))
+        }
+    }
+
+    @Test
+    fun `compact portrait keeps one pane`() {
+        assertFalse(shouldUseTwoPaneLayout(596.dp, 720.dp, 720.dp))
+    }
+
+    @Test
+    fun `expanded width uses two panes in any orientation`() {
+        assertTrue(shouldUseTwoPaneLayout(720.dp, 960.dp, 720.dp))
+    }
+
+    @Test
+    fun `only short landscape screens use compact dashboard density`() {
+        assertTrue(shouldUseCompactDashboardDensity(600.dp, 450.dp))
+        assertTrue(shouldUseCompactDashboardDensity(640.dp, 360.dp))
+        assertTrue(shouldUseCompactDashboardDensity(640.dp, 400.dp))
+        assertTrue(shouldUseCompactDashboardDensity(800.dp, 360.dp))
+        assertFalse(shouldUseCompactDashboardDensity(1280.dp, 800.dp))
+        assertFalse(shouldUseCompactDashboardDensity(600.dp, 800.dp))
+    }
+
+    @Test
+    fun `large landscape remains available to landscape dialogs without compact density`() {
+        assertTrue(isUsableLandscape(1280.dp, 800.dp))
+        assertFalse(shouldUseCompactDashboardDensity(1280.dp, 800.dp))
+    }
+
+    @Test
+    fun `preview rings share available width equally`() {
+        assertEquals(
+            86.5.dp,
+            previewRingDiameter(
+                availableWidth = 191.dp,
+                groupCount = 2,
+                spacing = 18.dp,
+                preferredDiameter = 112.dp,
+            ),
+        )
+    }
+}

--- a/shared/devices.json
+++ b/shared/devices.json
@@ -43,6 +43,54 @@
     "previewProfile": "retroid-stick-ring-rp5-v1"
   },
   {
+    "id": "retroid-pocket-nova",
+    "friendlyName": "Retroid Pocket Nova",
+    "android": {
+      "model": ["Retroid Pocket Nova", "Retroid_Pocket_Nova"],
+      "device": [],
+      "led": {
+        "driver": "htr3212",
+        "transport": "pserver",
+        "colorKey": "joystick_led_light_picker_color",
+        "colorFormat": "argb_hex_csv",
+        "brightnessKey": "led_light_brightness_percent",
+        "brightnessRange": [0.0, 1.0],
+        "enableKeys": [
+          "joystick_light_enabled",
+          "left_joystick_light_enabled",
+          "right_joystick_light_enabled",
+          "left_handle_light_enabled",
+          "right_handle_light_enabled"
+        ],
+        "zones": 8,
+        "requiresPermission": null,
+        "vendorService": "com.rp.gameassistant",
+        "htr3212": {
+          "leftBus": 3,
+          "rightBus": 6,
+          "address": 60,
+          "leftOrder": [0, 1, 2, 3],
+          "rightOrder": [0, 1, 2, 3],
+          "rgbStartRegister": 13,
+          "automaticActivation": true
+        }
+      },
+      "gridLayout": [
+        { "stick": 0, "row": 0, "col": 0, "position": "top_left" },
+        { "stick": 0, "row": 1, "col": 0, "position": "bottom_left" },
+        { "stick": 0, "row": 1, "col": 1, "position": "bottom_right" },
+        { "stick": 0, "row": 0, "col": 1, "position": "top_right" },
+        { "stick": 1, "row": 0, "col": 0, "position": "top_left" },
+        { "stick": 1, "row": 1, "col": 0, "position": "bottom_left" },
+        { "stick": 1, "row": 1, "col": 1, "position": "bottom_right" },
+        { "stick": 1, "row": 0, "col": 1, "position": "top_right" }
+      ]
+    },
+    "linux": null,
+    "capabilities": { "color": true, "brightness": true, "perZone": true },
+    "previewProfile": null
+  },
+  {
     "id": "ayn-odin2-portal",
     "friendlyName": "AYN Odin 2 Portal",
     "android": {


### PR DESCRIPTION
## Qué cambia / What changes

- Amplía el descubrimiento Android HTR3212 para encontrar pares observados mediante PServer aunque el firmware no publique el ajuste vendor de color.
- Añade snapshot y rollback del banco PWM auditado, conserva el fallback seguro y activa los perfiles multipunto nativos de RP5 y Retroid Pocket Nova solo cuando su topología coincide.
- Incorpora la Retroid Pocket Nova al registro exacto con sus dos alias de modelo, sin depender del codename `kalama` compartido con otras máquinas.
- Reconstruye el layout de ocho zonas de bindings aprendidos para que preview, gradientes y Ambilight compartan el mismo orden físico.
- Adapta la interfaz Compose a pantallas compactas, verticales, 4:3, 16:9, 16:10 y ultraanchas, con paneles desplazables y controles más contenidos.
- Hace que Ambilight capture la pantalla completa cuando Android 14 lo permite y conserva la relación de aspecto real en la superficie de muestreo.

## Por qué / Why

La RP5 y la Retroid Pocket Nova podían exponer dos controladores HTR3212 reales sin que el ajuste vendor fuese suficiente para descubrir o restaurar correctamente sus ocho emisores. Además, la UI y la captura asumían demasiado espacio horizontal o una superficie 16:9, lo que producía solapes y muestreo deformado en la Nova 4:3.

La ruta nueva sigue siendo capability-first: PServer, drivers, buses, dirección y banco deben observarse antes de ofrecer el asistente; los perfiles RP5 y Nova solo se activan automáticamente con su topología validada, y el resto conserva binding aprendido, rollback y degradación segura. Una calibración Nova compatible ya aprendida mantiene prioridad para conservar el orden físico confirmado en esa unidad.

## Pruebas / Testing

- [x] `./gradlew :app:testDebugUnitTest :app:lintDebug :app:assembleDebug`
- [x] `pnpm typecheck` y `pnpm build`
- [x] `.venv/bin/python -m pytest` (409 tests)
- [x] `.venv/bin/ruff check main.py py_modules tests`
- [x] Commits con formato convencional / Conventional commit messages
- [x] RP5: aislamiento visible de un punto por joystick con la inicialización multipunto validada durante el desarrollo.
- [x] Retroid Pocket Nova: binding de ocho zonas, muestreo Ambilight 32x24 y revisión visual de la UI compacta durante el desarrollo.
- [x] Registro Nova: alias reales de modelo, buses 3/6, dirección `0x3c`, activación con topología coincidente y fallback ante discrepancias cubiertos por tests.
- [ ] Reinstalar el APK del commit final en Nova. El dispositivo se desconectó de ADB después de la última limpieza de código; el APK final sí pasó tests, lint y assemble.
