### PR TITLE
Fix Ambilight latency by dropping stale captured frames

### DIFF
--- a/py_modules/ambilight.py
+++ b/py_modules/ambilight.py
@@ -71,6 +71,21 @@ def _gst_command(node, width, height):
     ]
 
 
+def _replace_queued(queue, item):
+    if queue.full():
+        queue.get_nowait()
+    queue.put_nowait(item)
+
+
+async def _read_latest_frames(reader, frame_bytes, queue):
+    try:
+        while True:
+            frame = await reader.readexactly(frame_bytes)
+            _replace_queued(queue, frame)
+    except Exception as error:
+        _replace_queued(queue, error)
+
+
 class Ambilight:
     def __init__(self, apply_zones, zones, runtime_dir, uid=None, gid=None, layout=None, max_fps=None):
         self._apply = apply_zones
@@ -179,6 +194,7 @@ class Ambilight:
             interval = self._capture_interval()
             command = _gst_command(node, CAP_W, CAP_H)
             proc = None
+            reader_task = None
             logger.info("ambilight start: node=%s fps=%.0f", node, 1.0 / interval)
             try:
                 proc = await asyncio.create_subprocess_exec(
@@ -190,8 +206,14 @@ class Ambilight:
                 )
                 self._proc = proc
                 self.status = "running"
+                frames = asyncio.Queue(maxsize=1)
+                reader_task = asyncio.create_task(
+                    _read_latest_frames(proc.stdout, frame_bytes, frames)
+                )
                 while True:
-                    frame = await proc.stdout.readexactly(frame_bytes)
+                    frame = await frames.get()
+                    if isinstance(frame, Exception):
+                        raise frame
                     self._update_targets(frame)
                     self._tick()
                     await asyncio.sleep(interval)
@@ -204,6 +226,9 @@ class Ambilight:
             except Exception:
                 logger.exception("ambilight loop failed")
             finally:
+                if reader_task is not None:
+                    reader_task.cancel()
+                    await asyncio.gather(reader_task, return_exceptions=True)
                 if proc is not None:
                     try:
                         proc.kill()

--- a/tests/test_ambilight.py
+++ b/tests/test_ambilight.py
@@ -8,6 +8,8 @@ from py_modules.ambilight import (
     CAP_W,
     CAP_H,
     _gst_command,
+    _read_latest_frames,
+    _replace_queued,
     alpha_for,
     avg_region,
     boost_saturation,
@@ -114,6 +116,26 @@ def test_gst_command_uses_leaky_queue_before_scaling():
     assert "leaky=downstream" in cmd
     assert cmd.index("queue") < cmd.index("videoscale")
     assert "path=68" in cmd
+
+
+def test_replace_queued_keeps_only_latest_item():
+    queue = asyncio.Queue(maxsize=1)
+    _replace_queued(queue, b"old")
+    _replace_queued(queue, b"new")
+    assert queue.get_nowait() == b"new"
+
+
+def test_frame_reader_drains_stream_and_reports_eof():
+    async def drive():
+        reader = asyncio.StreamReader()
+        queue = asyncio.Queue(maxsize=1)
+        reader.feed_data(b"oldnew")
+        reader.feed_eof()
+
+        await _read_latest_frames(reader, 3, queue)
+        return queue.get_nowait()
+
+    assert isinstance(asyncio.run(drive()), asyncio.IncompleteReadError)
 
 
 def test_capture_interval_respects_device_render_limit():


### PR DESCRIPTION
Fixes #129. (Beware vibe coded but works!)

Colores currently reads one frame from GStreamer and then sleeps for the configured capture interval. While it sleeps, completed frames can accumulate in the stdout pipe, causing Ambilight to process stale frames with approximately 2–3 seconds of latency.

This change leaves the existing GStreamer pipeline unchanged and adds a dedicated asynchronous reader that continuously drains complete frames. Frames are placed into an asyncio.Queue(maxsize=1), replacing any older queued frame so the paced processing loop always receives the newest available frame.

Capture and EOF errors are forwarded through the queue so the existing fallback and reconnect behavior remains intact. The reader task is cancelled and awaited during cleanup.

Validation:

Physically tested on a Legion Go S running SteamOS and Colores v0.22.0.
Ambilight transitions changed from 2–3 seconds delayed to effectively instant.
Verified with red, blue and black-screen transitions.
393 Python tests pass.
Ruff, TypeScript checking and frontend compilation pass.

A previous experiment modifying the GStreamer pipeline itself failed negotiation on the Go S, so this implementation deliberately keeps that pipeline unchanged.