### PR TITLE
fix: stop Ambilight capture before suspend

### DIFF
--- a/main.py
+++ b/main.py
@@ -847,6 +847,13 @@ class Plugin:
         self._init()
         return self._ambilight.status
 
+    async def prepare_suspend(self) -> None:
+        self._init()
+        if self._settings["mode"] != "ambient":
+            return
+        await self._ambilight.stop_and_wait()
+        decky.logger.info("Colores: ambilight capture stopped for suspend")
+
     async def get_audio_status(self) -> str:
         self._init()
         return self._audio.status

--- a/py_modules/ambilight.py
+++ b/py_modules/ambilight.py
@@ -169,6 +169,15 @@ class Ambilight:
             self._task = None
         self._kill()
 
+    async def stop_and_wait(self):
+        task = self._task
+        proc = self._proc
+        self.stop()
+        pending = [task] if task is not None else []
+        if proc is not None:
+            pending.append(proc.wait())
+        await asyncio.gather(*pending, return_exceptions=True)
+
     def _kill(self):
         if self._proc is not None:
             try:

--- a/src/api.ts
+++ b/src/api.ts
@@ -13,6 +13,7 @@ export const setEffect = callable<[id: string, speed: number, useGradient: boole
 export const setAmbilight = callable<[vividness: number, smoothing: number, fps: number], void>("set_ambilight");
 export const setAmbilightSampling = callable<[mode: string], void>("set_ambilight_sampling");
 export const getAmbilightStatus = callable<[], string>("get_ambilight_status");
+export const prepareSuspend = callable<[], void>("prepare_suspend");
 export const getAudioStatus = callable<[], string>("get_audio_status");
 export const saveGradient = callable<[name: string, stops: number[][]], GradientPreset[]>("save_gradient");
 export const deleteGradient = callable<[name: string], GradientPreset[]>("delete_gradient");

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -14,7 +14,7 @@ import { definePlugin } from "@decky/api";
 import { useCallback, useEffect, useMemo, useState } from "react";
 
 import { useColores } from "./useColores";
-import { getAmbilightStatus, getAudioStatus, getTemperature, getPerformance, reconnect as apiReconnect } from "./api";
+import { getAmbilightStatus, getAudioStatus, getTemperature, getPerformance, prepareSuspend, reconnect as apiReconnect } from "./api";
 import { rgbToCss, gradientCss, unifyColors } from "./color";
 import { Mode, RGB, ZoneGroup, GradientPreset, EffectColorNeed, Capabilities, SensorBand, SensorBands, SensorKind } from "./types";
 import { DevicePreview } from "./components/DevicePreview";
@@ -51,6 +51,7 @@ import { PINNED_TAB, tabMeta, TAB_META, SENSOR_TAB, SENSOR_MODES, tabForMode } f
 import { useShoulderNav } from "./nav/useShoulderNav";
 import { readActiveTab, writeActiveTab, readSensorMode, writeSensorMode } from "./nav/activeTab";
 import { startGameWatcher } from "./apps/gameWatcher";
+import { startSuspendPreparation } from "./lifecycle/suspend";
 import { ProfileScopeSelector } from "./components/ProfileScopeSelector";
 
 function DeviceHeader({ name, color }: { name: string; color: RGB }) {
@@ -1195,6 +1196,7 @@ function Content() {
 
 export default definePlugin(() => {
   const stopGameWatcher = startGameWatcher();
+  const stopSuspendPreparation = startSuspendPreparation(prepareSuspend);
   return {
     name: "Colores",
     titleView: <div className={staticClasses.Title}>Colores</div>,
@@ -1209,6 +1211,7 @@ export default definePlugin(() => {
     ),
     icon: <ColorWheelIcon />,
     onDismount() {
+      stopSuspendPreparation();
       stopGameWatcher();
     },
   };

--- a/src/lifecycle/suspend.test.ts
+++ b/src/lifecycle/suspend.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it, vi } from "vitest";
+
+import { startSuspendPreparation } from "./suspend";
+
+type Progress = { state: number; bGameSuspended: boolean };
+
+function fakeSteamUser() {
+  let callback: ((progress: Progress) => void) | undefined;
+  const unregister = vi.fn();
+  return {
+    user: {
+      RegisterForPrepareForSystemSuspendProgress(handler: (progress: Progress) => void) {
+        callback = handler;
+        return { unregister };
+      },
+    },
+    progress(value: Progress) {
+      callback?.(value);
+    },
+    unregister,
+  };
+}
+
+describe("startSuspendPreparation", () => {
+  it("only prepares Colores when Steam finishes its pre-suspend work", () => {
+    const steam = fakeSteamUser();
+    const prepare = vi.fn(async () => undefined);
+
+    startSuspendPreparation(prepare, steam.user);
+    steam.progress({ state: 0, bGameSuspended: false });
+    expect(prepare).not.toHaveBeenCalled();
+    steam.progress({ state: 1, bGameSuspended: true });
+    expect(prepare).toHaveBeenCalledOnce();
+  });
+
+  it("unregisters the Steam callback when the plugin dismounts", () => {
+    const steam = fakeSteamUser();
+    const prepare = vi.fn(async () => undefined);
+    const stop = startSuspendPreparation(prepare, steam.user);
+
+    stop();
+
+    expect(steam.unregister).toHaveBeenCalledOnce();
+  });
+});

--- a/src/lifecycle/suspend.ts
+++ b/src/lifecycle/suspend.ts
@@ -1,0 +1,14 @@
+type SteamUser = Partial<NonNullable<NonNullable<typeof SteamClient>["User"]>>;
+const PREPARATION_COMPLETE = 1;
+
+export function startSuspendPreparation(
+  prepare: () => Promise<void>,
+  steamUser: SteamUser | undefined = SteamClient?.User,
+): () => void {
+  const registration = steamUser?.RegisterForPrepareForSystemSuspendProgress?.(
+    ({ state }) => {
+      if (state === PREPARATION_COMPLETE) void prepare().catch(() => undefined);
+    },
+  );
+  return () => registration?.unregister();
+}

--- a/tests/test_ambilight.py
+++ b/tests/test_ambilight.py
@@ -160,6 +160,38 @@ def test_capture_interval_respects_device_render_limit():
     assert amb._capture_interval() == pytest.approx(0.1)
 
 
+def test_stop_and_wait_reaps_capture_before_returning():
+    class FakeProcess:
+        def __init__(self):
+            self.killed = False
+            self.waited = False
+
+        def kill(self):
+            self.killed = True
+
+        async def wait(self):
+            self.waited = True
+
+    async def drive():
+        amb = Ambilight(lambda colors: None, zones=1, runtime_dir=None)
+        process = FakeProcess()
+        task = asyncio.create_task(asyncio.sleep(60))
+        amb._proc = process
+        amb._task = task
+        amb.status = "running"
+
+        await amb.stop_and_wait()
+
+        assert task.done()
+        assert process.killed
+        assert process.waited
+        assert amb._task is None
+        assert amb._proc is None
+        assert amb.status == "idle"
+
+    asyncio.run(drive())
+
+
 def _solid_frame(width, height, color):
     return bytes(list(color) * (width * height))
 

--- a/tests/test_main_routing.py
+++ b/tests/test_main_routing.py
@@ -113,6 +113,9 @@ class FakeAmbilight:
     def stop(self):
         self.events.append(("stop",))
 
+    async def stop_and_wait(self):
+        self.events.append(("stop_and_wait",))
+
     def start(self, cfg):
         self.events.append(("start", cfg))
 
@@ -499,6 +502,16 @@ def test_reconnect_restarts_ambient_capture(main_module):
     ok = asyncio.run(p.reconnect())
     assert ok is True
     assert [event[0] for event in p._ambilight.events] == ["stop", "start"]
+
+
+def test_prepare_suspend_stops_capture_without_changing_user_intent(main_module):
+    p = _plugin(main_module, "ambient", power=True, per_zone=True)
+
+    asyncio.run(p.prepare_suspend())
+
+    assert p._ambilight.events == [("stop_and_wait",)]
+    assert p._settings["mode"] == "ambient"
+    assert p._settings["power"] is True
 
 
 def test_resume_watch_reconnects_after_suspend_clock_jump(main_module, monkeypatch):


### PR DESCRIPTION
## Qué cambia / What changes

- Detiene y recoge la captura de Ambilight cuando Steam completa la preparación para suspender.
- Conserva el modo y la energía configurados para que la ruta existente de reanudación restaure Ambilight.
- Desregistra el listener al desmontar el plugin.

## Por qué / Why

Evita que el proceso de captura siga activo durante la suspensión. Addresses #128.

La ROG Xbox Ally X del reporte aún necesita confirmación física; el cambio se ha validado en las máquinas disponibles.

## Pruebas / Testing

- [x] `pnpm test:fe`
- [x] `pnpm typecheck` y `pnpm build`
- [x] `.venv/bin/python -m pytest -q`
- [x] `.venv/bin/ruff check py_modules main.py tests`
- [x] Commits con formato convencional / Conventional commit messages
- [x] Legion Go S: suspensión, reanudación y una sola captura nueva
- [x] MSI Claw 8 AI+: suspensión, reanudación y una sola captura nueva
